### PR TITLE
Added Last Episode Air Date sorting option

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Configuration/config-core.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-core.js
@@ -62,6 +62,7 @@
         { value: 'Similarity', label: 'Similarity (requires Similar To rule)' },
         { value: 'TrackNumber', label: 'Track Number' },
         { value: 'Resolution', label: 'Resolution' },
+        { value: 'LastEpisodeAirDate', label: 'Last Episode Air Date' },
         { value: 'Rule Block Order', label: 'Rule Block Order' },
         { value: 'External List Order', label: 'External List Order' },
         { value: 'Random', label: 'Random' },

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-sorts.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-sorts.js
@@ -139,6 +139,7 @@
 
         const hasEpisode = selectedMediaTypes.indexOf('Episode') !== -1;
         const hasMovie = selectedMediaTypes.indexOf('Movie') !== -1;
+        const hasSeries = selectedMediaTypes.indexOf('Series') !== -1;
         const hasAudio = selectedMediaTypes.indexOf('Audio') !== -1;
         const hasAudioBook = selectedMediaTypes.indexOf('AudioBook') !== -1;
         const hasMusicVideo = selectedMediaTypes.indexOf('MusicVideo') !== -1;
@@ -147,6 +148,11 @@
         // Episode-only sort options
         if (sortValue === 'SeasonNumber' || sortValue === 'EpisodeNumber' || sortValue === 'SeriesName') {
             return hasEpisode;
+        }
+
+        // Series-only sort options
+        if (sortValue === 'LastEpisodeAirDate') {
+            return hasSeries;
         }
 
         // Audio/MusicVideo/AudioBook sort options

--- a/Jellyfin.Plugin.SmartLists/Core/Orders/LastEpisodeAirDateOrder.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Orders/LastEpisodeAirDateOrder.cs
@@ -1,0 +1,41 @@
+using System;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SmartLists.Services.Shared;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SmartLists.Core.Orders
+{
+    public class LastEpisodeAirDateOrder : PropertyOrder<double>
+    {
+        public override string Name => "LastEpisodeAirDate Ascending";
+        protected override bool IsDescending => false;
+        protected override double GetSortValue(BaseItem item, User? user = null, IUserDataManager? userDataManager = null, ILogger? logger = null, RefreshQueueService.RefreshCache? refreshCache = null)
+        {
+            ArgumentNullException.ThrowIfNull(item);
+            if (refreshCache != null && refreshCache.LastEpisodeAirDateById.TryGetValue(item.Id, out var cachedDate))
+            {
+                return cachedDate;
+            }
+
+            return 0;
+        }
+    }
+
+    public class LastEpisodeAirDateOrderDesc : PropertyOrder<double>
+    {
+        public override string Name => "LastEpisodeAirDate Descending";
+        protected override bool IsDescending => true;
+        protected override double GetSortValue(BaseItem item, User? user = null, IUserDataManager? userDataManager = null, ILogger? logger = null, RefreshQueueService.RefreshCache? refreshCache = null)
+        {
+            ArgumentNullException.ThrowIfNull(item);
+            if (refreshCache != null && refreshCache.LastEpisodeAirDateById.TryGetValue(item.Id, out var cachedDate))
+            {
+                return cachedDate;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -2055,6 +2055,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                    order is TrackNumberOrderDesc ||
                    order is Orders.RuleBlockOrderDesc ||
                    order is ExternalListOrderDesc ||
+                   order is LastEpisodeAirDateOrderDesc ||
                    order is SimilarityOrder; // Similarity descending is the default,
         }
 
@@ -2838,6 +2839,8 @@ namespace Jellyfin.Plugin.SmartLists.Core
             { "Rule Block Order Descending", () => new Orders.RuleBlockOrderDesc() },
             { "External List Order Ascending", () => new ExternalListOrder() },
             { "External List Order Descending", () => new ExternalListOrderDesc() },
+            { "LastEpisodeAirDate Ascending", () => new LastEpisodeAirDateOrder() },
+            { "LastEpisodeAirDate Descending", () => new LastEpisodeAirDateOrderDesc() },
             { "NoOrder", () => new NoOrder() },
         };
 
@@ -2982,6 +2985,13 @@ namespace Jellyfin.Plugin.SmartLists.Core
                     if (orders.Any(o => o.Name.Contains("Artist", StringComparison.OrdinalIgnoreCase) ||
                                        o.Name.Contains("Album", StringComparison.OrdinalIgnoreCase)))
                         requirements.RequiredGroups |= ExtractionGroup.AudioMetadata;
+                }
+
+                // LastEpisodeAirDate sort requires LastEpisodeAirDate extraction
+                if (!requirements.RequiredGroups.HasFlag(ExtractionGroup.LastEpisodeAirDate))
+                {
+                    if (orders.Any(o => o.Name.Contains("LastEpisodeAirDate", StringComparison.OrdinalIgnoreCase)))
+                        requirements.RequiredGroups |= ExtractionGroup.LastEpisodeAirDate;
                 }
             }
 


### PR DESCRIPTION
Closes https://github.com/jyourstone/jellyfin-smartlists-plugin/issues/305

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new sort option to organize Series content by last episode air date, available in both ascending and descending order for flexible content viewing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->