### PR TITLE
Added support for metadata tags and favorite state

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
@@ -281,6 +281,11 @@
         if (SmartLists.initializeSortSystem) {
             SmartLists.initializeSortSystem(page);
         }
+
+        // Initialize metadata tag input
+        if (SmartLists.initMetadataTagsInput) {
+            SmartLists.initMetadataTagsInput(page, []);
+        }
     };
 
     // ===== MEDIA TYPE CHECKBOXES GENERATION =====

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -122,6 +122,54 @@
     };
 
     // ===== PLAYLIST CRUD OPERATIONS =====
+    SmartLists.initMetadataTagsInput = function (page, tags) {
+        const container = page.querySelector('#metadataTagsContainer');
+        if (!container || !SmartLists.createTagBasedInput) {
+            return;
+        }
+
+        container.innerHTML = '';
+        container.classList.add('rule-value-container');
+
+        var currentValue = '';
+        if (Array.isArray(tags)) {
+            currentValue = tags.join(';');
+        } else if (typeof tags === 'string') {
+            currentValue = tags;
+        }
+
+        SmartLists.createTagBasedInput(container, currentValue);
+    };
+
+    SmartLists.getMetadataTags = function (page) {
+        const container = page.querySelector('#metadataTagsContainer');
+        if (!container) {
+            return [];
+        }
+
+        const hiddenInput = container.querySelector('input[type="hidden"].rule-value-input');
+        if (!hiddenInput || !hiddenInput.value) {
+            return [];
+        }
+
+        const seen = {};
+        return hiddenInput.value.split(';').map(function (tag) {
+            return tag.trim();
+        }).filter(function (tag) {
+            if (!tag) {
+                return false;
+            }
+
+            const key = tag.toLowerCase();
+            if (seen[key]) {
+                return false;
+            }
+
+            seen[key] = true;
+            return true;
+        });
+    };
+
     SmartLists.createPlaylist = function (page) {
         // Get edit state to determine if we're creating or updating
         const editState = SmartLists.getPageEditState(page);
@@ -235,6 +283,8 @@
             // Get metadata fields
             var sortTitleVal = SmartLists.getElementValue(page, '#metadataSortTitle');
             var overviewVal = SmartLists.getElementValue(page, '#metadataOverview');
+            var tagsVal = SmartLists.getMetadataTags ? SmartLists.getMetadataTags(page) : [];
+            var favoriteVal = SmartLists.getElementValue(page, '#metadataFavorite', '');
 
             const playlistDto = {
                 Type: listType,
@@ -254,6 +304,14 @@
             // Add metadata fields if set
             if (sortTitleVal) { playlistDto.SortTitle = sortTitleVal; }
             if (overviewVal) { playlistDto.Overview = overviewVal; }
+            if (tagsVal.length > 0 || (editState.editMode && page._metadataTagsWasManaged === true)) {
+                playlistDto.Tags = tagsVal;
+            }
+            if (favoriteVal === 'true') {
+                playlistDto.Favorite = true;
+            } else if (favoriteVal === 'false') {
+                playlistDto.Favorite = false;
+            }
 
             // Add type-specific fields
             if (isCollection) {
@@ -470,6 +528,7 @@
 
         // Clear stored edit state values
         delete page._editingPlaylistCreatedByUserId;
+        delete page._metadataTagsWasManaged;
 
         SmartLists.setElementValue(page, '#playlistName', '');
 
@@ -516,6 +575,10 @@
         // Clear metadata fields
         SmartLists.setElementValue(page, '#metadataSortTitle', '');
         SmartLists.setElementValue(page, '#metadataOverview', '');
+        SmartLists.setElementValue(page, '#metadataFavorite', '');
+        if (SmartLists.initMetadataTagsInput) {
+            SmartLists.initMetadataTagsInput(page, []);
+        }
 
         // Clear custom images container
         if (SmartLists.initCustomImagesContainer) {
@@ -777,6 +840,11 @@
                 // Populate metadata fields
                 SmartLists.setElementValue(page, '#metadataSortTitle', playlist.SortTitle || '');
                 SmartLists.setElementValue(page, '#metadataOverview', playlist.Overview || '');
+                SmartLists.setElementValue(page, '#metadataFavorite', playlist.Favorite === true ? 'true' : (playlist.Favorite === false ? 'false' : ''));
+                page._metadataTagsWasManaged = playlist.Tags !== undefined && playlist.Tags !== null;
+                if (SmartLists.initMetadataTagsInput) {
+                    SmartLists.initMetadataTagsInput(page, playlist.Tags || []);
+                }
 
                 // Load existing images for this playlist
                 if (SmartLists.loadExistingImages) {
@@ -1016,6 +1084,11 @@
                 // Populate metadata fields
                 SmartLists.setElementValue(page, '#metadataSortTitle', playlist.SortTitle || '');
                 SmartLists.setElementValue(page, '#metadataOverview', playlist.Overview || '');
+                SmartLists.setElementValue(page, '#metadataFavorite', playlist.Favorite === true ? 'true' : (playlist.Favorite === false ? 'false' : ''));
+                page._metadataTagsWasManaged = playlist.Tags !== undefined && playlist.Tags !== null;
+                if (SmartLists.initMetadataTagsInput) {
+                    SmartLists.initMetadataTagsInput(page, playlist.Tags || []);
+                }
 
                 // Show success message
                 SmartLists.showNotification('List "' + playlistName + '" cloned successfully! You can now modify and create the new list.', 'success');
@@ -1526,6 +1599,11 @@
         const eStatsDisplay = SmartLists.escapeHtml(statsDisplay);
         const eTotalRuntimeLong = totalRuntimeLong ? SmartLists.escapeHtml(totalRuntimeLong) : null;
         const eListType = SmartLists.escapeHtml(listType);
+        const tagsDisplayText = playlist.Tags && playlist.Tags.length > 0 ? playlist.Tags.join(', ') : 'Not set';
+        const favoriteDisplayText = playlist.Favorite === true ? 'Mark as favorite' :
+            (playlist.Favorite === false ? 'Mark as not favorite' : 'Leave unchanged');
+        const eTagsDisplayText = SmartLists.escapeHtml(tagsDisplayText);
+        const eFavoriteDisplayText = SmartLists.escapeHtml(favoriteDisplayText);
 
         // Build custom images display
         var customImagesHtml = '';
@@ -1818,6 +1896,14 @@
             '<td style="padding: 0.5em 0.75em; font-weight: bold; opacity: 0.8; width: 40%; border-right: 1px solid var(--jf-palette-divider);">Overview</td>' +
             '<td style="padding: 0.5em 0.75em; ">' + (playlist.Overview ? SmartLists.escapeHtml(playlist.Overview) : 'Not set') + '</td>' +
             '</tr>' +
+            '<tr style="border-bottom: 1px solid var(--jf-palette-divider);">' +
+            '<td style="padding: 0.5em 0.75em; font-weight: bold; opacity: 0.8; width: 40%; border-right: 1px solid var(--jf-palette-divider);">Tags</td>' +
+            '<td style="padding: 0.5em 0.75em; ">' + eTagsDisplayText + '</td>' +
+            '</tr>' +
+            '<tr style="border-bottom: 1px solid var(--jf-palette-divider);">' +
+            '<td style="padding: 0.5em 0.75em; font-weight: bold; opacity: 0.8; width: 40%; border-right: 1px solid var(--jf-palette-divider);">Favorite</td>' +
+            '<td style="padding: 0.5em 0.75em; ">' + eFavoriteDisplayText + '</td>' +
+            '</tr>' +
             '</table>' +
             '</div>' +
 
@@ -2026,4 +2112,3 @@
     };
 
 })(window.SmartLists = window.SmartLists || {});
-

--- a/Jellyfin.Plugin.SmartLists/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config.html
@@ -353,6 +353,21 @@
                                     placeholder="Leave empty for none" style="resize: vertical;"></textarea>
                                 <div class="fieldDescription">Set a custom description/overview for this list.</div>
                             </div>
+                            <div style="margin-top: 0.5em;">
+                                <label class="inputLabel" for="metadataTagsContainer">Tags</label>
+                                <div id="metadataTagsContainer"></div>
+                                <div class="fieldDescription">Set tags on the Jellyfin playlist or collection. Any existing tags will be replaced.</div>
+                            </div>
+                            <div style="margin-top: 0.5em;">
+                                <label class="inputLabel" for="metadataFavorite">Favorite</label>
+                                <select id="metadataFavorite" is="emby-select"
+                                    class="emby-select-withcolor emby-select">
+                                    <option value="">Leave unchanged</option>
+                                    <option value="true">Mark as favorite</option>
+                                    <option value="false">Mark as not favorite</option>
+                                </select>
+                                <div class="fieldDescription">For playlists, applies to the selected playlist user(s). For collections, applies to the selected collection user.</div>
+                            </div>
                         </div>
 
                         <div style="margin-top: 2em;">

--- a/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
@@ -298,6 +298,21 @@
                                     placeholder="Leave empty for none" style="resize: vertical;"></textarea>
                                 <div class="fieldDescription">Set a custom description/overview for this list.</div>
                             </div>
+                            <div style="margin-top: 0.5em;">
+                                <label class="inputLabel" for="metadataTagsContainer">Tags</label>
+                                <div id="metadataTagsContainer"></div>
+                                <div class="fieldDescription">Set tags on the Jellyfin playlist or collection. Any existing tags will be replaced.</div>
+                            </div>
+                            <div style="margin-top: 0.5em;">
+                                <label class="inputLabel" for="metadataFavorite">Favorite</label>
+                                <select id="metadataFavorite" is="emby-select"
+                                    class="emby-select-withcolor emby-select">
+                                    <option value="">Leave unchanged</option>
+                                    <option value="true">Mark as favorite</option>
+                                    <option value="false">Mark as not favorite</option>
+                                </select>
+                                <div class="fieldDescription">Set whether the created list is favorited for your user.</div>
+                            </div>
                         </div>
 
                         <div style="margin-top: 2em;">

--- a/Jellyfin.Plugin.SmartLists/Core/Models/SmartListDto.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Models/SmartListDto.cs
@@ -130,6 +130,20 @@ namespace Jellyfin.Plugin.SmartLists.Core.Models
         public string? Overview { get; set; }
 
         /// <summary>
+        /// Tags applied to the Jellyfin playlist/collection.
+        /// Null means tags are not managed by SmartLists; an empty list clears managed tags.
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<string>? Tags { get; set; }
+
+        /// <summary>
+        /// Favorite state applied to the Jellyfin playlist/collection for the relevant user.
+        /// Null means favorite state is not managed by SmartLists.
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? Favorite { get; set; }
+
+        /// <summary>
         /// Migrates legacy IsPlayed rules to PlaybackStatus.
         /// Called after deserialization.
         /// </summary>
@@ -155,4 +169,3 @@ namespace Jellyfin.Plugin.SmartLists.Core.Models
         }
     }
 }
-

--- a/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
@@ -324,7 +324,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                     }
 
                     // Update the collection items
-                    await UpdateCollectionItemsAsync(existingCollection, newLinkedChildren, dto, cancellationToken);
+                    await UpdateCollectionItemsAsync(existingCollection, newLinkedChildren, dto, ownerUser, cancellationToken);
 
                     _logger.LogDebug("Successfully updated existing collection: {CollectionName} with {ItemCount} items",
                         existingCollection.Name, newLinkedChildren.Length);
@@ -340,7 +340,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                     // Create new collection
                     _logger.LogDebug("Creating new collection: {CollectionName}", collectionName);
 
-                    var newCollectionId = await CreateNewCollectionAsync(collectionName, newLinkedChildren, dto, cancellationToken);
+                    var newCollectionId = await CreateNewCollectionAsync(collectionName, newLinkedChildren, dto, ownerUser, cancellationToken);
 
                     // Check if collection creation actually succeeded
                     if (string.IsNullOrEmpty(newCollectionId))
@@ -525,7 +525,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
             }
         }
 
-        private async Task UpdateCollectionItemsAsync(BaseItem collection, LinkedChild[] linkedChildren, SmartCollectionDto dto, CancellationToken cancellationToken)
+        private async Task UpdateCollectionItemsAsync(BaseItem collection, LinkedChild[] linkedChildren, SmartCollectionDto dto, User ownerUser, CancellationToken cancellationToken)
         {
             // Verify this is a BoxSet using BaseItemKind
             if (collection.GetBaseItemKind() != BaseItemKind.BoxSet)
@@ -594,11 +594,11 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                 await collectionAfterRefresh.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
 
                 // Apply custom metadata after metadata refresh to prevent providers from overwriting
-                await ApplyCustomMetadataAsync(collectionAfterRefresh, dto, cancellationToken).ConfigureAwait(false);
+                await ApplyCustomMetadataAsync(collectionAfterRefresh, dto, ownerUser, cancellationToken).ConfigureAwait(false);
             }
         }
 
-        private async Task<string> CreateNewCollectionAsync(string collectionName, LinkedChild[] linkedChildren, SmartCollectionDto dto, CancellationToken cancellationToken)
+        private async Task<string> CreateNewCollectionAsync(string collectionName, LinkedChild[] linkedChildren, SmartCollectionDto dto, User ownerUser, CancellationToken cancellationToken)
         {
             // Apply prefix/suffix to collection name using the same configuration as playlists
             var formattedName = NameFormatter.FormatPlaylistName(collectionName);
@@ -897,7 +897,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                     await retrievedItem.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
 
                     // Apply custom metadata after metadata refresh to prevent providers from overwriting
-                    await ApplyCustomMetadataAsync(retrievedItem, dto, cancellationToken).ConfigureAwait(false);
+                    await ApplyCustomMetadataAsync(retrievedItem, dto, ownerUser, cancellationToken).ConfigureAwait(false);
                 }
 
                 return collectionId.ToString("N");
@@ -909,8 +909,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
             }
         }
 
-        private Task ApplyCustomMetadataAsync(BaseItem item, SmartListDto dto, CancellationToken cancellationToken)
-            => MetadataHelper.ApplyCustomMetadataAsync(item, dto, _logger, cancellationToken);
+        private Task ApplyCustomMetadataAsync(BaseItem item, SmartListDto dto, User ownerUser, CancellationToken cancellationToken)
+            => MetadataHelper.ApplyCustomMetadataAsync(item, dto, _logger, cancellationToken, ownerUser, _userDataManager);
 
         /// <summary>
         /// Applies custom images from the smart list configuration to the Jellyfin collection.
@@ -2250,4 +2250,3 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
 
     }
 }
-

--- a/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
@@ -282,7 +282,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                     }
 
                     // Update the playlist items (includes metadata refresh)
-                    await UpdatePlaylistPublicStatusAsync(existingPlaylist, dto.Public, newLinkedChildren, dto, cancellationToken);
+                    await UpdatePlaylistPublicStatusAsync(existingPlaylist, dto.Public, newLinkedChildren, dto, user, cancellationToken);
 
                     logger.LogDebug("Successfully updated existing playlist: {PlaylistName} with {ItemCount} items",
                         existingPlaylist.Name, newLinkedChildren.Length);
@@ -294,7 +294,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                     // Create new playlist
                     logger.LogDebug("Creating new playlist: {PlaylistName}", smartPlaylistName);
 
-                    var newPlaylistId = await CreateNewPlaylistAsync(smartPlaylistName, user.Id, dto.Public, newLinkedChildren, dto, cancellationToken);
+                    var newPlaylistId = await CreateNewPlaylistAsync(smartPlaylistName, user, dto.Public, newLinkedChildren, dto, cancellationToken);
 
                     // Check if playlist creation actually succeeded
                     if (string.IsNullOrEmpty(newPlaylistId))
@@ -596,7 +596,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
             }
         }
 
-        private async Task UpdatePlaylistPublicStatusAsync(Playlist playlist, bool isPublic, LinkedChild[] linkedChildren, SmartPlaylistDto dto, CancellationToken cancellationToken)
+        private async Task UpdatePlaylistPublicStatusAsync(Playlist playlist, bool isPublic, LinkedChild[] linkedChildren, SmartPlaylistDto dto, User user, CancellationToken cancellationToken)
         {
             _logger.LogDebug("Updating playlist {PlaylistName} public status to {PublicStatus} and items to {ItemCount}",
     playlist.Name, isPublic ? "public" : "private", linkedChildren.Length);
@@ -656,10 +656,10 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
             }
 
             // Apply custom metadata after metadata refresh to prevent providers from overwriting
-            await ApplyCustomMetadataAsync(playlist, dto, cancellationToken).ConfigureAwait(false);
+            await ApplyCustomMetadataAsync(playlist, dto, user, cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task<string> CreateNewPlaylistAsync(string playlistName, Guid userId, bool isPublic, LinkedChild[] linkedChildren, SmartPlaylistDto dto, CancellationToken cancellationToken)
+        private async Task<string> CreateNewPlaylistAsync(string playlistName, User user, bool isPublic, LinkedChild[] linkedChildren, SmartPlaylistDto dto, CancellationToken cancellationToken)
         {
             _logger.LogDebug("Creating new smart playlist {PlaylistName} with {ItemCount} items and {PublicStatus} status",
                 playlistName, linkedChildren.Length, isPublic ? "public" : "private");
@@ -667,7 +667,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
             var result = await _playlistManager.CreatePlaylist(new PlaylistCreationRequest
             {
                 Name = playlistName,
-                UserId = userId,
+                UserId = user.Id,
                 Public = isPublic,
             }).ConfigureAwait(false);
 
@@ -702,7 +702,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                 }
 
                 // Apply custom metadata after metadata refresh to prevent providers from overwriting
-                await ApplyCustomMetadataAsync(newPlaylist, dto, cancellationToken).ConfigureAwait(false);
+                await ApplyCustomMetadataAsync(newPlaylist, dto, user, cancellationToken).ConfigureAwait(false);
 
                 return newPlaylist.Id.ToString("N");
             }
@@ -713,8 +713,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
             }
         }
 
-        private Task ApplyCustomMetadataAsync(BaseItem item, SmartListDto dto, CancellationToken cancellationToken)
-            => MetadataHelper.ApplyCustomMetadataAsync(item, dto, _logger, cancellationToken);
+        private Task ApplyCustomMetadataAsync(BaseItem item, SmartListDto dto, User user, CancellationToken cancellationToken)
+            => MetadataHelper.ApplyCustomMetadataAsync(item, dto, _logger, cancellationToken, user, _userDataManager);
 
         /// <summary>
         /// Applies custom images from the smart list configuration to the Jellyfin playlist.

--- a/Jellyfin.Plugin.SmartLists/Utilities/DtoMapper.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/DtoMapper.cs
@@ -41,6 +41,7 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
                 ExpressionSets = source.ExpressionSets,
                 Order = source.Order,
                 MediaTypes = source.MediaTypes,
+                IncludeExtras = source.IncludeExtras,
                 
                 // State and limits
                 Enabled = source.Enabled,
@@ -64,6 +65,13 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
                 
                 // Similarity comparison
                 SimilarityComparisonFields = source.SimilarityComparisonFields,
+
+                // Custom metadata
+                CustomImages = source.CustomImages,
+                SortTitle = source.SortTitle,
+                Overview = source.Overview,
+                Tags = source.Tags,
+                Favorite = source.Favorite,
                 
                 // Playlist-specific (initialize to defaults)
                 JellyfinPlaylistId = null,
@@ -105,6 +113,7 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
                 ExpressionSets = source.ExpressionSets,
                 Order = source.Order,
                 MediaTypes = source.MediaTypes,
+                IncludeExtras = source.IncludeExtras,
                 
                 // State and limits
                 Enabled = source.Enabled,
@@ -128,6 +137,13 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
                 
                 // Similarity comparison
                 SimilarityComparisonFields = source.SimilarityComparisonFields,
+
+                // Custom metadata
+                CustomImages = source.CustomImages,
+                SortTitle = source.SortTitle,
+                Overview = source.Overview,
+                Tags = source.Tags,
+                Favorite = source.Favorite,
                 
                 // Collection-specific (will be set by caller)
                 JellyfinCollectionId = null

--- a/Jellyfin.Plugin.SmartLists/Utilities/InputValidator.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/InputValidator.cs
@@ -23,6 +23,8 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
         private const int MaxExpressionsPerSet = 100;
         private const int MaxMediaTypesCount = 50;
         private const int MaxSchedulesCount = 100;
+        private const int MaxTagsCount = 100;
+        private const int MaxTagLength = 100;
 
         // Dangerous patterns
         private static readonly string[] SqlInjectionPatterns = new[]
@@ -319,6 +321,33 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
             if (list.VisibilitySchedules != null && list.VisibilitySchedules.Count > MaxSchedulesCount)
             {
                 return SmartListValidationResult.Failure($"Cannot have more than {MaxSchedulesCount} visibility schedules");
+            }
+
+            // Validate managed metadata tags
+            if (list.Tags != null)
+            {
+                if (list.Tags.Count > MaxTagsCount)
+                {
+                    return SmartListValidationResult.Failure($"Cannot have more than {MaxTagsCount} tags");
+                }
+
+                foreach (var tag in list.Tags)
+                {
+                    if (tag == null)
+                    {
+                        return SmartListValidationResult.Failure("Tags cannot contain null values");
+                    }
+
+                    if (tag.Length > MaxTagLength)
+                    {
+                        return SmartListValidationResult.Failure($"Tags cannot exceed {MaxTagLength} characters");
+                    }
+
+                    if (tag.Any(c => char.IsControl(c)))
+                    {
+                        return SmartListValidationResult.Failure("Tags cannot contain control characters");
+                    }
+                }
             }
 
             return SmartListValidationResult.Success();

--- a/Jellyfin.Plugin.SmartLists/Utilities/InputValidator.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/InputValidator.cs
@@ -333,9 +333,9 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
 
                 foreach (var tag in list.Tags)
                 {
-                    if (tag == null)
+                    if (string.IsNullOrWhiteSpace(tag))
                     {
-                        return SmartListValidationResult.Failure("Tags cannot contain null values");
+                        return SmartListValidationResult.Failure("Tags cannot be empty or whitespace");
                     }
 
                     if (tag.Length > MaxTagLength)

--- a/Jellyfin.Plugin.SmartLists/Utilities/MetadataHelper.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/MetadataHelper.cs
@@ -1,8 +1,12 @@
+using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.SmartLists.Core.Models;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.SmartLists.Utilities;
@@ -13,10 +17,16 @@ namespace Jellyfin.Plugin.SmartLists.Utilities;
 public static class MetadataHelper
 {
     /// <summary>
-    /// Applies custom metadata (Sort Title, Overview) from the smart list configuration to a Jellyfin item.
+    /// Applies custom metadata (Sort Title, Overview, Tags, Favorite) from the smart list configuration to a Jellyfin item.
     /// Called after metadata refresh to prevent providers from overwriting custom values.
     /// </summary>
-    public static async Task ApplyCustomMetadataAsync(BaseItem item, SmartListDto dto, ILogger logger, CancellationToken cancellationToken)
+    public static async Task ApplyCustomMetadataAsync(
+        BaseItem item,
+        SmartListDto dto,
+        ILogger logger,
+        CancellationToken cancellationToken,
+        User? favoriteUser = null,
+        IUserDataManager? userDataManager = null)
     {
         bool changed = false;
 
@@ -38,9 +48,52 @@ public static class MetadataHelper
             logger.LogDebug("Set Overview for {ItemName}", item.Name);
         }
 
+        // Apply Tags. Null means SmartLists should leave existing Jellyfin tags alone;
+        // an empty list is intentional and clears managed tags.
+        if (dto.Tags != null)
+        {
+            var newTags = dto.Tags
+                .Where(tag => !string.IsNullOrWhiteSpace(tag))
+                .Select(tag => tag.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            var currentTags = item.Tags ?? [];
+            if (!currentTags.SequenceEqual(newTags, StringComparer.OrdinalIgnoreCase))
+            {
+                item.Tags = newTags;
+                changed = true;
+                logger.LogDebug("Set {TagCount} tag(s) for {ItemName}", newTags.Length, item.Name);
+            }
+        }
+
         if (changed)
         {
             await item.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
+        }
+
+        // Favorite is stored as user data in Jellyfin, so it is applied separately from item metadata.
+        if (dto.Favorite.HasValue)
+        {
+            if (favoriteUser == null || userDataManager == null)
+            {
+                logger.LogDebug("Favorite state requested for {ItemName}, but no user context was available", item.Name);
+                return;
+            }
+
+            var userData = userDataManager.GetUserData(favoriteUser, item);
+            if (userData == null)
+            {
+                logger.LogWarning("Could not load user data for {ItemName} and user {UserId}; favorite state was not applied", item.Name, favoriteUser.Id);
+                return;
+            }
+
+            if (userData.IsFavorite != dto.Favorite.Value)
+            {
+                userData.IsFavorite = dto.Favorite.Value;
+                userDataManager.SaveUserData(favoriteUser, item, userData, UserDataSaveReason.UpdateUserData, cancellationToken);
+                logger.LogDebug("Set favorite state to {Favorite} for {ItemName} and user {UserId}", dto.Favorite.Value, item.Name, favoriteUser.Id);
+            }
         }
     }
 }

--- a/docs/content/user-guide/configuration.md
+++ b/docs/content/user-guide/configuration.md
@@ -118,8 +118,13 @@ The **Metadata** section lets you set additional properties on the Jellyfin play
 
 - **Sort Title** – Overrides the default sort title. Useful for controlling where the list appears when sorting alphabetically (e.g., set it to `_Movies` to force it to the top).
 - **Overview** – Sets a custom description that appears in Jellyfin's item detail view.
+- **Tags** – Sets tags on the generated Jellyfin playlist or collection. Enter each tag and press Enter, or paste multiple tags separated by semicolons.
+- **Favorite** – Optionally marks the generated list as favorite or not favorite. Leave it unchanged if you do not want SmartLists to manage favorite state.
 
-Both fields are optional. Leave them empty to use Jellyfin's defaults. Values are re-applied on each refresh.
+All fields are optional. Values are re-applied on each refresh.
+
+!!! note "Favorite is user-specific"
+    Favorite state in Jellyfin belongs to a user, not to the playlist or collection globally. For playlists, SmartLists applies the setting for each selected playlist user. For collections, SmartLists applies it for the selected collection reference user.
 
 !!! note "User Selection for Collections"
     When creating a collection, the user you select is used as a **reference** for rule evaluation, not as an owner. The collection itself is server-wide and visible to everyone. This user's context is important for:


### PR DESCRIPTION
- Implemented metadata tags input and retrieval for playlists and collections.
- Added favorite state management for playlists and collections.
- Updated configuration pages to include fields for tags and favorite state.
- Enhanced validation for metadata tags.
- Updated documentation to reflect new features.

Closes https://github.com/jyourstone/jellyfin-smartlists-plugin/issues/371

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to manage tags for playlists and collections through the configuration UI
  * Added per-user favorite marking for playlists and collections
  * New Metadata section displays tags and favorite status on playlist/collection cards

* **Documentation**
  * Updated configuration guide to document the new Tags and Favorite fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->