### PR TITLE
Fixed an issue where Jellyfin playlists wouldn't get deleted when disabled or converted into Collections.

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Api/Controllers/SmartListController.cs
+++ b/Jellyfin.Plugin.SmartLists/Api/Controllers/SmartListController.cs
@@ -2987,6 +2987,7 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
             // Remove smart suffix from all Jellyfin playlists for all users
             if (playlist.UserPlaylists != null && playlist.UserPlaylists.Count > 0)
             {
+                logger.LogDebug("Removing smart suffix from {Count} Jellyfin playlists for multi-user playlist {PlaylistName}", playlist.UserPlaylists.Count, playlist.Name);
                 foreach (var userMapping in playlist.UserPlaylists)
                 {
                     if (!string.IsNullOrEmpty(userMapping.JellyfinPlaylistId))
@@ -3001,6 +3002,7 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                                 JellyfinPlaylistId = userMapping.JellyfinPlaylistId
                             };
                             await playlistService.RemoveSmartSuffixAsync(tempDto);
+                            logger.LogDebug("Removed smart suffix from Jellyfin playlist {JellyfinPlaylistId} for user {UserId}", userMapping.JellyfinPlaylistId, userMapping.UserId);
                         }
                         catch (Exception ex)
                         {


### PR DESCRIPTION
- Consolidated playlist deletion and suffix removal logic into dedicated methods for better code organization and reusability.
- Introduced `DeleteAllPlaylistsAsync` and `RemoveSmartSuffixFromAllPlaylistsAsync` methods to handle operations for all users in a smart playlist.
- Updated existing calls to use the new methods, improving clarity and maintainability of the code.

This refactor enhances the handling of Jellyfin playlists, ensuring consistent behavior across user playlists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved multi-user playlist handling: deletions, disables, and removal of the "smart" suffix now operate consistently across all user-specific playlists (including legacy mappings), improving reliability when converting, deleting, or disabling smart playlists.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->