### PR TITLE
Fixed an issue where you could not leave Suffix Text blank.

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
@@ -1182,11 +1182,11 @@
                 config.DefaultScheduleInterval = '00:15:00';
             }
 
-            // Allow empty strings for prefix and suffix - only use defaults if undefined/null
+            // Allow empty strings for prefix and suffix
             const prefixValue = page.querySelector('#playlistNamePrefix').value;
             const suffixValue = page.querySelector('#playlistNameSuffix').value;
-            config.PlaylistNamePrefix = prefixValue !== undefined && prefixValue !== null ? prefixValue : '';
-            config.PlaylistNameSuffix = suffixValue !== undefined && suffixValue !== null ? suffixValue : '[Smart]';
+            config.PlaylistNamePrefix = prefixValue;
+            config.PlaylistNameSuffix = suffixValue;
 
             // Save processing batch size setting
             const processingBatchSizeInput = page.querySelector('#processingBatchSize').value;


### PR DESCRIPTION
Closes https://github.com/jyourstone/jellyfin-smartplaylist-plugin/issues/206

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Playlist naming now preserves explicit empty prefix/suffix values so playlists can be created without automatic additions when intentionally set blank.
  * Defaults are only applied when prefix/suffix are truly missing (undefined/null); the previous forced suffix is no longer applied when an empty value was explicitly provided.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->