### PR TITLE
You can now sort by track number

### DIFF
--- a/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
+++ b/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
@@ -1175,6 +1175,7 @@
             { Value: 'DateCreated', Label: 'Date Created' },
             { Value: 'ReleaseDate', Label: 'Release Date' },
             { Value: 'PlayCount (owner)', Label: 'Play Count (owner)' },
+            { Value: 'TrackNumber', Label: 'Track Number' },
             { Value: 'Resolution', Label: 'Resolution' },
             { Value: 'Random', Label: 'Random' },
             { Value: 'NoOrder', Label: 'No Order' }


### PR DESCRIPTION
- Introduced TrackNumberOrder and TrackNumberOrderDesc classes for sorting playlists by track number in both ascending and descending order.
- Updated configuration to include TrackNumber as a sorting option in the UI.

https://github.com/jyourstone/jellyfin-smartplaylist-plugin/issues/142

## Summary by Sourcery

Add TrackNumberOrder and TrackNumberOrderDesc classes to enable sorting playlists by track number and update configuration to include Track Number as a sorting option

New Features:
- Add sorting by track number in ascending and descending order

Enhancements:
- Expose 'Track Number' as a sorting option in the UI configuration