### PR TITLE
Added support for 'Music Album' media type in Collections

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Configuration/config-core.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-core.js
@@ -91,6 +91,7 @@
         { Value: "Episode", Label: "Episode (TV Show)" },
         { Value: "Series", Label: "Series (TV Show)", CollectionOnly: true }, // Series can only be added to Collections, not Playlists
         { Value: "Audio", Label: "Audio (Music)" },
+        { Value: "MusicAlbum", Label: "Album (Music)", CollectionOnly: true }, // MusicAlbum can only be added to Collections, not Playlists
         { Value: "MusicVideo", Label: "Music Video" },
         { Value: "Video", Label: "Video" },
         { Value: "Photo", Label: "Photo (Home Photo)" },

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
@@ -2626,8 +2626,16 @@
 
             // Restore previously selected media types, excluding collection-only types when switching to Playlist
             const filteredMediaTypes = currentlySelectedMediaTypes.filter(function (value) {
-                // Skip Series if switching to Playlist mode (Series is collection-only)
-                return !(value === 'Series' && !isCollection);
+                // Skip collection-only media types when switching to Playlist mode
+                if (!isCollection) {
+                    var isCollectionOnly = SmartLists.mediaTypes.some(function (mt) {
+                        return mt.Value === value && mt.CollectionOnly;
+                    });
+                    if (isCollectionOnly) {
+                        return false;
+                    }
+                }
+                return true;
             });
 
             if (filteredMediaTypes.length > 0) {

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -1449,14 +1449,18 @@
         const playlistId = playlist.Id || 'NO_ID';
 
         // Collections are server-wide, no library assignment needed
-        // Create individual media type labels - filter out Series for playlists only (not supported due to Jellyfin limitations)
+        // Create individual media type labels - filter out collection-only types for playlists (not supported due to Jellyfin limitations)
         let mediaTypesArray = [];
         if (playlist.MediaTypes && playlist.MediaTypes.length > 0) {
-            // Only filter Series for Playlists (Collections support Series)
+            // Only filter collection-only types for Playlists (Collections support all types)
             const isPlaylist = playlist.Type === 'Playlist' || !playlist.Type; // Default to Playlist if Type not set
             const validTypes = isPlaylist
-                ? playlist.MediaTypes.filter(function (type) { return type !== 'Series'; })
-                : playlist.MediaTypes; // Collections: show all types including Series
+                ? playlist.MediaTypes.filter(function (type) {
+                    return !SmartLists.mediaTypes.some(function (mt) {
+                        return mt.Value === type && mt.CollectionOnly;
+                    });
+                })
+                : playlist.MediaTypes; // Collections: show all types
             mediaTypesArray = validTypes.length > 0 ? validTypes : ['Unknown'];
         } else {
             mediaTypesArray = ['Unknown'];

--- a/Jellyfin.Plugin.SmartLists/Core/Constants/MediaTypes.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Constants/MediaTypes.cs
@@ -23,6 +23,10 @@ namespace Jellyfin.Plugin.SmartLists.Core.Constants
         // Audio Types
         public const string Audio = nameof(Audio);
 
+        // MusicAlbum media type: Not supported in Playlists (Jellyfin expands to individual tracks)
+        // but supported in Collections (same pattern as Series)
+        public const string MusicAlbum = nameof(MusicAlbum);
+
         // Music Video Types
         public const string MusicVideo = nameof(MusicVideo);
 
@@ -52,7 +56,9 @@ namespace Jellyfin.Plugin.SmartLists.Core.Constants
             { BaseItemKind.Book, Book },
             { BaseItemKind.AudioBook, AudioBook },
             // Series: Supported in Collections, not in Playlists
-            { BaseItemKind.Series, Series }
+            { BaseItemKind.Series, Series },
+            // MusicAlbum: Supported in Collections, not in Playlists
+            { BaseItemKind.MusicAlbum, MusicAlbum }
         };
 
         /// <summary>
@@ -69,7 +75,9 @@ namespace Jellyfin.Plugin.SmartLists.Core.Constants
             { Book, BaseItemKind.Book },
             { AudioBook, BaseItemKind.AudioBook },
             // Series: Supported in Collections, not in Playlists
-            { Series, BaseItemKind.Series }
+            { Series, BaseItemKind.Series },
+            // MusicAlbum: Supported in Collections, not in Playlists
+            { MusicAlbum, BaseItemKind.MusicAlbum }
         };
 
         /// <summary>
@@ -101,7 +109,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.Constants
         /// <summary>
         /// Gets music-related media types (Audio, AudioBook, MusicVideo)
         /// </summary>
-        public static readonly string[] MusicRelated = [Audio, AudioBook, MusicVideo];
+        public static readonly string[] MusicRelated = [Audio, AudioBook, MusicVideo, MusicAlbum];
 
         /// <summary>
         /// Gets media types that can have video streams (excludes Photo, Audio, Book, AudioBook)

--- a/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
@@ -1557,9 +1557,9 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
         /// </summary>
         private List<BaseItem> GetItemsWithImages(List<BaseItem> items)
         {
-            // First, get Movies and Series with images (preserving order)
+            // First, get Movies, Series and MusicAlbums with images (preserving order)
             var mediaItemsWithImages = items
-                .Where(item => (item is Movie || item is Series) &&
+                .Where(item => (item is Movie || item is Series || item is MusicAlbum) &&
                                item.ImageInfos != null &&
                                item.ImageInfos.Any(i => i.Type == ImageType.Primary))
                 .ToList();
@@ -1668,9 +1668,9 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
         /// </summary>
         private List<BaseItem> GetItemsWithThumbImages(List<BaseItem> items)
         {
-            // First, try to get Movies and Series with thumb images (preserving order)
+            // First, try to get Movies, Series and MusicAlbums with thumb images (preserving order)
             var mediaItemsWithThumbImages = items
-                .Where(item => (item is Movie || item is Series) &&
+                .Where(item => (item is Movie || item is Series || item is MusicAlbum) &&
                                item.ImageInfos != null &&
                                item.ImageInfos.Any(i => i.Type == ImageType.Thumb))
                 .ToList();

--- a/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
@@ -383,6 +383,12 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                     return (false, "Series media type is not supported for Playlists. Use Episode media type, or create a Collection instead.", string.Empty);
                 }
 
+                if (dto.MediaTypes?.Contains(Core.Constants.MediaTypes.MusicAlbum) == true)
+                {
+                    _logger.LogError("Smart playlist '{PlaylistName}' uses 'MusicAlbum' media type. MusicAlbum playlists are not supported due to Jellyfin playlist limitations. Use 'Audio' media type instead, or create a Collection for Album support. Skipping playlist refresh.", dto.Name);
+                    return (false, "MusicAlbum media type is not supported for Playlists. Use Audio media type, or create a Collection instead.", string.Empty);
+                }
+
                 if (dto.MediaTypes == null || dto.MediaTypes.Count == 0)
                 {
                     _logger.LogError("Smart playlist '{PlaylistName}' has no media types specified. At least one media type must be selected. Skipping playlist refresh.", dto.Name);
@@ -909,6 +915,13 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                 var playlistName = dto?.Name ?? "Unknown";
                 _logger?.LogError("Smart playlist '{PlaylistName}' uses 'Series' media type. Series playlists are not supported due to Jellyfin playlist limitations. Use 'Episode' media type instead, or create a Collection for Series support.", playlistName);
                 throw new InvalidOperationException("Series media type is not supported for Playlists. Use Episode media type, or create a Collection instead.");
+            }
+
+            if (mediaTypes?.Contains(Core.Constants.MediaTypes.MusicAlbum) == true)
+            {
+                var playlistName = dto?.Name ?? "Unknown";
+                _logger?.LogError("Smart playlist '{PlaylistName}' uses 'MusicAlbum' media type. MusicAlbum playlists are not supported due to Jellyfin playlist limitations. Use 'Audio' media type instead, or create a Collection for Album support.", playlistName);
+                throw new InvalidOperationException("MusicAlbum media type is not supported for Playlists. Use Audio media type, or create a Collection instead.");
             }
 
             if (mediaTypes == null || mediaTypes.Count == 0)

--- a/docs/content/examples/common-use-cases.md
+++ b/docs/content/examples/common-use-cases.md
@@ -146,6 +146,13 @@ Create distinct sections for different genres in one playlist:
 
 ## Music
 
+### Album Collection by Genre
+- **Genre** contains "Rock"
+- **Media Type**: Album (Music)
+- **List Type**: Collection
+- Creates a collection of all rock albums in your library
+- Albums can only be added to Collections, not Playlists
+
 ### Workout Mix
 - **Genre** contains "Electronic" OR "Rock" AND **Max Playtime** 45 minutes
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -50,7 +50,8 @@ SmartLists works with all media types supported by Jellyfin:
 - **Movie** - Individual movie files
 - **Series** - TV shows as a whole (can only be used when creating a Collection)
 - **Episode** - Individual TV show episodes
-- **Audio (Music)** - Music tracks and albums
+- **Audio (Music)** - Individual music tracks and songs
+- **Album (Music)** - Entire music albums (can only be used when creating a Collection)
 - **Music Video** - Music video files
 - **Video** - Personal home videos and recordings and extras (trailers, interviews etc.)
 - **Photo (Home Photo)** - Personal photos and images

--- a/docs/content/user-guide/configuration.md
+++ b/docs/content/user-guide/configuration.md
@@ -53,7 +53,7 @@ This means you can override auto-generation simply by uploading your own images 
 
 - If a collection contains only one item with an image, that item's primary image is used directly as the collection cover
 - If a collection contains two or more items with images, a 4-image collage is automatically created using the first items from the collection
-- The plugin prioritizes Movies and Series with images, falling back to any items with images if needed
+- The plugin prioritizes Movies, Series and Albums with images, falling back to any items with images if needed
 
 ##### Thumb Images (Horizontal/Landscape)
 

--- a/docs/content/user-guide/media-types.md
+++ b/docs/content/user-guide/media-types.md
@@ -10,6 +10,7 @@ When creating a smart list, you must select at least one **Media Type** to speci
 | **Episodes** | Shows | Individual TV show episodes |
 | **Series** | Shows | Entire TV series (collections only, not individual episodes) |
 | **Audio** | Music | Music tracks and songs |
+| **Album** | Music | Entire music albums (collections only, not individual tracks) |
 | **Music Videos** | Music Videos | Music video content |
 | **Video** | Home Videos and Photos | Personal video content and extras (behind the scenes, featurettes, trailers, etc.) |
 | **Photo** | Home Videos and Photos | Photo content |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Album (Music)" as a new media type, enabling you to create album-based smart collections from your music library

* **Documentation**
  * Updated supported media types documentation to include Album options
  * Added example configuration for creating genre-based album collections
  * Clarified that albums can only be used when creating Collections, not Playlists

<!-- end of auto-generated comment: release notes by coderabbit.ai -->