### PR TITLE
Added support for all-user playlists

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Api/Controllers/SmartListController.cs
+++ b/Jellyfin.Plugin.SmartLists/Api/Controllers/SmartListController.cs
@@ -167,28 +167,7 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
         /// </summary>
         private static HashSet<string> GetPlaylistUserIds(SmartPlaylistDto playlist)
         {
-            var userIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-            if (playlist.UserPlaylists != null && playlist.UserPlaylists.Count > 0)
-            {
-                foreach (var mapping in playlist.UserPlaylists)
-                {
-                    if (!string.IsNullOrEmpty(mapping.UserId) && Guid.TryParse(mapping.UserId, out var userId) && userId != Guid.Empty)
-                    {
-                        // Normalize to standard format without dashes for consistent comparison
-                        userIds.Add(userId.ToString("N"));
-                    }
-                }
-            }
-            else if (!string.IsNullOrEmpty(playlist.UserId) && Guid.TryParse(playlist.UserId, out var parsedUserId) && parsedUserId != Guid.Empty)
-            {
-                // Fallback to old format, normalize to standard format without dashes
-                // DEPRECATED: This fallback is for backwards compatibility with old single-user playlists.
-                // It is planned to be removed in version 10.12. Use UserPlaylists array instead.
-                userIds.Add(parsedUserId.ToString("N"));
-            }
-
-            return userIds;
+            return PlaylistUserResolver.GetEffectiveUserIds(playlist);
         }
 
         /// <summary>
@@ -429,6 +408,21 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
         private bool NormalizeAndValidateUserPlaylists(SmartPlaylistDto playlist, out string errorMessage)
         {
             errorMessage = string.Empty;
+
+            if (playlist.AllUsers)
+            {
+                PlaylistUserResolver.ExpandAllUsers(playlist, _userManager);
+                if (playlist.UserPlaylists == null || playlist.UserPlaylists.Count == 0)
+                {
+                    errorMessage = "At least one Jellyfin user is required for all-users playlists";
+                    return false;
+                }
+
+                playlist.Public = false;
+                logger.LogDebug("All-users playlist detected ({UserCount} users), setting Public=false", playlist.UserPlaylists.Count);
+                return true;
+            }
+
             if (playlist.UserPlaylists == null || playlist.UserPlaylists.Count == 0)
             {
                 errorMessage = "At least one playlist user is required";
@@ -1274,6 +1268,17 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                             playlistDto.DateCreated = existingCollection.DateCreated;
                         }
 
+                        if (!NormalizeAndValidateUserPlaylists(playlistDto, out var conversionValidationError))
+                        {
+                            logger.LogWarning("Collection-to-playlist conversion validation failed: {Error}. Name={Name}", conversionValidationError, playlistDto.Name);
+                            return BadRequest(new ProblemDetails
+                            {
+                                Title = "Validation Error",
+                                Detail = conversionValidationError,
+                                Status = StatusCodes.Status400BadRequest
+                            });
+                        }
+
                         // Delete-first approach for atomicity: if any deletion fails, original state is preserved
                         var collectionService = GetCollectionService();
                         await collectionService.DeleteAsync(existingCollection);
@@ -1443,7 +1448,7 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
 
                 // Compare old and new user lists to detect changes
                 var oldUserIds = GetPlaylistUserIds(existingPlaylist);
-                var newUserIds = GetPlaylistUserIds(playlist);
+                var newUserIds = PlaylistUserResolver.GetEffectiveUserIds(playlist, _userManager);
                 var usersToRemove = oldUserIds.Except(newUserIds, StringComparer.OrdinalIgnoreCase).ToList();
                 var usersToAdd = newUserIds.Except(oldUserIds, StringComparer.OrdinalIgnoreCase).ToList();
                 var usersToKeep = oldUserIds.Intersect(newUserIds, StringComparer.OrdinalIgnoreCase).ToList();
@@ -3686,6 +3691,22 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                     currentUserId = GetCurrentUserId();
                 }
                 return currentUserId;
+            }
+
+            if (playlist.AllUsers)
+            {
+                PlaylistUserResolver.ExpandAllUsers(playlist, _userManager);
+                if (playlist.UserPlaylists == null || playlist.UserPlaylists.Count == 0)
+                {
+                    return Task.FromResult((false, "Playlist has no valid users"));
+                }
+
+                if (Guid.TryParse(playlist.UserPlaylists[0].UserId, out var firstAllUserId))
+                {
+                    playlist.UserId = firstAllUserId.ToString("D");
+                }
+
+                return Task.FromResult((true, string.Empty));
             }
 
             // Check multi-user playlists

--- a/Jellyfin.Plugin.SmartLists/Api/Controllers/SmartListController.cs
+++ b/Jellyfin.Plugin.SmartLists/Api/Controllers/SmartListController.cs
@@ -1268,6 +1268,21 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                             playlistDto.DateCreated = existingCollection.DateCreated;
                         }
 
+                        if (!playlistDto.AllUsers && (playlistDto.UserPlaylists == null || playlistDto.UserPlaylists.Count == 0))
+                        {
+                            if (!string.IsNullOrEmpty(playlistDto.UserId) && Guid.TryParse(playlistDto.UserId, out var playlistUserId) && playlistUserId != Guid.Empty)
+                            {
+                                playlistDto.UserPlaylists =
+                                [
+                                    new SmartPlaylistDto.UserPlaylistMapping
+                                    {
+                                        UserId = playlistDto.UserId,
+                                        JellyfinPlaylistId = null
+                                    }
+                                ];
+                            }
+                        }
+
                         if (!NormalizeAndValidateUserPlaylists(playlistDto, out var conversionValidationError))
                         {
                             logger.LogWarning("Collection-to-playlist conversion validation failed: {Error}. Name={Name}", conversionValidationError, playlistDto.Name);

--- a/Jellyfin.Plugin.SmartLists/Api/Controllers/UserSmartListController.cs
+++ b/Jellyfin.Plugin.SmartLists/Api/Controllers/UserSmartListController.cs
@@ -287,6 +287,7 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
 
                 // Override user selection - always use current user
                 // Use "N" format to exclude hyphens (consistent with admin page and API responses)
+                list.AllUsers = false;
                 list.UserId = userId.ToString("N");
                 list.UserPlaylists =
                 [
@@ -479,6 +480,11 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
         /// </summary>
         private static bool IsUserInPlaylist(SmartPlaylistDto playlist, string normalizedUserId)
         {
+            if (playlist.AllUsers)
+            {
+                return false;
+            }
+
             // Check new format: UserPlaylists array
             if (playlist.UserPlaylists != null && playlist.UserPlaylists.Count > 0)
             {
@@ -633,6 +639,7 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                     MaxItems = 0,
                     MaxPlayTimeMinutes = 0,
                     Public = false,
+                    AllUsers = false,
                     UserPlaylists =
                     [
                         new SmartPlaylistDto.UserPlaylistMapping
@@ -1143,6 +1150,7 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
 
                     // Preserve the original filename, user ownership, and type
                     playlistDto.FileName = existingPlaylist.FileName;
+                    playlistDto.AllUsers = false;
                     playlistDto.UserId = existingPlaylist.UserId;
                     playlistDto.UserPlaylists = existingPlaylist.UserPlaylists;
                     playlistDto.Type = Core.Enums.SmartListType.Playlist;

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-api.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-api.js
@@ -122,6 +122,10 @@
             return Promise.resolve();
         }
 
+        if (page._pendingAllUsers || (SmartLists.isAllUsersSelected && SmartLists.isAllUsersSelected(page))) {
+            return Promise.resolve();
+        }
+
         // Don't overwrite if we have a pending collection user ID (from edit/clone mode for collections)
         if (page._pendingCollectionUserId) {
             return Promise.resolve();
@@ -661,4 +665,3 @@
     };
 
 })(window.SmartLists = window.SmartLists || {});
-

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-filters.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-filters.js
@@ -68,6 +68,9 @@
                 const normalizedFilter = normalizeUserId(userFilter);
 
                 return playlists.filter(function (playlist) {
+                    if (playlist.AllUsers) {
+                        return true;
+                    }
                     // User filter applies to both playlists (owner) and collections (rule context user)
                     // Check UserPlaylists array (multi-user playlists)
                     if (playlist.UserPlaylists && playlist.UserPlaylists.length > 0) {
@@ -269,6 +272,10 @@
             }
 
             // Search in username (resolved from User ID or UserPlaylists)
+            if (playlist.AllUsers && ('all users'.indexOf(searchTerm) !== -1 || 'everyone'.indexOf(searchTerm) !== -1)) {
+                return true;
+            }
+
             if (page && page._usernameCache) {
                 // Check UserPlaylists array (multi-user playlists)
                 if (playlist.UserPlaylists && playlist.UserPlaylists.length > 0) {
@@ -599,6 +606,9 @@
 
             for (var i = 0; i < playlists.length; i++) {
                 const playlist = playlists[i];
+                if (playlist.AllUsers) {
+                    continue;
+                }
                 // Check UserPlaylists array (multi-user playlists)
                 if (playlist.UserPlaylists && playlist.UserPlaylists.length > 0) {
                     for (var j = 0; j < playlist.UserPlaylists.length; j++) {
@@ -773,4 +783,3 @@
     // Note: getPeopleFieldDisplayName is defined in config-formatters.js to avoid duplication
 
 })(window.SmartLists = window.SmartLists || {});
-

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
@@ -446,6 +446,9 @@
         const userSelect = page.querySelector('#playlistUser');
         if (userSelect) {
             userSelect.value = '';
+            if (SmartLists.setAllUsersSelected) {
+                SmartLists.setAllUsersSelected(page, false);
+            }
             SmartLists.setCurrentUserAsDefault(page);
         }
     };
@@ -554,7 +557,9 @@
                     }
 
                     // Check if there are pending userIds to set (from edit/clone mode)
-                    if (page._pendingUserIds && Array.isArray(page._pendingUserIds) && page._pendingUserIds.length > 0) {
+                    if (page._pendingAllUsers && SmartLists.setAllUsersSelected) {
+                        SmartLists.setAllUsersSelected(page, true);
+                    } else if (page._pendingUserIds && Array.isArray(page._pendingUserIds) && page._pendingUserIds.length > 0) {
                         // Use setTimeout to ensure checkboxes are fully rendered
                         setTimeout(function () {
                             if (SmartLists.setSelectedUserIds) {
@@ -566,7 +571,8 @@
                     } else {
                         // Check if checkboxes already have selections before defaulting to current user
                         const checkboxes = page.querySelectorAll('#userMultiSelectOptions .user-multi-select-checkbox:checked');
-                        if (checkboxes.length === 0) {
+                        const allUsersSelected = SmartLists.isAllUsersSelected && SmartLists.isAllUsersSelected(page);
+                        if (checkboxes.length === 0 && !allUsersSelected) {
                             // Set current user as default (only if not in edit/clone mode)
                             SmartLists.setCurrentUserAsDefault(page);
                         }
@@ -2559,6 +2565,9 @@
             // Priority: current UI state (most accurate) > pending IDs (may be stale from earlier toggles)
             var currentEditState = SmartLists.getPageEditState(page);
             if (isCollection && (currentEditState.editMode || currentEditState.cloneMode)) {
+                if (SmartLists.setAllUsersSelected) {
+                    SmartLists.setAllUsersSelected(page, false);
+                }
                 // Switching to Collection: check current checkbox selection first (highest priority)
                 var selectedCheckboxes = page.querySelectorAll('#userMultiSelectOptions .user-multi-select-checkbox:checked');
                 if (selectedCheckboxes.length > 0) {

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -27,6 +27,10 @@
             return Promise.resolve('Unknown User');
         }
 
+        if (playlist.AllUsers) {
+            return Promise.resolve('All users');
+        }
+
         // Check for multi-user playlists (UserPlaylists array)
         if (playlist.UserPlaylists && playlist.UserPlaylists.length > 0) {
             // Resolve all user IDs to names
@@ -192,6 +196,7 @@
 
             // Get selected user ID(s) - collections use single select, playlists use multi-select
             let userIds;
+            let allUsers = false;
             if (SmartLists.IS_USER_PAGE) {
                 // User page: always use the current logged-in user
                 const apiClient = SmartLists.getApiClient();
@@ -205,12 +210,13 @@
                 userIds = userId ? [normalizeUserId(userId)] : [];
             } else {
                 // Admin page - Playlists: potentially multiple users
-                const selectedIds = SmartLists.getSelectedUserIds ? SmartLists.getSelectedUserIds(page) : [];
+                allUsers = SmartLists.isAllUsersSelected ? SmartLists.isAllUsersSelected(page) : false;
+                const selectedIds = allUsers ? [] : (SmartLists.getSelectedUserIds ? SmartLists.getSelectedUserIds(page) : []);
                 // Normalize all user IDs (remove hyphens and lowercase)
                 userIds = selectedIds.map(function(id) { return normalizeUserId(id); });
             }
 
-            if (!userIds || userIds.length === 0) {
+            if (!allUsers && (!userIds || userIds.length === 0)) {
                 SmartLists.showNotification('Please select at least one ' + (isCollection ? 'collection user' : 'playlist user') + '.');
                 return;
             }
@@ -262,14 +268,15 @@
                 // Collections are server-wide, no library assignment needed
             } else {
                 // Playlists: send UserPlaylists array structure
-                playlistDto.UserPlaylists = userIds.map(function (userId) {
+                playlistDto.AllUsers = allUsers;
+                playlistDto.UserPlaylists = allUsers ? [] : userIds.map(function (userId) {
                     return {
                         UserId: userId,
                         JellyfinPlaylistId: null  // Backend will populate on creation
                     };
                 });
-                // Only set Public for single-user playlists (multi-user playlists are always private)
-                playlistDto.Public = userIds.length === 1 ? isPublic : false;
+                // Only set Public for single-user playlists (all-user and multi-user playlists are always private)
+                playlistDto.Public = (!allUsers && userIds.length === 1) ? isPublic : false;
             }
 
             // Add similarity comparison fields if specified
@@ -470,8 +477,13 @@
 
         // Clear stored edit state values
         delete page._editingPlaylistCreatedByUserId;
+        delete page._pendingAllUsers;
+        delete page._pendingUserIds;
 
         SmartLists.setElementValue(page, '#playlistName', '');
+        if (SmartLists.setAllUsersSelected) {
+            SmartLists.setAllUsersSelected(page, false);
+        }
 
         // Clean up all existing event listeners before clearing rules
         const rulesContainer = page.querySelector('#rules-container');
@@ -561,6 +573,7 @@
                 // This ensures pendingUserIds is set before loadUsers checks for it
                 let userIds = [];
                 if (!isCollection) {
+                    page._pendingAllUsers = playlist.AllUsers === true;
                     // Playlists can have multiple users
                     if (playlist.UserPlaylists && playlist.UserPlaylists.length > 0) {
                         userIds = playlist.UserPlaylists.map(function (up) { return up.UserId; });
@@ -570,6 +583,7 @@
                     // Store userIds to set after users are loaded (loadUsers is async)
                     page._pendingUserIds = userIds;
                 } else {
+                    page._pendingAllUsers = false;
                     // Collections: store the user ID to prevent setCurrentUserAsDefault from overwriting
                     if (playlist.UserId) {
                         page._pendingCollectionUserId = String(playlist.UserId);
@@ -657,7 +671,10 @@
                     // userIds were already extracted and stored in page._pendingUserIds above
                     // Try to set immediately if users are already loaded, otherwise wait for loadUsers
                     const checkboxes = page.querySelectorAll('#userMultiSelectOptions .user-multi-select-checkbox');
-                    if (checkboxes.length > 0 && page._pendingUserIds) {
+                    if (page._pendingAllUsers && SmartLists.setAllUsersSelected) {
+                        SmartLists.setAllUsersSelected(page, true);
+                        page._pendingAllUsers = false;
+                    } else if (checkboxes.length > 0 && page._pendingUserIds) {
                         // Users already loaded, set immediately
                         if (SmartLists.setSelectedUserIds) {
                             SmartLists.setSelectedUserIds(page, page._pendingUserIds);
@@ -827,6 +844,7 @@
                 // This ensures pendingUserIds is set before loadUsers checks for it
                 let userIds = [];
                 if (!isCollection) {
+                    page._pendingAllUsers = playlist.AllUsers === true;
                     // Playlists can have multiple users
                     if (playlist.UserPlaylists && playlist.UserPlaylists.length > 0) {
                         userIds = playlist.UserPlaylists.map(function (up) { return up.UserId; });
@@ -836,6 +854,7 @@
                     // Store userIds to set after users are loaded (loadUsers is async)
                     page._pendingUserIds = userIds;
                 } else {
+                    page._pendingAllUsers = false;
                     // Collections: store the source user ID to prevent setCurrentUserAsDefault from overwriting
                     if (playlist.UserId) {
                         page._pendingCollectionUserId = String(playlist.UserId);
@@ -922,7 +941,10 @@
                     // userIds were already extracted and stored in page._pendingUserIds above
                     // Try to set immediately if users are already loaded, otherwise wait for loadUsers
                     const checkboxes = page.querySelectorAll('#userMultiSelectOptions .user-multi-select-checkbox');
-                    if (checkboxes.length > 0 && page._pendingUserIds) {
+                    if (page._pendingAllUsers && SmartLists.setAllUsersSelected) {
+                        SmartLists.setAllUsersSelected(page, true);
+                        page._pendingAllUsers = false;
+                    } else if (checkboxes.length > 0 && page._pendingUserIds) {
                         // Users already loaded, set immediately
                         if (SmartLists.setSelectedUserIds) {
                             SmartLists.setSelectedUserIds(page, page._pendingUserIds);
@@ -1908,7 +1930,7 @@
                 processedPlaylists = processedPlaylists.filter(function (playlist) {
                     // Only show playlists that have 0 or 1 user
                     // Multi-user playlists (created by admins) should only be visible/editable by admins
-                    return !playlist.UserPlaylists || playlist.UserPlaylists.length <= 1;
+                    return !playlist.AllUsers && (!playlist.UserPlaylists || playlist.UserPlaylists.length <= 1);
                 });
             }
 
@@ -2026,4 +2048,3 @@
     };
 
 })(window.SmartLists = window.SmartLists || {});
-

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-user-select.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-user-select.js
@@ -25,6 +25,17 @@
                 SmartLists.updatePublicCheckboxVisibility(page);
             }
         });
+
+        const allUsersCheckbox = page.querySelector('#playlistAllUsers');
+        if (allUsersCheckbox && !allUsersCheckbox._smartListsAllUsersInitialized) {
+            allUsersCheckbox._smartListsAllUsersInitialized = true;
+            allUsersCheckbox.addEventListener('change', function () {
+                SmartLists.updateAllUsersSelectionState(page);
+                SmartLists.updatePublicCheckboxVisibility(page);
+            });
+        }
+
+        SmartLists.updateAllUsersSelectionState(page);
     };
 
     /**
@@ -45,6 +56,9 @@
      * Get array of selected user IDs
      */
     SmartLists.getSelectedUserIds = function (page) {
+        if (SmartLists.isAllUsersSelected(page)) {
+            return [];
+        }
         return SmartLists.getSelectedItems(page, 'playlistUserMultiSelect', 'user-multi-select-checkbox');
     };
 
@@ -54,6 +68,73 @@
     SmartLists.setSelectedUserIds = function (page, userIds) {
         SmartLists.setSelectedItems(page, 'playlistUserMultiSelect', userIds, 'user-multi-select-checkbox', 'Select users...');
         SmartLists.updatePublicCheckboxVisibility(page);
+    };
+
+    SmartLists.isAllUsersSelected = function (page) {
+        const allUsersCheckbox = page.querySelector('#playlistAllUsers');
+        return !!(allUsersCheckbox && allUsersCheckbox.checked);
+    };
+
+    SmartLists.setAllUsersSelected = function (page, selected) {
+        const allUsersCheckbox = page.querySelector('#playlistAllUsers');
+        if (allUsersCheckbox) {
+            allUsersCheckbox.checked = !!selected;
+        }
+        SmartLists.updateAllUsersSelectionState(page);
+        SmartLists.updatePublicCheckboxVisibility(page);
+    };
+
+    SmartLists.updateAllUsersSelectionState = function (page) {
+        const allUsers = SmartLists.isAllUsersSelected(page);
+        const options = page.querySelector('#userMultiSelectOptions');
+        const display = page.querySelector('#userMultiSelectDisplay');
+
+        if (options) {
+            const checkboxes = options.querySelectorAll('.user-multi-select-checkbox');
+            checkboxes.forEach(function (checkbox) {
+                checkbox.disabled = allUsers;
+                if (allUsers) {
+                    checkbox.checked = false;
+                }
+            });
+        }
+
+        if (display) {
+            display.style.opacity = allUsers ? '0.6' : '';
+            display.style.pointerEvents = allUsers ? 'none' : '';
+        }
+
+        if (allUsers) {
+            SmartLists.setUserMultiSelectDisplayText(page, 'All users');
+        } else {
+            SmartLists.updateUserMultiSelectDisplay(page);
+        }
+    };
+
+    SmartLists.setUserMultiSelectDisplayText = function (page, text) {
+        const display = page.querySelector('#userMultiSelectDisplay');
+        if (!display) return;
+
+        const placeholder = display.querySelector('.multi-select-placeholder');
+        if (placeholder) {
+            placeholder.style.display = 'none';
+        }
+
+        const existingSelected = display.querySelector('.multi-select-selected-items');
+        if (existingSelected) {
+            existingSelected.remove();
+        }
+
+        const selectedItems = document.createElement('span');
+        selectedItems.className = 'multi-select-selected-items';
+        selectedItems.textContent = text;
+
+        const arrow = display.querySelector('.multi-select-arrow');
+        if (arrow) {
+            display.insertBefore(selectedItems, arrow);
+        } else {
+            display.appendChild(selectedItems);
+        }
     };
 
     /**
@@ -80,11 +161,12 @@
         }
 
         const userIds = SmartLists.getSelectedUserIds(page);
+        const allUsers = SmartLists.isAllUsersSelected(page);
         const publicCheckboxContainer = page.querySelector('#publicCheckboxContainer');
 
         if (publicCheckboxContainer) {
-            if (userIds.length > 1) {
-                // Hide public checkbox for multi-user playlists (using inline style)
+            if (allUsers || userIds.length > 1) {
+                // Hide public checkbox for all-user and multi-user playlists (using inline style)
                 // Note: We use removeProperty() when showing to avoid style persistence across navigations
                 publicCheckboxContainer.style.display = 'none';
             } else {
@@ -103,4 +185,3 @@
     };
 
 })(window.SmartLists);
-

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-user-select.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-user-select.js
@@ -29,10 +29,11 @@
         const allUsersCheckbox = page.querySelector('#playlistAllUsers');
         if (allUsersCheckbox && !allUsersCheckbox._smartListsAllUsersInitialized) {
             allUsersCheckbox._smartListsAllUsersInitialized = true;
-            allUsersCheckbox.addEventListener('change', function () {
+            allUsersCheckbox._smartListsAllUsersChangeHandler = function () {
                 SmartLists.updateAllUsersSelectionState(page);
                 SmartLists.updatePublicCheckboxVisibility(page);
-            });
+            };
+            allUsersCheckbox.addEventListener('change', allUsersCheckbox._smartListsAllUsersChangeHandler);
         }
 
         SmartLists.updateAllUsersSelectionState(page);
@@ -181,6 +182,13 @@
      * Cleanup function to be called on page navigation to prevent memory leaks
      */
     SmartLists.cleanupUserMultiSelect = function (page) {
+        const allUsersCheckbox = page.querySelector('#playlistAllUsers');
+        if (allUsersCheckbox && allUsersCheckbox._smartListsAllUsersChangeHandler) {
+            allUsersCheckbox.removeEventListener('change', allUsersCheckbox._smartListsAllUsersChangeHandler);
+            delete allUsersCheckbox._smartListsAllUsersChangeHandler;
+            delete allUsersCheckbox._smartListsAllUsersInitialized;
+        }
+
         SmartLists.cleanupMultiSelect(page, 'playlistUserMultiSelect');
     };
 

--- a/Jellyfin.Plugin.SmartLists/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config.html
@@ -193,9 +193,10 @@
                             </div>
 
                             <div class="fieldDescription">
-                                <span class="playlist-only-description">Select one or more users for this playlist. When
-                                    multiple users are selected, a separate playlist will be created for each
-                                    user.</span>
+                                <span class="playlist-only-description">Select one or more users from the dropdown to
+                                    create a separate personalized playlist for each selected user. Select All users to
+                                    create it for every current user and automatically include future users on
+                                    refresh.</span>
                                 <span class="collection-only-description">The user context for creating the collection
                                     and rule evaluation (e.g., PlaybackStatus, IsFavorite). The collection itself is
                                     visible

--- a/Jellyfin.Plugin.SmartLists/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config.html
@@ -168,6 +168,17 @@
 
                             <!-- Playlist: Custom Multi-Select -->
                             <div id="playlistUserMultiSelect" class="playlist-only-field" style="display: none;">
+                                <label class="emby-checkbox-label" style="margin-bottom: 0.5em;">
+                                    <input type="checkbox" is="emby-checkbox" id="playlistAllUsers"
+                                        data-embycheckbox="true" class="emby-checkbox">
+                                    <span class="checkboxLabel">All users</span>
+                                    <span class="checkboxOutline">
+                                        <span class="material-icons checkboxIcon checkboxIcon-checked check"
+                                            aria-hidden="true"></span>
+                                        <span class="material-icons checkboxIcon checkboxIcon-unchecked"
+                                            aria-hidden="true"></span>
+                                    </span>
+                                </label>
                                 <div class="multi-select-container">
                                     <div class="multi-select-display emby-select-withcolor" id="userMultiSelectDisplay">
                                         <span class="multi-select-placeholder">Select users...</span>

--- a/Jellyfin.Plugin.SmartLists/Core/Models/SmartPlaylistDto.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Models/SmartPlaylistDto.cs
@@ -19,6 +19,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.Models
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? JellyfinPlaylistId { get; set; }  // Jellyfin playlist ID for reliable lookup (backwards compatibility - first user's playlist)
         public bool Public { get; set; } = false; // Default to private
+        public bool AllUsers { get; set; } = false; // Create one personalized playlist for every current and future Jellyfin user
 
         /// <summary>
         /// Multi-user playlist support: Array of user-playlist mappings.
@@ -39,4 +40,3 @@ namespace Jellyfin.Plugin.SmartLists.Core.Models
         }
     }
 }
-

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/AutoRefreshService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/AutoRefreshService.cs
@@ -84,6 +84,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
 
         // Batch processing for library events (add/remove) to avoid spam during bulk operations
         private readonly ConcurrentDictionary<string, DateTime> _pendingLibraryRefreshes = new();
+        private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, byte>> _pendingUserDataRefreshUsers = new();
+        private readonly ConcurrentDictionary<string, byte> _pendingFullAutoRefreshes = new();
         private readonly Timer _batchProcessTimer;
         private readonly TimeSpan _batchDelay = TimeSpan.FromSeconds(3); // Short delay for batching library events
 
@@ -431,6 +433,19 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                     foreach (var playlistId in affectedPlaylistIds)
                     {
                         _pendingLibraryRefreshes[playlistId] = DateTime.UtcNow.Add(_batchDelay);
+                        if (triggeringUserId.HasValue)
+                        {
+                            if (!_pendingFullAutoRefreshes.ContainsKey(playlistId))
+                            {
+                                var userIds = _pendingUserDataRefreshUsers.GetOrAdd(playlistId, _ => new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase));
+                                userIds[triggeringUserId.Value.ToString("N")] = 0;
+                            }
+                        }
+                        else
+                        {
+                            _pendingFullAutoRefreshes[playlistId] = 0;
+                            _pendingUserDataRefreshUsers.TryRemove(playlistId, out _);
+                        }
                     }
 
                     foreach (var collectionId in affectedCollectionIds)
@@ -453,6 +468,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
             {
                 var now = DateTime.UtcNow;
                 var readyToProcess = new List<string>();
+                var triggeringUsersByPlaylist = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
 
                 // Find playlists that are ready to be refreshed (delay has passed)
                 foreach (var kvp in _pendingLibraryRefreshes.ToList())
@@ -461,6 +477,15 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                     {
                         readyToProcess.Add(kvp.Key);
                         _pendingLibraryRefreshes.TryRemove(kvp.Key, out _);
+                        var isFullRefresh = _pendingFullAutoRefreshes.TryRemove(kvp.Key, out _);
+                        if (!isFullRefresh && _pendingUserDataRefreshUsers.TryRemove(kvp.Key, out var userIds))
+                        {
+                            triggeringUsersByPlaylist[kvp.Key] = userIds.Keys.ToList();
+                        }
+                        else
+                        {
+                            _pendingUserDataRefreshUsers.TryRemove(kvp.Key, out _);
+                        }
                     }
                 }
 
@@ -471,7 +496,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                         readyToProcess.Count, _batchDelay.TotalSeconds);
 
                     // Process the batch in background - separate playlists and collections
-                    _ = Task.Run(async () => await ProcessListRefreshes(readyToProcess));
+                    _ = Task.Run(async () => await ProcessListRefreshes(readyToProcess, triggeringUsersByPlaylist));
                 }
             }
             catch (Exception ex)
@@ -1330,7 +1355,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
 
 
 
-        private async Task ProcessListRefreshes(List<string> listIds)
+        private async Task ProcessListRefreshes(List<string> listIds, IReadOnlyDictionary<string, List<string>>? triggeringUsersByPlaylist = null)
         {
             if (_disposed) return;
 
@@ -1368,7 +1393,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                 // Process playlists
                 if (playlistIds.Any())
                 {
-                    await ProcessPlaylistRefreshes(playlistIds).ConfigureAwait(false);
+                    await ProcessPlaylistRefreshes(playlistIds, triggeringUsersByPlaylist).ConfigureAwait(false);
                 }
 
                 // Process collections
@@ -1383,7 +1408,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
             }
         }
 
-        private async Task ProcessPlaylistRefreshes(List<string> playlistIds)
+        private async Task ProcessPlaylistRefreshes(List<string> playlistIds, IReadOnlyDictionary<string, List<string>>? triggeringUsersByPlaylist = null)
         {
             if (_disposed) return;
 
@@ -1410,6 +1435,9 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                                 OperationType = RefreshOperationType.Refresh,
                                 ListData = playlist,
                                 UserId = playlist.UserId,
+                                TriggeringUserIds = triggeringUsersByPlaylist != null && triggeringUsersByPlaylist.TryGetValue(playlistId, out var triggeringUserIds)
+                                    ? triggeringUserIds
+                                    : null,
                                 TriggerType = Core.Enums.RefreshTriggerType.Auto
                             };
                             

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/AutoRefreshService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/AutoRefreshService.cs
@@ -1045,6 +1045,11 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
         {
             try
             {
+                if (playlist.AllUsers)
+                {
+                    return true;
+                }
+
                 // Check if the user is in the UserPlaylists array (multi-user playlists)
                 // UserPlaylists stores UserId in "N" format (no dashes), so normalize for comparison
                 if (playlist.UserPlaylists != null && playlist.UserPlaylists.Count > 0)

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
@@ -407,6 +407,12 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
 
             // Multi-user playlists: Process each user in the UserPlaylists array
             var userPlaylists = userPlaylistsToProcess ?? dto.UserPlaylists;
+            if (userPlaylistsToProcess != null && userPlaylistsToProcess.Count == 0)
+            {
+                _logger.LogDebug("Skipping all-users playlist '{PlaylistName}' because no triggering users matched current users", dto.Name);
+                return;
+            }
+
             if (userPlaylists != null && userPlaylists.Count > 0)
             {
                 _logger.LogDebug("Processing multi-user playlist '{PlaylistName}' with {UserCount} users", dto.Name, userPlaylists.Count);

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
@@ -42,6 +42,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
         public RefreshOperationType OperationType { get; set; }
         public SmartListDto? ListData { get; set; }
         public string? UserId { get; set; }
+        public List<string>? TriggeringUserIds { get; set; }
         public RefreshTriggerType TriggerType { get; set; }
         public DateTime QueuedAt { get; set; }
     }
@@ -321,12 +322,12 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                     {
                         _logger.LogDebug("Reloaded playlist '{PlaylistName}' from store (CustomImages: {HasImages})",
                             latestDto.Name, latestDto.CustomImages?.Count > 0);
-                        await ProcessPlaylistRefreshAsync(latestDto, cancellationToken);
+                        await ProcessPlaylistRefreshAsync(latestDto, item.TriggeringUserIds, cancellationToken);
                         return;
                     }
                 }
                 // Fallback to original DTO if reload fails
-                await ProcessPlaylistRefreshAsync((SmartPlaylistDto)item.ListData, cancellationToken);
+                await ProcessPlaylistRefreshAsync((SmartPlaylistDto)item.ListData, item.TriggeringUserIds, cancellationToken);
             }
             else if (item.ListType == SmartListType.Collection)
             {
@@ -383,20 +384,35 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
         /// <summary>
         /// Processes a playlist refresh with caching support
         /// </summary>
-        private async Task ProcessPlaylistRefreshAsync(SmartPlaylistDto dto, CancellationToken cancellationToken)
+        private async Task ProcessPlaylistRefreshAsync(SmartPlaylistDto dto, List<string>? triggeringUserIds, CancellationToken cancellationToken)
         {
+            List<SmartPlaylistDto.UserPlaylistMapping>? userPlaylistsToProcess = null;
             if (dto.AllUsers)
             {
                 PlaylistUserResolver.ExpandAllUsers(dto, _userManager);
+
+                if (triggeringUserIds != null && triggeringUserIds.Count > 0 && dto.UserPlaylists != null)
+                {
+                    var triggeringUserSet = triggeringUserIds
+                        .Where(userId => !string.IsNullOrEmpty(userId) && Guid.TryParse(userId, out _))
+                        .Select(PlaylistUserResolver.NormalizeUserId)
+                        .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+                    userPlaylistsToProcess = dto.UserPlaylists
+                        .Where(mapping => !string.IsNullOrEmpty(mapping.UserId) &&
+                                          triggeringUserSet.Contains(PlaylistUserResolver.NormalizeUserId(mapping.UserId)))
+                        .ToList();
+                }
             }
 
             // Multi-user playlists: Process each user in the UserPlaylists array
-            if (dto.UserPlaylists != null && dto.UserPlaylists.Count > 0)
+            var userPlaylists = userPlaylistsToProcess ?? dto.UserPlaylists;
+            if (userPlaylists != null && userPlaylists.Count > 0)
             {
-                _logger.LogDebug("Processing multi-user playlist '{PlaylistName}' with {UserCount} users", dto.Name, dto.UserPlaylists.Count);
+                _logger.LogDebug("Processing multi-user playlist '{PlaylistName}' with {UserCount} users", dto.Name, userPlaylists.Count);
                 
                 var validUserCount = 0;
-                foreach (var userMapping in dto.UserPlaylists)
+                foreach (var userMapping in userPlaylists)
                 {
                     if (string.IsNullOrEmpty(userMapping.UserId) || !Guid.TryParse(userMapping.UserId, out var userId) || userId == Guid.Empty)
                     {
@@ -420,7 +436,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                 if (validUserCount == 0)
                 {
                     _logger.LogWarning("Playlist '{PlaylistName}' had no valid users to refresh (all {UserCount} users were invalid or missing)", 
-                        dto.Name, dto.UserPlaylists.Count);
+                        dto.Name, userPlaylists.Count);
                 }
             }
             // Single-user playlist (backwards compatibility): Use top-level UserId

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
@@ -385,6 +385,11 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
         /// </summary>
         private async Task ProcessPlaylistRefreshAsync(SmartPlaylistDto dto, CancellationToken cancellationToken)
         {
+            if (dto.AllUsers)
+            {
+                PlaylistUserResolver.ExpandAllUsers(dto, _userManager);
+            }
+
             // Multi-user playlists: Process each user in the UserPlaylists array
             if (dto.UserPlaylists != null && dto.UserPlaylists.Count > 0)
             {
@@ -791,4 +796,3 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
         }
     }
 }
-

--- a/Jellyfin.Plugin.SmartLists/Utilities/DtoMapper.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/DtoMapper.cs
@@ -68,6 +68,7 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
                 // Playlist-specific (initialize to defaults)
                 JellyfinPlaylistId = null,
                 Public = false,
+                AllUsers = false,
                 UserPlaylists = null
             };
             

--- a/Jellyfin.Plugin.SmartLists/Utilities/PlaylistUserResolver.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/PlaylistUserResolver.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SmartLists.Core.Models;
+using MediaBrowser.Controller.Library;
+
+namespace Jellyfin.Plugin.SmartLists.Utilities
+{
+    /// <summary>
+    /// Resolves the effective user mappings for smart playlists.
+    /// </summary>
+    internal static class PlaylistUserResolver
+    {
+        public static string NormalizeUserId(Guid userId) => userId.ToString("N");
+
+        public static string NormalizeUserId(string userId)
+        {
+            return Guid.TryParse(userId, out var guid) ? guid.ToString("N") : userId;
+        }
+
+        public static List<User> GetAllUsers(IUserManager userManager)
+        {
+            return userManager.Users
+                .Where(u => u != null && u.Id != Guid.Empty)
+                .OrderBy(u => u.Username, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        public static void ExpandAllUsers(SmartPlaylistDto playlist, IUserManager userManager)
+        {
+            ArgumentNullException.ThrowIfNull(playlist);
+            ArgumentNullException.ThrowIfNull(userManager);
+
+            if (!playlist.AllUsers)
+            {
+                return;
+            }
+
+            var existingByUserId = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+            if (playlist.UserPlaylists != null)
+            {
+                foreach (var mapping in playlist.UserPlaylists)
+                {
+                    if (!string.IsNullOrEmpty(mapping.UserId) &&
+                        Guid.TryParse(mapping.UserId, out var userId) &&
+                        userId != Guid.Empty &&
+                        !existingByUserId.ContainsKey(userId.ToString("N")))
+                    {
+                        existingByUserId[userId.ToString("N")] = mapping.JellyfinPlaylistId;
+                    }
+                }
+            }
+
+            playlist.UserPlaylists = GetAllUsers(userManager)
+                .Select(user =>
+                {
+                    var normalizedUserId = user.Id.ToString("N");
+                    existingByUserId.TryGetValue(normalizedUserId, out var jellyfinPlaylistId);
+                    return new SmartPlaylistDto.UserPlaylistMapping
+                    {
+                        UserId = normalizedUserId,
+                        JellyfinPlaylistId = jellyfinPlaylistId
+                    };
+                })
+                .ToList();
+
+            playlist.Public = false;
+        }
+
+        public static HashSet<string> GetEffectiveUserIds(SmartPlaylistDto playlist, IUserManager? userManager = null)
+        {
+            ArgumentNullException.ThrowIfNull(playlist);
+
+            var userIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            if (playlist.AllUsers && userManager != null)
+            {
+                foreach (var user in GetAllUsers(userManager))
+                {
+                    userIds.Add(user.Id.ToString("N"));
+                }
+
+                return userIds;
+            }
+
+            if (playlist.UserPlaylists != null && playlist.UserPlaylists.Count > 0)
+            {
+                foreach (var mapping in playlist.UserPlaylists)
+                {
+                    if (!string.IsNullOrEmpty(mapping.UserId) &&
+                        Guid.TryParse(mapping.UserId, out var userId) &&
+                        userId != Guid.Empty)
+                    {
+                        userIds.Add(userId.ToString("N"));
+                    }
+                }
+            }
+            else if (!string.IsNullOrEmpty(playlist.UserId) &&
+                     Guid.TryParse(playlist.UserId, out var parsedUserId) &&
+                     parsedUserId != Guid.Empty)
+            {
+                userIds.Add(parsedUserId.ToString("N"));
+            }
+
+            return userIds;
+        }
+
+        public static SmartPlaylistDto.UserPlaylistMapping? FindMapping(SmartPlaylistDto playlist, string userId)
+        {
+            if (playlist.UserPlaylists == null)
+            {
+                return null;
+            }
+
+            var normalizedUserId = NormalizeUserId(userId);
+            return playlist.UserPlaylists.FirstOrDefault(mapping =>
+                !string.IsNullOrEmpty(mapping.UserId) &&
+                string.Equals(NormalizeUserId(mapping.UserId), normalizedUserId, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Utilities/RefreshCache.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/RefreshCache.cs
@@ -82,6 +82,11 @@ namespace Jellyfin.Plugin.SmartLists
 
             try
             {
+                foreach (var playlist in playlists.Where(p => p.AllUsers))
+                {
+                    PlaylistUserResolver.ExpandAllUsers(playlist, _userManager);
+                }
+
                 // Handle playlists with missing/invalid User first
                 // Helper predicate to check if a playlist has a valid user ID (either top-level UserId or UserPlaylists array)
                 static bool IsValidUserId(SmartPlaylistDto p)

--- a/docs/content/user-guide/configuration.md
+++ b/docs/content/user-guide/configuration.md
@@ -171,7 +171,7 @@ View and edit your smart playlists and collections:
 !!! info "User Page Differences"
     On the **User Page**, you can only see and manage lists you own. Admins can see and manage all lists server-wide.
     
-    Additionally, **multi-user playlists are hidden** from the user page. When an admin creates a playlist with multiple users selected, those playlists will not appear in the manage tab for regular users. This prevents users from accidentally editing playlists that would affect other users. Multi-user playlists can only be viewed and managed by administrators.
+    Additionally, **multi-user and all-user playlists are hidden** from the user page. When an admin creates a playlist with multiple users selected, or with **All users** enabled, those playlists will not appear in the manage tab for regular users. This prevents users from accidentally editing playlists that would affect other users. These playlists can only be viewed and managed by administrators.
 
 ### 3. Status
 

--- a/docs/content/user-guide/user-selection.md
+++ b/docs/content/user-guide/user-selection.md
@@ -17,6 +17,12 @@ For **Playlists**, you can select one or more users who will be the **owners** o
 - Each playlist is filtered based on the respective user's own data
 - This allows the same smart playlist configuration to show different content for each user
 
+### All Users
+- When you select **All users**, a separate Jellyfin playlist is created for every current Jellyfin user
+- Future Jellyfin users are included automatically the next time the smart playlist refreshes
+- Each user still gets their own personalized version based on their own watch data, favorites, play count, and library access
+- All-user playlists are managed by administrators only
+
 !!! example "Multi-User Playlist Example"
     If you create a "My Favorites" playlist and select three users (Alice, Bob, and Charlie):
     
@@ -42,10 +48,10 @@ Playlists also have a **"Make playlist public"** option:
 - **Public (checked)**: The playlist is visible to all logged-in users on the server, but the content is still based on the owner's data
 
 !!! note "Public Playlists with Multiple Users"
-    When you select multiple users for a playlist, the "Make playlist public" option is automatically hidden and disabled. This is because each user gets their own separate playlist, and it wouldn't make sense for one user's personalized playlist to be visible to others.
+    When you select multiple users, or select **All users**, the "Make playlist public" option is automatically hidden and disabled. This is because each user gets their own separate playlist, and it wouldn't make sense for one user's personalized playlist to be visible to others.
 
 !!! warning "Multi-User Playlists and User Page Access"
-    Multi-user playlists are **only visible and editable by administrators**. Regular users accessing the SmartLists user page will not see multi-user playlists in their list, even if they are one of the selected users.
+    Multi-user and all-user playlists are **only visible and editable by administrators**. Regular users accessing the SmartLists user page will not see these smart playlist configurations in their list, even if they are one of the selected users.
     
     This is a safety measure to prevent users from accidentally modifying playlists that would affect other users. If a user needs their own version of a multi-user playlist, an administrator should create separate single-user playlists instead (one for each user).
 
@@ -88,7 +94,7 @@ For **Collections**, the user selection works differently because collections do
 | **Ownership** | Each selected user owns their playlist | No ownership (server-wide) |
 | **Visibility** | Private or public | Always visible to all users |
 | **Content Filtering** | Based on each owner's data | Based on reference user's data |
-| **Multiple Instances** | One playlist per selected user | Single collection for all users |
+| **Multiple Instances** | One playlist per selected user, or one per current/future user with All users | Single collection for all users |
 
 ## Selecting Users
 
@@ -97,8 +103,9 @@ In the SmartLists configuration interface:
 ### For Playlists
 1. Click on the **Playlist Users** multi-select dropdown
 2. Check the boxes for the users you want to create playlists for
-3. At least one user must be selected
-4. Each selected user will get their own personalized playlist
+3. Or check **All users** to include every current and future Jellyfin user
+4. At least one user must be selected unless **All users** is checked
+5. Each selected user will get their own personalized playlist
 
 ### For Collections
 1. Select a single user from the **Collection User** dropdown


### PR DESCRIPTION
- Introduced `AllUsers` property in `SmartPlaylistDto` to create personalized playlists for all current and future users.
- Updated `PlaylistUserResolver` to handle user mappings for all-user playlists.
- Modified various controllers and services to accommodate the new all-user functionality.
- Enhanced user selection UI to include an option for all users.
- Updated documentation to reflect changes in user selection and playlist management.

Closes https://github.com/jyourstone/jellyfin-smartlists-plugin/issues/377

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced "All users" option for smart playlists (creates personalized playlists for current and future users) with an "All users" checkbox in the UI
  * Auto-refresh now respects per-user triggering for playlists, improving refresh behavior for All-users playlists

* **Bug Fixes / UX**
  * "Make playlist public" is hidden/disabled when multiple users or All users are selected
  * Search, filters and user-selection UI now correctly handle All-users playlists and preserve pending All-users state during edit/clone

* **Documentation**
  * Updated user guides to describe All-users behavior, admin-only management, and selection rules
<!-- end of auto-generated comment: release notes by coderabbit.ai -->