### PR TITLE
Performance optimizations

### DIFF
--- a/Jellyfin.Plugin.SmartPlaylist/Constants/MediaTypes.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/Constants/MediaTypes.cs
@@ -89,6 +89,16 @@ namespace Jellyfin.Plugin.SmartPlaylist.Constants
         /// </summary>
         public static readonly string[] TV = [Series, Episode];
         
+        /// <summary>
+        /// Gets music-related media types (Audio, AudioBook, MusicVideo)
+        /// </summary>
+        public static readonly string[] MusicRelated = [Audio, AudioBook, MusicVideo];
+        
+        /// <summary>
+        /// Gets media types that can have video streams (excludes Photo, Audio, Book, AudioBook)
+        /// </summary>
+        public static readonly string[] VideoStreamCapable = [Movie, Series, Episode, MusicVideo, Video];
+        
         // HashSet variants for O(1) membership checks (performance optimization)
         
         /// <summary>
@@ -105,6 +115,16 @@ namespace Jellyfin.Plugin.SmartPlaylist.Constants
         /// HashSet variant of BookTypes for O(1) membership checks
         /// </summary>
         public static readonly HashSet<string> BookTypesSet = new(BookTypes, StringComparer.Ordinal);
+        
+        /// <summary>
+        /// HashSet variant of MusicRelated for O(1) membership checks
+        /// </summary>
+        public static readonly HashSet<string> MusicRelatedSet = new(MusicRelated, StringComparer.Ordinal);
+        
+        /// <summary>
+        /// HashSet variant of VideoStreamCapable for O(1) membership checks
+        /// </summary>
+        public static readonly HashSet<string> VideoStreamCapableSet = new(VideoStreamCapable, StringComparer.Ordinal);
         
         /// <summary>
         /// Gets BaseItemKind array for audio-only content (derived from centralized mapping)

--- a/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Factory.cs
@@ -953,8 +953,8 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
                 operand.AudioLanguages = [];
             }
 
-            // Extract resolution/framerate only for items that can have video streams (exclude audio, photos, and books)
-            if (baseItem is not Photo and not Audio and not Book and not AudioBook)
+            // Extract resolution/framerate only for items that can have video streams
+            if (MediaTypes.VideoStreamCapableSet.Contains(operand.ItemType))
             {
                 ExtractResolution(operand, baseItem, logger);
                 ExtractFramerate(operand, baseItem, logger);
@@ -981,7 +981,7 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
             }
             
             // Extract artists and album artists only for music-related items (cheap operations when applicable)
-            if (baseItem is Audio or AudioBook or MusicVideo)
+            if (MediaTypes.MusicRelatedSet.Contains(operand.ItemType))
             {
                 ExtractArtists(operand, baseItem, logger);
             }
@@ -1055,6 +1055,8 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
             
             return operand;
         }
+
+
 
         /// <summary>
         /// Gets the item type name using efficient type checking instead of reflection


### PR DESCRIPTION
- Updated resolution and framerate extraction to exclude Books and Audiobooks.
- Modified artist extraction to apply only to music-related items, ensuring proper handling of non-music media types.
- Cleared artist and album artist fields for unsupported media types to improve data integrity.

## Summary by Sourcery

Introduce media type sets and restrict metadata extraction to relevant media types to boost performance and ensure data integrity.

Enhancements:
- Add MusicRelated and VideoStreamCapable media type arrays and HashSet variants for efficient membership checks
- Restrict resolution and framerate extraction to video-stream capable items using VideoStreamCapableSet
- Restrict artist and album artist extraction to music-related items and clear these fields for unsupported media types