### PR TITLE
Fixed issue where equals/not equals operators were missing for some rule fields.

### DIFF
--- a/Jellyfin.Plugin.SmartPlaylist/Constants/Operators.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/Constants/Operators.cs
@@ -37,8 +37,9 @@ namespace Jellyfin.Plugin.SmartPlaylist.Constants
 
         /// <summary>
         /// Operators for multi-valued fields (collections, lists, etc.).
+        /// Equal/NotEqual check if the entire list matches exactly.
         /// </summary>
-        public static readonly string[] MultiValuedFieldOperators = ["Contains", "NotContains", "IsIn", "IsNotIn", "MatchRegex"];
+        public static readonly string[] MultiValuedFieldOperators = ["Equal", "NotEqual", "Contains", "NotContains", "IsIn", "IsNotIn", "MatchRegex"];
 
         /// <summary>
         /// Operators for string fields (text-based fields like Name, Album, etc).


### PR DESCRIPTION
## Summary by Sourcery

Add missing Equal and NotEqual operators to the multi-valued field operators list and clarify their behavior in the documentation comment.

Bug Fixes:
- Include missing Equal and NotEqual operators for multi-valued fields

Documentation:
- Update the summary comment to explain that Equal/NotEqual check if the entire list matches exactly