### PR TITLE
You can now include individual episodes from series within the Collections rule field

### DIFF
--- a/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Expression.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Expression.cs
@@ -16,6 +16,10 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? IncludeUnwatchedSeries { get; set; } = null;
         
+        // Collections-specific option - only serialize when meaningful
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? IncludeEpisodesWithinSeries { get; set; } = null;
+        
         // Helper property to check if this is a user-specific expression
         // Only serialize when UserId is not null
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]

--- a/README.md
+++ b/README.md
@@ -256,7 +256,13 @@ The web interface provides access to all available fields for creating playlist 
 - **Artists** - Track-level artists *for music*
 - **Album Artists** - Album-level primary artists *for music*
 
-> **Collections Field Details**: The **Collections** field captures all Jellyfin collections that contain the media item. This is useful for creating playlists like "All items from Movie Franchise"".
+> **Collections Field Details**: The **Collections** field captures all Jellyfin collections that contain the media item. This is useful for creating playlists like "All items from Movie Franchise". 
+>
+> **Collections Episode Expansion**: When using the **Collections** field, you can choose to include individual episodes from TV series within the collections:
+> - **"No - Only include the series themselves"** (default): Collections rules will match and include the series as a whole
+> - **"Yes - Include individual episodes from series in collections"**: When a series in a collection matches your rules, all episodes from that series will be individually evaluated and included if they also match your other playlist rules
+>
+> This feature is particularly useful for creating episode-level playlists from franchise collections while still respecting other filters like date ranges, ratings, or viewing status.
  
 > **Date Filtering**: Date fields support both exact date comparisons and relative date filtering:
 > - **Exact dates**: Use "After" or "Before" with a specific date (e.g., "2024-01-01")


### PR DESCRIPTION
- Added support for including individual episodes from TV series within the Collections field in smart playlists https://github.com/jyourstone/jellyfin-smartplaylist-plugin/issues/69

## Summary by Sourcery

Enable individual episode inclusion within series for Collections-based smart playlist rules by adding a new expression flag, UI controls, and query engine logic to expand and filter episodes.

New Features:
- Add IncludeEpisodesWithinSeries option to Collections expressions
- Introduce UI selector for including episodes within series when configuring Collections rules
- Implement filter logic to expand matched series into episodes and evaluate them against playlist rules

Enhancements:
- Update README to document the Collections episode expansion feature