### PR TITLE
You can now choose to include parent album genres for music

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -1493,8 +1493,16 @@
 
                         // Add Genres configuration info
                         let genresInfo = '';
-                        if (rule.MemberName === 'Genres' && rule.IncludeParentSeriesGenres === true) {
-                            genresInfo = ' (including parent series genres)';
+                        if (rule.MemberName === 'Genres') {
+                            const includesParentSeriesGenres = rule.IncludeParentSeriesGenres === true;
+                            const includesParentAlbumGenres = rule.IncludeParentAlbumGenres === true;
+                            if (includesParentSeriesGenres && includesParentAlbumGenres) {
+                                genresInfo = ' (including parent series/album genres)';
+                            } else if (includesParentAlbumGenres) {
+                                genresInfo = ' (including parent album genres)';
+                            } else if (includesParentSeriesGenres) {
+                                genresInfo = ' (including parent series genres)';
+                            }
                         }
 
                         // Add AudioLanguages configuration info

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-rules.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-rules.js
@@ -1145,11 +1145,11 @@
             '</div>' +
             '<div class="rule-genres-options" style="display: none; margin-bottom: 0.75em; padding: 0.5em; background: var(--jf-palette-background-paper); border: 1px solid var(--jf-palette-divider); border-radius: 4px;">' +
             '<label style="display: block; margin-bottom: 0.25em; font-size: 0.85em; opacity: 0.8; font-weight: 500;">' +
-            'Include parent series genres:' +
+            'Include parent genres:' +
             '</label>' +
             '<select is="emby-select" class="emby-select rule-genres-select" style="width: 100%;">' +
-            '<option value="false">No - Only check episode genres</option>' +
-            '<option value="true">Yes - Also check genres from parent series</option>' +
+            '<option value="false">No - Only check item genres</option>' +
+            '<option value="true">Yes - Also check parent genres</option>' +
             '</select>' +
             '</div>' +
             '<div class="rule-audiolanguages-options" style="display: none; margin-bottom: 0.75em; padding: 0.5em; background: var(--jf-palette-background-paper); border: 1px solid var(--jf-palette-divider); border-radius: 4px;">' +
@@ -1534,6 +1534,7 @@
         }
         if (fieldValue === 'Genres' && genresValue === 'true') {
             expression.IncludeParentSeriesGenres = true;
+            expression.IncludeParentAlbumGenres = true;
         }
         if (fieldValue === 'AudioLanguages' && audioLanguagesValue === 'true') {
             expression.OnlyDefaultAudioLanguage = true;
@@ -2301,12 +2302,31 @@
         const genresOptionsDiv = ruleRow.querySelector('.rule-genres-options');
 
         if (genresOptionsDiv) {
-            // Get selected media types to check if Episode is selected
+            // Get selected media types to check if Episode or Audio is selected
             const selectedMediaTypes = page ? SmartLists.getSelectedMediaTypes(page) : [];
             const hasEpisode = selectedMediaTypes.indexOf('Episode') !== -1;
+            const hasAudio = selectedMediaTypes.indexOf('Audio') !== -1;
 
-            // Show only if Genres field is selected AND Episode media type is selected
-            if (isGenresField && hasEpisode) {
+            const label = genresOptionsDiv.querySelector('label');
+            const select = genresOptionsDiv.querySelector('.rule-genres-select');
+            if (label && select && select.options.length >= 2) {
+                if (hasEpisode && hasAudio) {
+                    label.textContent = 'Include parent series/album genres:';
+                    select.options[0].textContent = 'No - Only check item genres';
+                    select.options[1].textContent = 'Yes - Also check genres from parent series/albums';
+                } else if (hasAudio) {
+                    label.textContent = 'Include parent album genres:';
+                    select.options[0].textContent = 'No - Only check track genres';
+                    select.options[1].textContent = 'Yes - Also check genres from parent album';
+                } else {
+                    label.textContent = 'Include parent series genres:';
+                    select.options[0].textContent = 'No - Only check episode genres';
+                    select.options[1].textContent = 'Yes - Also check genres from parent series';
+                }
+            }
+
+            // Show only if Genres field is selected AND Episode or Audio media type is selected
+            if (isGenresField && (hasEpisode || hasAudio)) {
                 genresOptionsDiv.style.display = 'block';
             } else {
                 // Hide but preserve user's selection - don't reset value
@@ -2527,6 +2547,7 @@
         const expressionSets = [];
         const selectedMediaTypes = SmartLists.getSelectedMediaTypes(page);
         const hasEpisode = selectedMediaTypes.indexOf('Episode') !== -1;
+        const hasAudio = selectedMediaTypes.indexOf('Audio') !== -1;
         const hasAudioCapable = selectedMediaTypes.some(function (type) {
             return SmartLists.AUDIO_CAPABLE_TYPES.indexOf(type) !== -1;
         });
@@ -2661,13 +2682,16 @@
                         // If false (default), don't include the parameter to save space
                     }
 
-                    // Handle Genres-specific options (only if Episode is selected)
+                    // Handle Genres-specific options (only if Episode or Audio is selected)
                     const genresSelect = rule.querySelector('.rule-genres-select');
-                    if (genresSelect && memberName === 'Genres' && hasEpisode) {
+                    if (genresSelect && memberName === 'Genres' && (hasEpisode || hasAudio)) {
                         // Convert string to boolean and only include if it's explicitly true
-                        const includeParentSeriesGenres = genresSelect.value === 'true';
-                        if (includeParentSeriesGenres) {
+                        const includeParentGenres = genresSelect.value === 'true';
+                        if (includeParentGenres && hasEpisode) {
                             expression.IncludeParentSeriesGenres = true;
+                        }
+                        if (includeParentGenres && hasAudio) {
+                            expression.IncludeParentAlbumGenres = true;
                         }
                         // If false (default), don't include the parameter to save space
                     }
@@ -2842,7 +2866,7 @@
             if (expression.MemberName === 'Genres') {
                 const genresSelect = ruleRow.querySelector('.rule-genres-select');
                 if (genresSelect) {
-                    const includeValue = expression.IncludeParentSeriesGenres === true ? 'true' : 'false';
+                    const includeValue = (expression.IncludeParentSeriesGenres === true || expression.IncludeParentAlbumGenres === true) ? 'true' : 'false';
                     genresSelect.value = includeValue;
                 }
             }
@@ -2873,4 +2897,3 @@
     };
 
 })(window.SmartLists = window.SmartLists || {});
-

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
@@ -99,21 +99,32 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             if (r.MemberName == "Tags" && r.IncludeParentSeriesTags == true)
             {
                 logger?.LogDebug("SmartLists building Tags expression with parent series tags inclusion");
-                return BuildCombinedStringEnumerableExpression(r, param, "Tags", "ParentSeriesTags", logger);
+                return BuildCombinedStringEnumerableExpression(r, param, logger, "Tags", "ParentSeriesTags");
             }
 
             // Special handling for Studios field with IncludeParentSeriesStudios option
             if (r.MemberName == "Studios" && r.IncludeParentSeriesStudios == true)
             {
                 logger?.LogDebug("SmartLists building Studios expression with parent series studios inclusion");
-                return BuildCombinedStringEnumerableExpression(r, param, "Studios", "ParentSeriesStudios", logger);
+                return BuildCombinedStringEnumerableExpression(r, param, logger, "Studios", "ParentSeriesStudios");
             }
 
-            // Special handling for Genres field with IncludeParentSeriesGenres option
-            if (r.MemberName == "Genres" && r.IncludeParentSeriesGenres == true)
+            // Special handling for Genres field with parent item options
+            if (r.MemberName == "Genres" && (r.IncludeParentSeriesGenres == true || r.IncludeParentAlbumGenres == true))
             {
-                logger?.LogDebug("SmartLists building Genres expression with parent series genres inclusion");
-                return BuildCombinedStringEnumerableExpression(r, param, "Genres", "ParentSeriesGenres", logger);
+                var fields = new List<string> { "Genres" };
+                if (r.IncludeParentSeriesGenres == true)
+                {
+                    fields.Add("ParentSeriesGenres");
+                }
+
+                if (r.IncludeParentAlbumGenres == true)
+                {
+                    fields.Add("ParentAlbumGenres");
+                }
+
+                logger?.LogDebug("SmartLists building Genres expression with parent genre inclusion: {Fields}", string.Join(", ", fields));
+                return BuildCombinedStringEnumerableExpression(r, param, logger, [.. fields]);
             }
 
             // Special handling for AudioLanguages field with OnlyDefaultAudioLanguage option
@@ -180,52 +191,43 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         }
 
         /// <summary>
-        /// Builds combined expressions for a field that also checks its parent series equivalent.
-        /// For positive operators (Contains, IsIn, MatchRegex): Uses OR logic - item passes if EITHER field OR parent series field match
-        /// For negative operators (NotContains, IsNotIn): Uses AND logic - item passes only if BOTH field AND parent series field don't match
+        /// Builds combined expressions for a field that also checks parent item equivalents.
+        /// For positive operators: Uses OR logic - item passes if any field matches.
+        /// For negative operators: Uses AND logic - item passes only if all fields don't match.
         /// </summary>
         /// <param name="r">The expression rule</param>
         /// <param name="param">The parameter expression</param>
-        /// <param name="fieldName">The name of the field (e.g., "Tags", "Studios", "Genres")</param>
-        /// <param name="parentSeriesFieldName">The name of the parent series field (e.g., "ParentSeriesTags", "ParentSeriesStudios", "ParentSeriesGenres")</param>
         /// <param name="logger">Logger instance</param>
-        private static System.Linq.Expressions.Expression BuildCombinedStringEnumerableExpression(Expression r, ParameterExpression param, string fieldName, string parentSeriesFieldName, ILogger? logger)
+        /// <param name="fieldNames">The fields to evaluate together (e.g., "Genres", "ParentSeriesGenres", "ParentAlbumGenres")</param>
+        private static System.Linq.Expressions.Expression BuildCombinedStringEnumerableExpression(Expression r, ParameterExpression param, ILogger? logger, params string[] fieldNames)
         {
-            var fieldProperty = System.Linq.Expressions.Expression.PropertyOrField(param, fieldName);
-            var parentSeriesFieldProperty = System.Linq.Expressions.Expression.PropertyOrField(param, parentSeriesFieldName);
-
-            // For Equal/NotEqual, check membership against the combined (deduplicated) list.
-            // "Equal" = any item in the merged list matches; "NotEqual" = no item matches.
-            if (r.Operator == "Equal" || r.Operator == "NotEqual")
+            if (fieldNames.Length == 0)
             {
-                logger?.LogDebug("SmartLists building combined {Field} {Operator} against merged list", fieldName, r.Operator);
-                var right = System.Linq.Expressions.Expression.Constant(r.TargetValue, typeof(string));
-                var method = typeof(Engine).GetMethod("AnyCombinedItemEquals", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-                if (method == null) throw new InvalidOperationException("Engine.AnyCombinedItemEquals method not found");
-                var equalsCall = System.Linq.Expressions.Expression.Call(method, fieldProperty, parentSeriesFieldProperty, right);
-                if (r.Operator == "Equal") return equalsCall;
-                return System.Linq.Expressions.Expression.Not(equalsCall);
+                throw new ArgumentException("At least one field name is required", nameof(fieldNames));
             }
 
-            var fieldExpression = BuildStringEnumerableExpression(r, fieldProperty, logger);
-            var parentSeriesFieldExpression = BuildStringEnumerableExpression(r, parentSeriesFieldProperty, logger);
+            var expressions = fieldNames
+                .Select(fieldName =>
+                {
+                    var fieldProperty = System.Linq.Expressions.Expression.PropertyOrField(param, fieldName);
+                    return BuildStringEnumerableExpression(r, fieldProperty, logger);
+                })
+                .ToList();
 
             // Determine if this is a negative operator
-            bool isNegativeOperator = r.Operator == "NotContains" || r.Operator == "IsNotIn";
+            bool isNegativeOperator = r.Operator == "NotEqual" || r.Operator == "NotContains" || r.Operator == "IsNotIn";
 
             if (isNegativeOperator)
             {
                 // For negative operators: Use AND logic
-                // Item passes only if BOTH field don't match AND parent series field don't match
-                logger?.LogDebug("SmartLists building combined {Field} expression with AND logic for negative operator {Operator}", fieldName, r.Operator);
-                return System.Linq.Expressions.Expression.AndAlso(fieldExpression, parentSeriesFieldExpression);
+                logger?.LogDebug("SmartLists building combined {Fields} expression with AND logic for negative operator {Operator}", string.Join(", ", fieldNames), r.Operator);
+                return expressions.Aggregate(System.Linq.Expressions.Expression.AndAlso);
             }
             else
             {
                 // For positive operators: Use OR logic
-                // Item passes if EITHER field match OR parent series field match
-                logger?.LogDebug("SmartLists building combined {Field} expression with OR logic for positive operator {Operator}", fieldName, r.Operator);
-                return System.Linq.Expressions.Expression.OrElse(fieldExpression, parentSeriesFieldExpression);
+                logger?.LogDebug("SmartLists building combined {Fields} expression with OR logic for positive operator {Operator}", string.Join(", ", fieldNames), r.Operator);
+                return expressions.Aggregate(System.Linq.Expressions.Expression.OrElse);
             }
         }
 

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
@@ -95,36 +95,10 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                 return BuildUserSpecificExpression<T>(userSpecificExpression, param, logger);
             }
 
-            // Special handling for Tags field with IncludeParentSeriesTags option
-            if (r.MemberName == "Tags" && r.IncludeParentSeriesTags == true)
+            var parentAwareExpression = BuildParentAwareListExpression(r, param, logger);
+            if (parentAwareExpression != null)
             {
-                logger?.LogDebug("SmartLists building Tags expression with parent series tags inclusion");
-                return BuildCombinedStringEnumerableExpression(r, param, logger, "Tags", "ParentSeriesTags");
-            }
-
-            // Special handling for Studios field with IncludeParentSeriesStudios option
-            if (r.MemberName == "Studios" && r.IncludeParentSeriesStudios == true)
-            {
-                logger?.LogDebug("SmartLists building Studios expression with parent series studios inclusion");
-                return BuildCombinedStringEnumerableExpression(r, param, logger, "Studios", "ParentSeriesStudios");
-            }
-
-            // Special handling for Genres field with parent item options
-            if (r.MemberName == "Genres" && (r.IncludeParentSeriesGenres == true || r.IncludeParentAlbumGenres == true))
-            {
-                var fields = new List<string> { "Genres" };
-                if (r.IncludeParentSeriesGenres == true)
-                {
-                    fields.Add("ParentSeriesGenres");
-                }
-
-                if (r.IncludeParentAlbumGenres == true)
-                {
-                    fields.Add("ParentAlbumGenres");
-                }
-
-                logger?.LogDebug("SmartLists building Genres expression with parent genre inclusion: {Fields}", string.Join(", ", fields));
-                return BuildCombinedStringEnumerableExpression(r, param, logger, [.. fields]);
+                return parentAwareExpression;
             }
 
             // Special handling for AudioLanguages field with OnlyDefaultAudioLanguage option
@@ -188,6 +162,40 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
 
             // Handle standard .NET operators for other types
             return BuildStandardOperatorExpression(r, left, tProp, logger);
+        }
+
+        private static System.Linq.Expressions.Expression? BuildParentAwareListExpression(ModelExpression r, ParameterExpression param, ILogger? logger)
+        {
+            if (r.MemberName == "Tags" && r.IncludeParentSeriesTags == true)
+            {
+                logger?.LogDebug("SmartLists building Tags expression with parent series tags inclusion");
+                return BuildCombinedStringEnumerableExpression(r, param, logger, "Tags", "ParentSeriesTags");
+            }
+
+            if (r.MemberName == "Studios" && r.IncludeParentSeriesStudios == true)
+            {
+                logger?.LogDebug("SmartLists building Studios expression with parent series studios inclusion");
+                return BuildCombinedStringEnumerableExpression(r, param, logger, "Studios", "ParentSeriesStudios");
+            }
+
+            if (r.MemberName == "Genres" && (r.IncludeParentSeriesGenres == true || r.IncludeParentAlbumGenres == true))
+            {
+                var fields = new List<string> { "Genres" };
+                if (r.IncludeParentSeriesGenres == true)
+                {
+                    fields.Add("ParentSeriesGenres");
+                }
+
+                if (r.IncludeParentAlbumGenres == true)
+                {
+                    fields.Add("ParentAlbumGenres");
+                }
+
+                logger?.LogDebug("SmartLists building Genres expression with parent genre inclusion: {Fields}", string.Join(", ", fields));
+                return BuildCombinedStringEnumerableExpression(r, param, logger, [.. fields]);
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Expression.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Expression.cs
@@ -40,6 +40,10 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? IncludeParentSeriesGenres { get; set; } = null;
 
+        // Genres-specific option for audio tracks - only serialize when meaningful
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? IncludeParentAlbumGenres { get; set; } = null;
+
         // AudioLanguages-specific option - only serialize when meaningful
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? OnlyDefaultAudioLanguage { get; set; } = null;

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
@@ -112,6 +112,12 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             set => RequiredGroups = value ? RequiredGroups | ExtractionGroup.ParentSeriesGenres : RequiredGroups & ~ExtractionGroup.ParentSeriesGenres;
         }
 
+        public bool ExtractParentAlbumGenres
+        {
+            get => RequiredGroups.HasFlag(ExtractionGroup.ParentAlbumGenres);
+            set => RequiredGroups = value ? RequiredGroups | ExtractionGroup.ParentAlbumGenres : RequiredGroups & ~ExtractionGroup.ParentAlbumGenres;
+        }
+
         public bool ExtractLastEpisodeAirDate
         {
             get => RequiredGroups.HasFlag(ExtractionGroup.LastEpisodeAirDate);
@@ -299,6 +305,8 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         private static readonly ConcurrentDictionary<Type, System.Reflection.PropertyInfo?> _parentIndexPropertyCache = new();
         private static readonly ConcurrentDictionary<Type, System.Reflection.PropertyInfo?> _indexPropertyCache = new();
         private static readonly ConcurrentDictionary<Type, System.Reflection.PropertyInfo?> _seriesIdPropertyCache = new();
+        private static readonly ConcurrentDictionary<Type, System.Reflection.PropertyInfo?> _albumIdPropertyCache = new();
+        private static readonly ConcurrentDictionary<Type, System.Reflection.PropertyInfo?> _parentIdPropertyCache = new();
 
 
         /// <summary>
@@ -1735,13 +1743,56 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             if (seriesIdProperty == null) return false;
 
             var seriesId = seriesIdProperty.GetValue(baseItem);
-            if (seriesId is Guid g) { seriesGuid = g; return true; }
-            if (seriesId != null && seriesId.GetType() == typeof(Guid?))
+            if (TryExtractGuid(seriesId, out seriesGuid)) return true;
+
+            return false;
+        }
+
+        /// <summary>
+        /// Helper method to safely extract an album ID as Guid from audio items.
+        /// Prefers AlbumId when available and falls back to ParentId.
+        /// </summary>
+        private static bool TryGetAudioAlbumGuid(BaseItem baseItem, out Guid albumGuid)
+        {
+            albumGuid = Guid.Empty;
+            if (baseItem is not Audio) return false;
+
+            var audioType = baseItem.GetType();
+
+            var albumIdProperty = _albumIdPropertyCache.GetOrAdd(audioType, t => t.GetProperty("AlbumId"));
+            if (albumIdProperty != null && TryExtractGuid(albumIdProperty.GetValue(baseItem), out albumGuid))
             {
-                var nullableGuid = (Guid?)seriesId;
-                if (nullableGuid.HasValue) { seriesGuid = nullableGuid.Value; return true; }
+                return true;
             }
-            if (seriesId is string s && Guid.TryParse(s, out var parsed)) { seriesGuid = parsed; return true; }
+
+            var parentIdProperty = _parentIdPropertyCache.GetOrAdd(audioType, t => t.GetProperty("ParentId"));
+            return parentIdProperty != null && TryExtractGuid(parentIdProperty.GetValue(baseItem), out albumGuid);
+        }
+
+        private static bool TryExtractGuid(object? value, out Guid guid)
+        {
+            guid = Guid.Empty;
+            if (value is Guid g && g != Guid.Empty)
+            {
+                guid = g;
+                return true;
+            }
+
+            if (value != null && value.GetType() == typeof(Guid?))
+            {
+                var nullableGuid = (Guid?)value;
+                if (nullableGuid.HasValue && nullableGuid.Value != Guid.Empty)
+                {
+                    guid = nullableGuid.Value;
+                    return true;
+                }
+            }
+
+            if (value is string s && Guid.TryParse(s, out var parsed) && parsed != Guid.Empty)
+            {
+                guid = parsed;
+                return true;
+            }
 
             return false;
         }
@@ -2081,6 +2132,62 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             catch (Exception ex)
             {
                 logger?.LogWarning(ex, "Failed to extract parent series genres for item '{ItemName}'", baseItem.Name);
+            }
+        }
+
+        /// <summary>
+        /// Extracts parent album genres for audio tracks with per-refresh caching.
+        /// This is an expensive operation as it requires a database lookup, so caching is critical for performance.
+        /// </summary>
+        private static void ExtractParentAlbumGenres(Operand operand, BaseItem baseItem, ILibraryManager libraryManager, RefreshQueueServiceRefreshCache cache, ILogger? logger)
+        {
+            operand.ParentAlbumGenres = [];
+            try
+            {
+                if (baseItem is not Audio)
+                {
+                    logger?.LogDebug("Item '{ItemName}' is not an audio track, parent album genres remain empty", baseItem.Name);
+                    return;
+                }
+
+                if (TryGetAudioAlbumGuid(baseItem, out var albumGuid))
+                {
+                    if (cache.AlbumGenresById.TryGetValue(albumGuid, out var cachedGenres))
+                    {
+                        operand.ParentAlbumGenres = cachedGenres;
+                        logger?.LogDebug("Using cached parent album genres for audio track '{TrackName}' (album ID: {AlbumId}): [{Genres}]",
+                            baseItem.Name, albumGuid, string.Join(", ", cachedGenres));
+                    }
+                    else
+                    {
+                        try
+                        {
+                            var parentAlbum = libraryManager.GetItemById(albumGuid);
+                            var albumGenres = parentAlbum?.Genres?.ToList() ?? [];
+
+                            cache.AlbumGenresById[albumGuid] = albumGenres;
+                            operand.ParentAlbumGenres = albumGenres;
+
+                            logger?.LogDebug("Extracted and cached parent album genres for audio track '{TrackName}' (album: '{AlbumName}'): [{Genres}]",
+                                baseItem.Name, parentAlbum?.Name ?? "Unknown", string.Join(", ", albumGenres));
+                        }
+                        catch (Exception ex)
+                        {
+                            logger?.LogDebug(ex, "Failed to get parent album genres for audio track '{TrackName}' with AlbumId {AlbumId}",
+                                baseItem.Name, albumGuid);
+
+                            cache.AlbumGenresById[albumGuid] = [];
+                        }
+                    }
+                }
+                else
+                {
+                    logger?.LogDebug("Could not extract valid AlbumId or ParentId from audio track '{TrackName}'", baseItem.Name);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex, "Failed to extract parent album genres for item '{ItemName}'", baseItem.Name);
             }
         }
 
@@ -2437,6 +2544,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             var extractParentSeriesTags = options.ExtractParentSeriesTags;
             var extractParentSeriesStudios = options.ExtractParentSeriesStudios;
             var extractParentSeriesGenres = options.ExtractParentSeriesGenres;
+            var extractParentAlbumGenres = options.ExtractParentAlbumGenres;
             var extractLastEpisodeAirDate = options.ExtractLastEpisodeAirDate;
 
             // Cheap extraction flags (for performance optimization)
@@ -2915,6 +3023,17 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             else
             {
                 operand.ParentSeriesGenres = [];
+            }
+
+            // Extract parent album genres for audio tracks - only when needed for performance
+            // This is an expensive operation (database lookup), so we use caching
+            if (extractParentAlbumGenres)
+            {
+                ExtractParentAlbumGenres(operand, baseItem, libraryManager, cache, logger);
+            }
+            else
+            {
+                operand.ParentAlbumGenres = [];
             }
 
             // AudioMetadata extraction - conditionally extracted for performance optimization

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
@@ -1797,6 +1797,43 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             return false;
         }
 
+        private delegate bool TryResolveParentKey(BaseItem baseItem, out Guid parentId);
+
+        private static List<string>? GetOrFetchParentValues(
+            BaseItem baseItem,
+            TryResolveParentKey keyResolver,
+            ConcurrentDictionary<Guid, List<string>> cache,
+            Func<Guid, (List<string> Values, string ParentName)> fetcher,
+            Action<Guid, List<string>> logCacheHit,
+            Action<Guid, string, List<string>> logFetched,
+            Action<Exception, Guid> logFailure)
+        {
+            if (!keyResolver(baseItem, out var parentId))
+            {
+                return null;
+            }
+
+            if (cache.TryGetValue(parentId, out var cachedValues))
+            {
+                logCacheHit(parentId, cachedValues);
+                return cachedValues;
+            }
+
+            try
+            {
+                var (values, parentName) = fetcher(parentId);
+                cache[parentId] = values;
+                logFetched(parentId, parentName, values);
+                return values;
+            }
+            catch (Exception ex)
+            {
+                logFailure(ex, parentId);
+                cache[parentId] = [];
+                return [];
+            }
+        }
+
         /// <summary>
         /// Extracts the series name for episodes and extras with per-refresh caching.
         /// For episodes: uses SeriesId property directly.
@@ -2150,35 +2187,34 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                     return;
                 }
 
-                if (TryGetAudioAlbumGuid(baseItem, out var albumGuid))
-                {
-                    if (cache.AlbumGenresById.TryGetValue(albumGuid, out var cachedGenres))
+                var albumGenres = GetOrFetchParentValues(
+                    baseItem,
+                    TryGetAudioAlbumGuid,
+                    cache.AlbumGenresById,
+                    albumGuid =>
                     {
-                        operand.ParentAlbumGenres = cachedGenres;
+                        var parentAlbum = libraryManager.GetItemById(albumGuid);
+                        return (parentAlbum?.Genres?.ToList() ?? [], parentAlbum?.Name ?? "Unknown");
+                    },
+                    (albumGuid, cachedGenres) =>
+                    {
                         logger?.LogDebug("Using cached parent album genres for audio track '{TrackName}' (album ID: {AlbumId}): [{Genres}]",
                             baseItem.Name, albumGuid, string.Join(", ", cachedGenres));
-                    }
-                    else
+                    },
+                    (albumGuid, albumName, fetchedGenres) =>
                     {
-                        try
-                        {
-                            var parentAlbum = libraryManager.GetItemById(albumGuid);
-                            var albumGenres = parentAlbum?.Genres?.ToList() ?? [];
+                        logger?.LogDebug("Extracted and cached parent album genres for audio track '{TrackName}' (album: '{AlbumName}'): [{Genres}]",
+                            baseItem.Name, albumName, string.Join(", ", fetchedGenres));
+                    },
+                    (ex, albumGuid) =>
+                    {
+                        logger?.LogDebug(ex, "Failed to get parent album genres for audio track '{TrackName}' with AlbumId {AlbumId}",
+                            baseItem.Name, albumGuid);
+                    });
 
-                            cache.AlbumGenresById[albumGuid] = albumGenres;
-                            operand.ParentAlbumGenres = albumGenres;
-
-                            logger?.LogDebug("Extracted and cached parent album genres for audio track '{TrackName}' (album: '{AlbumName}'): [{Genres}]",
-                                baseItem.Name, parentAlbum?.Name ?? "Unknown", string.Join(", ", albumGenres));
-                        }
-                        catch (Exception ex)
-                        {
-                            logger?.LogDebug(ex, "Failed to get parent album genres for audio track '{TrackName}' with AlbumId {AlbumId}",
-                                baseItem.Name, albumGuid);
-
-                            cache.AlbumGenresById[albumGuid] = [];
-                        }
-                    }
+                if (albumGenres != null)
+                {
+                    operand.ParentAlbumGenres = albumGenres;
                 }
                 else
                 {

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/FieldRegistry.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/FieldRegistry.cs
@@ -50,6 +50,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
     /// - ParentSeriesTags: SeriesTagsById
     /// - ParentSeriesStudios: SeriesStudiosById
     /// - ParentSeriesGenres: SeriesGenresById
+    /// - ParentAlbumGenres: AlbumGenresById
     /// - LastEpisodeAirDate: LastEpisodeAirDateById
     /// - LibraryInfo: LibraryNameById
     /// </summary>
@@ -74,6 +75,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         SimilarTo = 1 << 11,          // Fields: SimilarTo | Special handling in Engine
         LastEpisodeAirDate = 1 << 12, // Fields: LastEpisodeAirDate | Cache: LastEpisodeAirDateById
         ExternalLists = 1 << 20,      // Fields: ExternalList | Cache: ExternalListData, ItemExternalLists
+        ParentAlbumGenres = 1 << 21,  // Fields: Genres (with IncludeParentAlbumGenres) | Cache: AlbumGenresById
 
         // Cheap extraction groups (conditional but fast - don't trigger two-phase filtering)
         // Defined in FieldRegistry.CheapExtractionGroups

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Operand.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Operand.cs
@@ -28,6 +28,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         public List<string> ParentSeriesTags { get; set; } = [];
         public List<string> ParentSeriesStudios { get; set; } = [];
         public List<string> ParentSeriesGenres { get; set; } = [];
+        public List<string> ParentAlbumGenres { get; set; } = [];
         public double RuntimeMinutes { get; set; } = 0;
         public string OfficialRating { get; set; } = string.Empty;
         public List<string> AudioLanguages { get; set; } = [];

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -52,6 +52,20 @@ namespace Jellyfin.Plugin.SmartLists.Core
         private static DateTime _lastCleanupTime = DateTime.MinValue;
         private static readonly TimeSpan MIN_CLEANUP_INTERVAL = TimeSpan.FromMinutes(5); // Minimum time between cleanups
 
+        private static bool IsNonExpensiveExpression(Expression? expr)
+        {
+            return expr != null
+                && !FieldRegistry.IsExpensiveField(expr.MemberName)
+                && !IsParentAwareListExpression(expr);
+        }
+
+        private static bool IsParentAwareListExpression(Expression expr)
+        {
+            return (expr.MemberName == "Tags" && expr.IncludeParentSeriesTags == true) ||
+                   (expr.MemberName == "Studios" && expr.IncludeParentSeriesStudios == true) ||
+                   (expr.MemberName == "Genres" && (expr.IncludeParentSeriesGenres == true || expr.IncludeParentAlbumGenres == true));
+        }
+
         public SmartList(SmartPlaylistDto dto)
         {
             ArgumentNullException.ThrowIfNull(dto);
@@ -955,11 +969,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                     {
                         hasNonExpensiveRules = ExpressionSets
                             .SelectMany(set => set?.Expressions ?? [])
-                            .Any(expr => expr != null
-                                && !FieldRegistry.IsExpensiveField(expr.MemberName)
-                                && !(expr.MemberName == "Tags" && expr.IncludeParentSeriesTags == true)
-                                && !(expr.MemberName == "Studios" && expr.IncludeParentSeriesStudios == true)
-                                && !(expr.MemberName == "Genres" && (expr.IncludeParentSeriesGenres == true || expr.IncludeParentAlbumGenres == true)));
+                            .Any(IsNonExpensiveExpression);
                     }
                 }
                 catch (Exception ex)
@@ -2331,11 +2341,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
 
                                     var compiledRule = compiledRules[setIndex][compiledIndex++];
 
-                                    // Check if this is an expensive field
-                                    bool isExpensive = FieldRegistry.IsExpensiveField(expr.MemberName) ||
-                                                      (expr.MemberName == "Tags" && expr.IncludeParentSeriesTags == true) ||
-                                                      (expr.MemberName == "Studios" && expr.IncludeParentSeriesStudios == true) ||
-                                                      (expr.MemberName == "Genres" && (expr.IncludeParentSeriesGenres == true || expr.IncludeParentAlbumGenres == true));
+                                    bool isExpensive = !IsNonExpensiveExpression(expr);
 
                                     if (isExpensive)
                                     {

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -471,6 +471,8 @@ namespace Jellyfin.Plugin.SmartLists.Core
                         hashBuilder.Append(':');
                         hashBuilder.Append(expr.IncludeParentSeriesGenres?.ToString() ?? "null");
                         hashBuilder.Append(':');
+                        hashBuilder.Append(expr.IncludeParentAlbumGenres?.ToString() ?? "null");
+                        hashBuilder.Append(':');
                         hashBuilder.Append(expr.IncludeCollectionOnly?.ToString() ?? "null");
                         hashBuilder.Append(':');
                         hashBuilder.Append(expr.IncludePlaylistOnly?.ToString() ?? "null");
@@ -957,7 +959,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                                 && !FieldRegistry.IsExpensiveField(expr.MemberName)
                                 && !(expr.MemberName == "Tags" && expr.IncludeParentSeriesTags == true)
                                 && !(expr.MemberName == "Studios" && expr.IncludeParentSeriesStudios == true)
-                                && !(expr.MemberName == "Genres" && expr.IncludeParentSeriesGenres == true));
+                                && !(expr.MemberName == "Genres" && (expr.IncludeParentSeriesGenres == true || expr.IncludeParentAlbumGenres == true)));
                     }
                 }
                 catch (Exception ex)
@@ -2333,7 +2335,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                                     bool isExpensive = FieldRegistry.IsExpensiveField(expr.MemberName) ||
                                                       (expr.MemberName == "Tags" && expr.IncludeParentSeriesTags == true) ||
                                                       (expr.MemberName == "Studios" && expr.IncludeParentSeriesStudios == true) ||
-                                                      (expr.MemberName == "Genres" && expr.IncludeParentSeriesGenres == true);
+                                                      (expr.MemberName == "Genres" && (expr.IncludeParentSeriesGenres == true || expr.IncludeParentAlbumGenres == true));
 
                                     if (isExpensive)
                                     {
@@ -3017,6 +3019,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
         public bool NeedsParentSeriesTags => RequiredGroups.HasFlag(ExtractionGroup.ParentSeriesTags);
         public bool NeedsParentSeriesStudios => RequiredGroups.HasFlag(ExtractionGroup.ParentSeriesStudios);
         public bool NeedsParentSeriesGenres => RequiredGroups.HasFlag(ExtractionGroup.ParentSeriesGenres);
+        public bool NeedsParentAlbumGenres => RequiredGroups.HasFlag(ExtractionGroup.ParentAlbumGenres);
         public bool NeedsSimilarTo => RequiredGroups.HasFlag(ExtractionGroup.SimilarTo);
         public bool NeedsLastEpisodeAirDate => RequiredGroups.HasFlag(ExtractionGroup.LastEpisodeAirDate);
         public bool NeedsExternalLists => RequiredGroups.HasFlag(ExtractionGroup.ExternalLists);
@@ -3063,6 +3066,8 @@ namespace Jellyfin.Plugin.SmartLists.Core
                     requirements.RequiredGroups |= ExtractionGroup.ParentSeriesStudios;
                 if (expr.MemberName == "Genres" && expr.IncludeParentSeriesGenres == true)
                     requirements.RequiredGroups |= ExtractionGroup.ParentSeriesGenres;
+                if (expr.MemberName == "Genres" && expr.IncludeParentAlbumGenres == true)
+                    requirements.RequiredGroups |= ExtractionGroup.ParentAlbumGenres;
 
                 // Collect SimilarTo expressions for reference item lookup
                 if (expr.MemberName == "SimilarTo")

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
@@ -738,6 +738,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
             public ConcurrentDictionary<Guid, List<string>> SeriesTagsById { get; } = new();
             public ConcurrentDictionary<Guid, List<string>> SeriesStudiosById { get; } = new();
             public ConcurrentDictionary<Guid, List<string>> SeriesGenresById { get; } = new();
+            public ConcurrentDictionary<Guid, List<string>> AlbumGenresById { get; } = new();
             public ConcurrentDictionary<Guid, CategorizedPeople> ItemPeople { get; } = new();
             
             // User-specific data cache - keyed by (ItemId, UserId) to support playlist user + additional users in rules

--- a/docs/content/user-guide/fields-and-operators.md
+++ b/docs/content/user-guide/fields-and-operators.md
@@ -186,6 +186,10 @@ Filter by cast and crew members. Select "People" in the field dropdown, then cho
 
 - **Include parent series [tags/studios/genres]** (default: No) - When enabled, episodes match if either the episode or its parent series has the specified value. Useful when series-level metadata is more complete.
 
+**Audio-specific option** for Genres:
+
+- **Include parent album genres** (default: No) - When enabled, audio tracks match if either the track or its parent album has the specified genre. Useful when album-level genre metadata is more complete than track-level metadata.
+
 #### Collection Name
 
 Filter items based on Jellyfin collection membership.


### PR DESCRIPTION
Closes https://github.com/jyourstone/jellyfin-smartlists-plugin/issues/388

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to filter audio tracks by their parent album genres in addition to track-level genres
  * Configuration interface now intelligently adjusts genre filtering options based on selected media types

* **Documentation**
  * Added documentation explaining the new "Include parent album genres" option for audio content filtering

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jyourstone/jellyfin-smartlists-plugin/pull/389?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->