### PR TITLE
Store JellyfinPlaylistId and JellyfinCollectionId without dashes for concistency with UserId.

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
@@ -318,7 +318,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                     dto.LastRefreshed = DateTime.UtcNow;
                     _logger.LogDebug("Updated LastRefreshed timestamp for collection: {CollectionName}", dto.Name);
 
-                    return (true, $"Updated collection '{existingCollection.Name}' with {newLinkedChildren.Length} items", existingCollection.Id.ToString());
+                    return (true, $"Updated collection '{existingCollection.Name}' with {newLinkedChildren.Length} items", existingCollection.Id.ToString("N"));
                 }
                 else
                 {
@@ -822,7 +822,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                     await SetPhotoForCollection(retrievedItem, cancellationToken).ConfigureAwait(false);
                 }
 
-                return collectionId.ToString("D");
+                return collectionId.ToString("N");
             }
             else
             {

--- a/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
@@ -246,7 +246,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                     logger.LogDebug("Successfully updated existing playlist: {PlaylistName} with {ItemCount} items",
                         existingPlaylist.Name, newLinkedChildren.Length);
 
-                    return (true, $"Updated playlist '{existingPlaylist.Name}' with {newLinkedChildren.Length} items", existingPlaylist.Id.ToString("D"));
+                    return (true, $"Updated playlist '{existingPlaylist.Name}' with {newLinkedChildren.Length} items", existingPlaylist.Id.ToString("N"));
                 }
                 else
                 {
@@ -616,7 +616,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                 // Refresh metadata to generate cover images
                 await RefreshPlaylistMetadataAsync(newPlaylist, cancellationToken).ConfigureAwait(false);
 
-                return newPlaylist.Id.ToString("D");
+                return newPlaylist.Id.ToString("N");
             }
             else
             {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Standardized the format of collection and playlist identifiers for consistency across the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->