### PR TITLE
Fixed issue where Equal/NotEqual operators would show up as options for list fields

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/FieldRegistry.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/FieldRegistry.cs
@@ -166,7 +166,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
 
         // Operator arrays for reuse
         private static readonly string[] StringOperators = ["Equal", "NotEqual", "Contains", "NotContains", "IsIn", "IsNotIn", "MatchRegex"];
-        private static readonly string[] MultiValueOperators = ["Equal", "NotEqual", "Contains", "NotContains", "IsIn", "IsNotIn", "MatchRegex"];
+        private static readonly string[] MultiValueOperators = ["Contains", "NotContains", "IsIn", "IsNotIn", "MatchRegex"];
         private static readonly string[] NumericOperators = ["Equal", "NotEqual", "GreaterThan", "LessThan", "GreaterThanOrEqual", "LessThanOrEqual"];
         private static readonly string[] DateOperators = ["Equal", "NotEqual", "After", "Before", "NewerThan", "OlderThan", "Weekday"];
         private static readonly string[] BooleanOperators = ["Equal", "NotEqual"];


### PR DESCRIPTION
Fixes https://github.com/jyourstone/jellyfin-smartlists-plugin/issues/302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined operators available for multi-value fields in smart lists. Equal and NotEqual operators are no longer supported; multi-value fields now exclusively use Contains, NotContains, IsIn, IsNotIn, and MatchRegex operators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->