### PR TITLE
Add support for episode-level sorting in Trakt integration and update documentation

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Services/ExternalList/TraktListProvider.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/ExternalList/TraktListProvider.cs
@@ -160,7 +160,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
         private static void AddItemIds(TraktListItem item, ExternalListResult result, ref int position)
         {
             // Items can be wrapped (list items) or direct (trending/popular)
-            var ids = item.Movie?.Ids ?? item.Show?.Ids ?? item.Ids;
+            var ids = item.Episode?.Ids ?? item.Movie?.Ids ?? item.Show?.Ids ?? item.Ids;
             if (ids == null)
             {
                 return;

--- a/Jellyfin.Plugin.SmartLists/Services/ExternalList/TraktModels.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/ExternalList/TraktModels.cs
@@ -22,6 +22,12 @@ namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
         public TraktMedia? Show { get; set; }
 
         /// <summary>
+        /// Gets or sets the episode object (present when list contains individual episodes).
+        /// </summary>
+        [JsonPropertyName("episode")]
+        public TraktMedia? Episode { get; set; }
+
+        /// <summary>
         /// Gets or sets the ids directly on the item (some endpoints).
         /// </summary>
         [JsonPropertyName("ids")]

--- a/docs/content/user-guide/external-lists.md
+++ b/docs/content/user-guide/external-lists.md
@@ -8,7 +8,7 @@ External Lists let you populate smart lists from external services like MDBList,
 2. Create a rule with the `External List` field, `equals` operator, and the list URL as the value
 3. On refresh, the plugin fetches the external list and matches items by provider IDs (IMDb, TMDB, TVDB) against your Jellyfin library
 
-Items are matched by comparing provider IDs between the external list and your library metadata. For episodes, the parent series IDs are also checked. If any provider ID matches, the item is included.
+Items are matched by comparing provider IDs between the external list and your library metadata. For episodes, the episode's own provider IDs are checked first, then the parent series IDs as a fallback. If any provider ID matches, the item is included.
 
 ## Supported Providers
 
@@ -150,6 +150,9 @@ External List / equals / https://trakt.tv/movies/trending
 
 !!! note "Public Lists Only"
     The plugin uses API-key authentication (not OAuth), so only public user lists and watchlists are accessible. Private lists require the list owner to make them public.
+
+!!! note "Episode-Level Lists"
+    Trakt lists that contain individual episodes (e.g., a chronological viewing order across multiple series) are supported. Each episode is matched by its own provider IDs and preserves its position in the list. Use **External List Order Ascending** sort to maintain the list creator's intended episode order.
 
 ---
 


### PR DESCRIPTION
Closes https://github.com/jyourstone/jellyfin-smartlists-plugin/issues/321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for episode-level matching in Trakt external lists, with episodes now matched using their own provider IDs.
  * Episode position and order are now preserved when using external lists.

* **Documentation**
  * Updated user guide with details on episode matching behavior and ordering guidance for external lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->