### PR TITLE
Fixed an issue with ReleaseDate sorting using multiple sort orders

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Core/Orders/ComparableTuple4.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Orders/ComparableTuple4.cs
@@ -4,10 +4,23 @@ using System.Collections.Generic;
 namespace Jellyfin.Plugin.SmartLists.Core.Orders
 {
     /// <summary>
+    /// Marker interface for composite sort keys that embed tiebreaker values.
+    /// In multi-sort scenarios, non-final sorts use only the primary value
+    /// so that actual secondary sorts can determine sub-ordering.
+    /// </summary>
+    internal interface ICompositeSortKey
+    {
+        /// <summary>
+        /// Gets the primary sort value without embedded tiebreakers.
+        /// </summary>
+        IComparable PrimaryValue { get; }
+    }
+
+    /// <summary>
     /// A comparable tuple for composite sort keys with 4 elements.
     /// Used for complex multi-level sorting.
     /// </summary>
-    internal sealed class ComparableTuple4<T1, T2, T3, T4> : IComparable
+    internal sealed class ComparableTuple4<T1, T2, T3, T4> : IComparable, ICompositeSortKey
         where T1 : IComparable
         where T2 : IComparable
         where T3 : IComparable
@@ -37,6 +50,9 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
             _comparer3 = comparer3 ?? Comparer<T3>.Default;
             _comparer4 = comparer4 ?? Comparer<T4>.Default;
         }
+
+        /// <inheritdoc/>
+        public IComparable PrimaryValue => _item1;
 
         public int CompareTo(object? obj)
         {

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -1982,13 +1982,25 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 SortKeys = orders.Select((order, idx) =>
                 {
                     var key = order.GetSortKey(item, user, userDataManager, logger, itemRandomKeys, refreshCache);
-                    // For non-final sorts, truncate DateTime keys to day precision
-                    // so secondary sorts can differentiate items within the same day.
-                    // Example: DateCreated Desc + TrackNumber Asc — without this, each track
-                    // has a unique timestamp and the TrackNumber sort never takes effect.
-                    if (idx < orderCount - 1 && key is DateTime dt)
+                    // For non-final sorts, simplify keys so secondary sorts can take effect.
+                    // Without this, the primary sort fully determines order and secondary sorts
+                    // become no-ops. Two cases:
+                    // 1. DateTime keys (DateCreated, LastPlayed): truncate to day precision so
+                    //    items from the same day are grouped, letting e.g. TrackNumber sort within.
+                    // 2. Composite keys (ReleaseDate, TrackNumber): strip embedded tiebreakers
+                    //    (season/episode, disc/track) so the user's secondary sort determines
+                    //    sub-ordering instead.
+                    if (idx < orderCount - 1)
                     {
-                        return (IComparable)dt.Date;
+                        if (key is DateTime dt)
+                        {
+                            return (IComparable)dt.Date;
+                        }
+
+                        if (key is Orders.ICompositeSortKey compositeKey)
+                        {
+                            return compositeKey.PrimaryValue;
+                        }
                     }
 
                     return key;


### PR DESCRIPTION
Fixes https://github.com/jyourstone/jellyfin-smartlists-plugin/discussions/319

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cascade sorting behavior to ensure secondary sort criteria are properly applied and effective.
  * Enhanced date-based sorting to better handle secondary sorts within the same date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->