### PR TITLE
Changes to Collections

### DIFF
--- a/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Factory.cs
@@ -981,12 +981,11 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
                         membershipSet.Contains(baseItem.Id))
                     {
                         collections.Add(collection.Name);
-                        logger?.LogDebug("Item '{ItemName}' belongs to collection '{CollectionName}'", baseItem.Name, collection.Name);
+
                     }
                 }
                 
-                logger?.LogDebug("Item '{ItemName}' belongs to {CollectionCount} collections: [{Collections}]", 
-                    baseItem.Name, collections.Count, string.Join(", ", collections));
+
             }
             catch (Exception ex)
             {

--- a/README.md
+++ b/README.md
@@ -262,6 +262,11 @@ The web interface provides access to all available fields for creating playlist 
 > - **"No - Only include the series themselves"** (default): Collections rules will match and include the series as a whole
 > - **"Yes - Include individual episodes from series in collections"**: When a series in a collection matches your rules, all episodes from that series will be individually evaluated and included if they also match your other playlist rules
 >
+> **⚠️ Important**: To use episode expansion, you must select **"Episodes"** as one of your Media Types. The expansion feature works as follows:
+> - **Episodes only**: Returns individual episodes (direct + expanded from series), no series items
+> - **Episodes + Series**: Returns both series items AND individual episodes (direct + expanded)  
+> - **Series only**: Returns only series items, episode expansion is disabled
+>
 > This feature is particularly useful for creating episode-level playlists from franchise collections while still respecting other filters like date ranges, ratings, or viewing status.
  
 > **Date Filtering**: Date fields support both exact date comparisons and relative date filtering:


### PR DESCRIPTION
- You now have to choose "Episodes" as Media Type if you choose to include episodes within series.
- Other improvements

## Summary by Sourcery

Drive collection expansion by media type selection: require “Episodes” media type for episode-level expansion, refactor expansion logic accordingly, and adjust query and caching to support the new behavior

Enhancements:
- Refactor series expansion into a single ExpandCollectionsBasedOnMediaType method gated by ShouldExpandEpisodesForCollections
- Auto-include Series items in user media queries when Episodes media type is selected and collection expansion is enabled
- Extend media-types cache key to include collection expansion flag to prevent incorrect cache hits
- Modify PlaylistService to pass SmartPlaylistDto through media retrieval calls

Documentation:
- Update README to require “Episodes” media type for episode expansion and document the three expansion modes: Episodes only, Episodes + Series, and Series only