### PR TITLE
Fixed an issue when using multiple external lists

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
@@ -1134,6 +1134,13 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                     method = typeof(Engine).GetMethod("OnlyPlaylistEquals", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
                     if (method == null) throw new InvalidOperationException("Engine.OnlyPlaylistEquals method not found");
                 }
+                else if (r.MemberName == "ExternalList")
+                {
+                    // ExternalList uses membership check (any URL matches), not exclusive equals,
+                    // because an item can appear in multiple external lists simultaneously.
+                    method = typeof(Engine).GetMethod("AnyItemEquals", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+                    if (method == null) throw new InvalidOperationException("Engine.AnyItemEquals method not found");
+                }
                 else
                 {
                     method = typeof(Engine).GetMethod("OnlyItemEquals", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed external list matching behavior in queries to correctly accept lists containing any matching item instead of requiring exact single-item matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->