### PR TITLE
Added support for season playback status

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Core/Orders/LastPlayedOrderBase.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Orders/LastPlayedOrderBase.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.SmartLists.Services.Shared;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using Microsoft.Extensions.Logging;
 
@@ -40,6 +42,13 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
                 {
                     try
                     {
+                        var aggregateLastPlayedDate = GetAggregateLastPlayedDate(item, user, userDataManager, refreshCache);
+                        if (aggregateLastPlayedDate.HasValue)
+                        {
+                            sortValueCache[item] = aggregateLastPlayedDate.Value;
+                            continue;
+                        }
+
                         object? userData = null;
                         
                         // Try to get user data from cache if available
@@ -83,6 +92,15 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
         {
             try
             {
+                if (userDataManager != null)
+                {
+                    var aggregateLastPlayedDate = GetAggregateLastPlayedDate(item, user, userDataManager, refreshCache);
+                    if (aggregateLastPlayedDate.HasValue)
+                    {
+                        return aggregateLastPlayedDate.Value;
+                    }
+                }
+
                 object? userData = null;
                 
                 // Try to get user data from cache if available
@@ -102,6 +120,61 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
                 logger?.LogError(ex, "Error getting last played date for item {ItemId} user {UserId}", item.Id, user.Id);
                 return DateTime.MinValue;
             }
+        }
+
+        /// <summary>
+        /// Gets aggregate LastPlayedDate for container items when their children are already cached.
+        /// </summary>
+        private static DateTime? GetAggregateLastPlayedDate(
+            BaseItem item,
+            User user,
+            IUserDataManager userDataManager,
+            RefreshQueueService.RefreshCache? refreshCache)
+        {
+            if (refreshCache == null)
+            {
+                return null;
+            }
+
+            BaseItem[]? children = item switch
+            {
+                Season => refreshCache.SeasonEpisodes.TryGetValue((item.Id, user.Id), out var seasonEpisodes) ? seasonEpisodes : null,
+                Series => refreshCache.SeriesEpisodes.TryGetValue((item.Id, user.Id), out var seriesEpisodes) ? seriesEpisodes : null,
+                MusicAlbum => refreshCache.AlbumTracks.TryGetValue((item.Id, user.Id), out var tracks) ? tracks : null,
+                _ => null
+            };
+
+            if (children == null || children.Length == 0)
+            {
+                return null;
+            }
+
+            DateTime maxLastPlayedDate = DateTime.MinValue;
+            foreach (var child in children)
+            {
+                UserItemData? childUserData = null;
+                var cacheKey = (child.Id, user.Id);
+                if (refreshCache.UserDataCache.TryGetValue(cacheKey, out var cachedUserData))
+                {
+                    childUserData = cachedUserData;
+                }
+                else
+                {
+                    childUserData = userDataManager.GetUserData(user, child);
+                    if (childUserData != null)
+                    {
+                        refreshCache.UserDataCache[cacheKey] = childUserData;
+                    }
+                }
+
+                var childLastPlayedDate = GetLastPlayedDateFromUserData(childUserData);
+                if (childLastPlayedDate > maxLastPlayedDate)
+                {
+                    maxLastPlayedDate = childLastPlayedDate;
+                }
+            }
+
+            return maxLastPlayedDate == DateTime.MinValue ? null : maxLastPlayedDate;
         }
 
         /// <summary>
@@ -145,4 +218,3 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
         }
     }
 }
-

--- a/Jellyfin.Plugin.SmartLists/Core/Orders/LastPlayedOrderBase.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Orders/LastPlayedOrderBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.SmartLists.Services.Shared;
+using Jellyfin.Plugin.SmartLists.Utilities;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Entities.TV;
@@ -52,9 +53,9 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
                         object? userData = null;
                         
                         // Try to get user data from cache if available
-                        if (refreshCache != null && refreshCache.UserDataCache.TryGetValue((item.Id, user.Id), out var cachedUserData))
+                        if (refreshCache != null)
                         {
-                            userData = cachedUserData;
+                            userData = UserDataCacheHelper.GetCachedUserData(user, item, refreshCache, userDataManager);
                         }
                         else
                         {
@@ -104,9 +105,9 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
                 object? userData = null;
                 
                 // Try to get user data from cache if available
-                if (refreshCache != null && refreshCache.UserDataCache.TryGetValue((item.Id, user.Id), out var cachedUserData))
+                if (refreshCache != null && userDataManager != null)
                 {
-                    userData = cachedUserData;
+                    userData = UserDataCacheHelper.GetCachedUserData(user, item, refreshCache, userDataManager);
                 }
                 else if (userDataManager != null)
                 {
@@ -152,21 +153,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
             DateTime maxLastPlayedDate = DateTime.MinValue;
             foreach (var child in children)
             {
-                UserItemData? childUserData = null;
-                var cacheKey = (child.Id, user.Id);
-                if (refreshCache.UserDataCache.TryGetValue(cacheKey, out var cachedUserData))
-                {
-                    childUserData = cachedUserData;
-                }
-                else
-                {
-                    childUserData = userDataManager.GetUserData(user, child);
-                    if (childUserData != null)
-                    {
-                        refreshCache.UserDataCache[cacheKey] = childUserData;
-                    }
-                }
-
+                var childUserData = UserDataCacheHelper.GetCachedUserData(user, child, refreshCache, userDataManager);
                 var childLastPlayedDate = GetLastPlayedDateFromUserData(childUserData);
                 if (childLastPlayedDate > maxLastPlayedDate)
                 {

--- a/Jellyfin.Plugin.SmartLists/Core/Orders/PlayCountOrder.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Orders/PlayCountOrder.cs
@@ -44,21 +44,12 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
             try
             {
                 // For aggregate items, calculate from child media when a prior filter populated the cache.
-                if (item is Season && userDataManager != null && refreshCache != null)
+                if (userDataManager != null && refreshCache != null)
                 {
-                    var key = (item.Id, user.Id);
-                    if (refreshCache.SeasonEpisodes.TryGetValue(key, out var episodes) && episodes.Length > 0)
+                    var children = TryGetAggregateChildren(item, user, refreshCache);
+                    if (children != null)
                     {
-                        return CalculateMinPlayCountFromTracks(episodes, user, userDataManager, refreshCache);
-                    }
-                }
-
-                if (item is MusicAlbum && userDataManager != null && refreshCache != null)
-                {
-                    var key = (item.Id, user.Id);
-                    if (refreshCache.AlbumTracks.TryGetValue(key, out var tracks) && tracks.Length > 0)
-                    {
-                        return CalculateMinPlayCountFromTracks(tracks, user, userDataManager, refreshCache);
+                        return CalculateMinPlayCountFromTracks(children, user, userDataManager, refreshCache);
                     }
                 }
 
@@ -92,6 +83,27 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
                 logger?.LogDebug(ex, "Error extracting PlayCount from userData for item {ItemName}", item.Name);
                 return 0;
             }
+        }
+
+        /// <summary>
+        /// Returns the cached child array for aggregate items (Season → episodes, MusicAlbum → tracks),
+        /// or null if the item is not an aggregate type or the cache has no entry for it.
+        /// </summary>
+        private static BaseItem[]? TryGetAggregateChildren(
+            BaseItem item,
+            User user,
+            RefreshQueueService.RefreshCache refreshCache)
+        {
+            var key = (item.Id, user.Id);
+            if (item is Season && refreshCache.SeasonEpisodes.TryGetValue(key, out var episodes) && episodes.Length > 0)
+            {
+                return episodes;
+            }
+            if (item is MusicAlbum && refreshCache.AlbumTracks.TryGetValue(key, out var tracks) && tracks.Length > 0)
+            {
+                return tracks;
+            }
+            return null;
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Core/Orders/PlayCountOrder.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Orders/PlayCountOrder.cs
@@ -6,6 +6,7 @@ using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.SmartLists.Services.Shared;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using Microsoft.Extensions.Logging;
 
@@ -28,7 +29,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
 
         /// <summary>
         /// Shared logic for extracting PlayCount from user data.
-        /// For MusicAlbum, calculates the minimum PlayCount across all child tracks.
+        /// For aggregate items, calculates the minimum PlayCount across all cached child media.
         /// </summary>
         public static int GetPlayCountFromUserData(
             BaseItem item,
@@ -41,7 +42,16 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
             ArgumentNullException.ThrowIfNull(user);
             try
             {
-                // For MusicAlbum, calculate from child tracks using cache
+                // For aggregate items, calculate from child media when a prior filter populated the cache.
+                if (item is Season && userDataManager != null && refreshCache != null)
+                {
+                    var key = (item.Id, user.Id);
+                    if (refreshCache.SeasonEpisodes.TryGetValue(key, out var episodes) && episodes.Length > 0)
+                    {
+                        return CalculateMinPlayCountFromTracks(episodes, user, userDataManager, refreshCache);
+                    }
+                }
+
                 if (item is MusicAlbum && userDataManager != null && refreshCache != null)
                 {
                     var key = (item.Id, user.Id);
@@ -143,4 +153,3 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
         }
     }
 }
-

--- a/Jellyfin.Plugin.SmartLists/Core/Orders/PlayCountOrder.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Orders/PlayCountOrder.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.SmartLists.Services.Shared;
+using Jellyfin.Plugin.SmartLists.Utilities;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Entities.TV;
@@ -64,9 +65,9 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
                 object? userData = null;
                 
                 // Try to get user data from cache if available
-                if (refreshCache != null && refreshCache.UserDataCache.TryGetValue((item.Id, user.Id), out var cachedUserData))
+                if (refreshCache != null && userDataManager != null)
                 {
-                    userData = cachedUserData;
+                    userData = UserDataCacheHelper.GetCachedUserData(user, item, refreshCache, userDataManager);
                 }
                 else if (userDataManager != null)
                 {
@@ -111,21 +112,8 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
             int minPlayCount = int.MaxValue;
             foreach (var track in tracks)
             {
-                int trackPlayCount = 0;
-                var cacheKey = (track.Id, user.Id);
-                if (refreshCache.UserDataCache.TryGetValue(cacheKey, out var trackUserData))
-                {
-                    trackPlayCount = trackUserData?.PlayCount ?? 0;
-                }
-                else
-                {
-                    var fetchedData = userDataManager.GetUserData(user, track);
-                    trackPlayCount = fetchedData?.PlayCount ?? 0;
-                    if (fetchedData != null)
-                    {
-                        refreshCache.UserDataCache[cacheKey] = fetchedData;
-                    }
-                }
+                var trackUserData = UserDataCacheHelper.GetCachedUserData(user, track, refreshCache, userDataManager);
+                var trackPlayCount = trackUserData?.PlayCount ?? 0;
 
                 if (trackPlayCount < minPlayCount)
                 {

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
@@ -449,18 +449,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                 // Use LINQ Count with cache retrieval to count watched episodes
                 int watchedCount = validEpisodes.Count(e =>
                 {
-                    // Use UserDataCache to avoid redundant DB lookups
-                    // Only cache non-null UserData to avoid polluting the cache
-                    var cacheKey = (e.Id, user.Id);
-                    if (!cache.UserDataCache.TryGetValue(cacheKey, out var userData))
-                    {
-                        userData = userDataManager.GetUserData(user, e);
-                        // Only add to cache if non-null
-                        if (userData != null)
-                        {
-                            cache.UserDataCache[cacheKey] = userData;
-                        }
-                    }
+                    var userData = GetCachedUserData(e, user, userDataManager, cache);
                     return userData != null && e.IsPlayed(user, userData);
                 });
                 int totalCount = validEpisodes.Count;
@@ -563,17 +552,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
 
                 foreach (var episode in validEpisodes)
                 {
-                    // Use UserDataCache to avoid redundant DB lookups
-                    var cacheKey = (episode.Id, user.Id);
-                    if (!cache.UserDataCache.TryGetValue(cacheKey, out var episodeUserData))
-                    {
-                        episodeUserData = userDataManager.GetUserData(user, episode);
-                        // Cache the result if non-null
-                        if (episodeUserData != null)
-                        {
-                            cache.UserDataCache[cacheKey] = episodeUserData;
-                        }
-                    }
+                    var episodeUserData = GetCachedUserData(episode, user, userDataManager, cache);
 
                     if (episodeUserData != null)
                     {
@@ -773,15 +752,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                 int playedCount = 0;
                 foreach (var track in tracks)
                 {
-                    var cacheKey = (track.Id, user.Id);
-                    if (!cache.UserDataCache.TryGetValue(cacheKey, out var trackUserData))
-                    {
-                        trackUserData = userDataManager.GetUserData(user, track);
-                        if (trackUserData != null)
-                        {
-                            cache.UserDataCache[cacheKey] = trackUserData;
-                        }
-                    }
+                    var trackUserData = GetCachedUserData(track, user, userDataManager, cache);
 
                     if (trackUserData != null && trackUserData.Played)
                     {
@@ -857,15 +828,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
 
                 foreach (var track in tracks)
                 {
-                    var cacheKey = (track.Id, user.Id);
-                    if (!cache.UserDataCache.TryGetValue(cacheKey, out var trackUserData))
-                    {
-                        trackUserData = userDataManager.GetUserData(user, track);
-                        if (trackUserData != null)
-                        {
-                            cache.UserDataCache[cacheKey] = trackUserData;
-                        }
-                    }
+                    var trackUserData = GetCachedUserData(track, user, userDataManager, cache);
 
                     if (trackUserData != null)
                     {
@@ -967,19 +930,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             IUserDataManager userDataManager,
             RefreshQueueServiceRefreshCache cache)
         {
-            var cacheKey = (item.Id, user.Id);
-            if (cache.UserDataCache.TryGetValue(cacheKey, out var userData))
-            {
-                return userData;
-            }
-
-            userData = userDataManager.GetUserData(user, item);
-            if (userData != null)
-            {
-                cache.UserDataCache[cacheKey] = userData;
-            }
-
-            return userData;
+            return UserDataCacheHelper.GetCachedUserData(user, item, cache, userDataManager);
         }
 
         /// <summary>
@@ -994,6 +945,24 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             operand.PlayCountByUser[userId] = playbackStatus == "Played" ? 1 : 0;
             operand.IsFavoriteByUser[userId] = false;
             operand.LastPlayedDateByUser[userId] = -1; // Never played,
+        }
+
+        /// <summary>
+        /// Populates normal fallback user data, then overlays derived aggregate values where available.
+        /// </summary>
+        private static void PopulateUserFallbacks(
+            Operand operand,
+            string normalizedUserId,
+            string playbackStatus,
+            BaseItem baseItem,
+            User user,
+            ILibraryManager libraryManager,
+            IUserDataManager? userDataManager,
+            RefreshQueueServiceRefreshCache cache,
+            ILogger? logger)
+        {
+            SetUserDataFallbacks(operand, normalizedUserId, playbackStatus);
+            PopulateAggregateUserDataFallbacks(operand, normalizedUserId, baseItem, user, libraryManager, userDataManager, cache, logger);
         }
 
         /// <summary>
@@ -2848,19 +2817,9 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             // Only extract user data if specifically requested or if NextUnwatched is needed (which depends on it)
             if (extractUserData || extractNextUnwatched)
             {
-                var userDataCacheKey = (baseItem.Id, user.Id);
-                if (cache.UserDataCache.TryGetValue(userDataCacheKey, out var cachedUserData))
+                if (userDataManager != null)
                 {
-                    userData = cachedUserData;
-                }
-                else if (userDataManager != null)
-                {
-                    userData = userDataManager.GetUserData(user, baseItem);
-                    // Cache the result
-                    if (userData != null)
-                    {
-                        cache.UserDataCache[userDataCacheKey] = userData;
-                    }
+                    userData = GetCachedUserData(baseItem, user, userDataManager, cache);
                 }
 
                 // Calculate playback status based on item type
@@ -2940,8 +2899,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                         // Fallback when userData is null - treat as never played for playlist user
                         // Normalize to "N" format (no dashes) to match UserPlaylists format
                         var normalizedUserId = user.Id.ToString("N");
-                        SetUserDataFallbacks(operand, normalizedUserId, playbackStatus);
-                        PopulateAggregateUserDataFallbacks(operand, normalizedUserId, baseItem, user, libraryManager, userDataManager, cache, logger);
+                        PopulateUserFallbacks(operand, normalizedUserId, playbackStatus, baseItem, user, libraryManager, userDataManager, cache, logger);
                     }
                     else
                     {
@@ -3006,22 +2964,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                                 var targetUser = GetUserById(userManager, userGuid);
                                 if (targetUser != null)
                                 {
-                                    // Get user data first for Jellyfin 10.11 compatibility - check cache first
-                                    MediaBrowser.Controller.Entities.UserItemData? targetUserData = null;
-                                    var targetUserDataCacheKey = (baseItem.Id, userGuid);
-                                    if (cache.UserDataCache.TryGetValue(targetUserDataCacheKey, out var cachedTargetUserData))
-                                    {
-                                        targetUserData = cachedTargetUserData;
-                                    }
-                                    else
-                                    {
-                                        targetUserData = userDataManager.GetUserData(targetUser, baseItem);
-                                        // Cache the result
-                                        if (targetUserData != null)
-                                        {
-                                            cache.UserDataCache[targetUserDataCacheKey] = targetUserData;
-                                        }
-                                    }
+                                    var targetUserData = GetCachedUserData(baseItem, targetUser, userDataManager, cache);
                                     // Calculate playback status for additional user
                                     string userPlaybackStatus = CalculatePlaybackStatusForUser(
                                         baseItem,
@@ -3039,8 +2982,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                                     else
                                     {
                                         // Fallback values when targetUserData is null
-                                        SetUserDataFallbacks(operand, normalizedUserId, userPlaybackStatus);
-                                        PopulateAggregateUserDataFallbacks(operand, normalizedUserId, baseItem, targetUser, libraryManager, userDataManager, cache, logger);
+                                        PopulateUserFallbacks(operand, normalizedUserId, userPlaybackStatus, baseItem, targetUser, libraryManager, userDataManager, cache, logger);
                                     }
                                 }
                                 else

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
@@ -402,6 +402,10 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             {
                 return CalculateSeriesPlaybackStatus(series, user, libraryManager, userDataManager, cache, logger);
             }
+            else if (baseItem is Season season && userDataManager != null)
+            {
+                return CalculateSeasonPlaybackStatus(season, user, libraryManager, userDataManager, cache, logger);
+            }
             else if (baseItem is MusicAlbum album && userDataManager != null)
             {
                 return CalculateAlbumPlaybackStatus(album, user, libraryManager, userDataManager, cache, logger);
@@ -605,6 +609,147 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         }
 
         /// <summary>
+        /// Calculates playback status for a Season based on child episode watch progress.
+        /// </summary>
+        private static string CalculateSeasonPlaybackStatus(
+            Season season,
+            User user,
+            ILibraryManager libraryManager,
+            IUserDataManager userDataManager,
+            RefreshQueueServiceRefreshCache cache,
+            ILogger? logger)
+        {
+            try
+            {
+                var episodes = GetCachedSeasonEpisodes(season.Id, user, libraryManager, cache, logger);
+
+                if (episodes.Length == 0)
+                {
+                    logger?.LogDebug("Season '{SeasonName}' has 0 episodes, treating as Unplayed", season.Name);
+                    return "Unplayed";
+                }
+
+                var playedCount = 0;
+                var hasPartialProgress = false;
+                foreach (var episode in episodes)
+                {
+                    var episodeUserData = GetCachedUserData(episode, user, userDataManager, cache);
+                    if (episodeUserData == null)
+                    {
+                        continue;
+                    }
+
+                    if (episode.IsPlayed(user, episodeUserData))
+                    {
+                        playedCount++;
+                    }
+                    else if (episodeUserData.PlaybackPositionTicks > 0)
+                    {
+                        hasPartialProgress = true;
+                    }
+                }
+
+                if (playedCount == episodes.Length)
+                {
+                    return "Played";
+                }
+
+                if (playedCount > 0 || hasPartialProgress)
+                {
+                    return "InProgress";
+                }
+
+                return "Unplayed";
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex, "Error calculating playback status for season '{SeasonName}'", season.Name);
+                return "Unplayed";
+            }
+        }
+
+        /// <summary>
+        /// Calculates play count for a Season as the minimum PlayCount across all child episodes.
+        /// </summary>
+        private static int CalculateSeasonPlayCount(
+            Season season,
+            User user,
+            ILibraryManager libraryManager,
+            IUserDataManager userDataManager,
+            RefreshQueueServiceRefreshCache cache,
+            ILogger? logger)
+        {
+            try
+            {
+                var episodes = GetCachedSeasonEpisodes(season.Id, user, libraryManager, cache, logger);
+                return PlayCountOrder.CalculateMinPlayCountFromTracks(episodes, user, userDataManager, cache);
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex, "Error calculating play count for season '{SeasonName}'", season.Name);
+                return 0;
+            }
+        }
+
+        /// <summary>
+        /// Calculates the most recent LastPlayedDate for a Season based on child episode play dates.
+        /// </summary>
+        private static DateTime? CalculateSeasonLastPlayedDate(
+            Season season,
+            User user,
+            ILibraryManager libraryManager,
+            IUserDataManager userDataManager,
+            RefreshQueueServiceRefreshCache cache,
+            ILogger? logger)
+        {
+            try
+            {
+                var episodes = GetCachedSeasonEpisodes(season.Id, user, libraryManager, cache, logger);
+
+                if (episodes.Length == 0)
+                {
+                    logger?.LogDebug("Season '{SeasonName}' has 0 episodes, returning null LastPlayedDate", season.Name);
+                    return null;
+                }
+
+                DateTime? maxLastPlayedDate = null;
+
+                foreach (var episode in episodes)
+                {
+                    var episodeUserData = GetCachedUserData(episode, user, userDataManager, cache);
+                    if (episodeUserData == null)
+                    {
+                        continue;
+                    }
+
+                    var userDataType = episodeUserData.GetType();
+                    var lastPlayedDateProp = userDataType.GetProperty("LastPlayedDate");
+                    if (lastPlayedDateProp == null)
+                    {
+                        continue;
+                    }
+
+                    var lastPlayedDateValue = lastPlayedDateProp.GetValue(episodeUserData);
+                    if (lastPlayedDateValue is DateTime dateTime && dateTime != DateTime.MinValue)
+                    {
+                        if (!maxLastPlayedDate.HasValue || dateTime > maxLastPlayedDate.Value)
+                        {
+                            maxLastPlayedDate = dateTime;
+                        }
+                    }
+                }
+
+                logger?.LogDebug("Season '{SeasonName}' calculated LastPlayedDate: {Date} (from {EpisodeCount} episodes)", season.Name, maxLastPlayedDate, episodes.Length);
+                return maxLastPlayedDate;
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex, "Error calculating LastPlayedDate for season '{SeasonName}'", season.Name);
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Calculates playback status for a MusicAlbum based on child audio track watch counts.
         /// </summary>
         private static string CalculateAlbumPlaybackStatus(
@@ -782,6 +927,62 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         }
 
         /// <summary>
+        /// Gets cached episodes for a Season, fetching from library manager on cache miss.
+        /// </summary>
+        private static BaseItem[] GetCachedSeasonEpisodes(
+            Guid seasonId,
+            User user,
+            ILibraryManager libraryManager,
+            RefreshQueueServiceRefreshCache cache,
+            ILogger? logger)
+        {
+            var key = (seasonId, user.Id);
+            if (cache.SeasonEpisodes.TryGetValue(key, out var cachedEpisodes))
+            {
+                return cachedEpisodes;
+            }
+
+            var episodes = libraryManager.GetItemList(new InternalItemsQuery
+            {
+                ParentId = seasonId,
+                IncludeItemTypes = [BaseItemKind.Episode],
+                Recursive = true,
+                IsVirtualItem = false,
+                User = user
+            }).ToArray();
+
+            var seasonName = libraryManager.GetItemById(seasonId)?.Name ?? "Unknown";
+            logger?.LogDebug("Fetched {EpisodeCount} episodes for season '{SeasonName}' ({SeasonId})", episodes.Length, seasonName, seasonId);
+
+            cache.SeasonEpisodes[key] = episodes;
+            return episodes;
+        }
+
+        /// <summary>
+        /// Gets user data for an item and writes successful lookups to the per-refresh cache.
+        /// </summary>
+        private static UserItemData? GetCachedUserData(
+            BaseItem item,
+            User user,
+            IUserDataManager userDataManager,
+            RefreshQueueServiceRefreshCache cache)
+        {
+            var cacheKey = (item.Id, user.Id);
+            if (cache.UserDataCache.TryGetValue(cacheKey, out var userData))
+            {
+                return userData;
+            }
+
+            userData = userDataManager.GetUserData(user, item);
+            if (userData != null)
+            {
+                cache.UserDataCache[cacheKey] = userData;
+            }
+
+            return userData;
+        }
+
+        /// <summary>
         /// Sets fallback values for user-specific data when userData is unavailable or invalid.
         /// </summary>
         /// <param name="operand">The operand to populate</param>
@@ -793,6 +994,32 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             operand.PlayCountByUser[userId] = playbackStatus == "Played" ? 1 : 0;
             operand.IsFavoriteByUser[userId] = false;
             operand.LastPlayedDateByUser[userId] = -1; // Never played,
+        }
+
+        /// <summary>
+        /// Populates derived user data for aggregate items when Jellyfin has no direct UserItemData row.
+        /// </summary>
+        private static void PopulateAggregateUserDataFallbacks(
+            Operand operand,
+            string userId,
+            BaseItem baseItem,
+            User user,
+            ILibraryManager libraryManager,
+            IUserDataManager? userDataManager,
+            RefreshQueueServiceRefreshCache cache,
+            ILogger? logger)
+        {
+            if (userDataManager == null)
+            {
+                return;
+            }
+
+            if (baseItem is Season season)
+            {
+                operand.PlayCountByUser[userId] = CalculateSeasonPlayCount(season, user, libraryManager, userDataManager, cache, logger);
+                var lastPlayedDate = CalculateSeasonLastPlayedDate(season, user, libraryManager, userDataManager, cache, logger);
+                operand.LastPlayedDateByUser[userId] = lastPlayedDate.HasValue ? SafeToUnixTimeSeconds(lastPlayedDate.Value) : -1;
+            }
         }
 
         /// <summary>
@@ -1049,8 +1276,12 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             // Use reflection to safely extract properties from userData
             var userDataType = userData.GetType();
 
-            // Extract PlayCount - for MusicAlbum, calculate from child tracks
-            if (baseItem is MusicAlbum albumForPlayCount && userDataManager != null)
+            // Extract PlayCount - for aggregate items, calculate from child media.
+            if (baseItem is Season seasonForPlayCount && userDataManager != null)
+            {
+                operand.PlayCountByUser[userId] = CalculateSeasonPlayCount(seasonForPlayCount, user, libraryManager, userDataManager, cache, logger);
+            }
+            else if (baseItem is MusicAlbum albumForPlayCount && userDataManager != null)
             {
                 operand.PlayCountByUser[userId] = CalculateAlbumPlayCount(albumForPlayCount, user, libraryManager, userDataManager, cache, logger);
             }
@@ -1107,7 +1338,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             }
 
             // Extract LastPlayedDate - handle both nullable and non-nullable DateTime
-            // For Series, calculate from episodes; for other types, use direct extraction
+            // For aggregate items, calculate from child media; for leaf items, use direct extraction.
             if (baseItem is Series series && userDataManager != null)
             {
                 // Calculate LastPlayedDate from episodes for Series
@@ -1122,6 +1353,21 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                 {
                     logger?.LogDebug("Series '{SeriesName}' has no LastPlayedDate (no episodes watched)", series.Name);
                     operand.LastPlayedDateByUser[userId] = -1; // Never played - no episodes watched
+                }
+            }
+            else if (baseItem is Season seasonForDate && userDataManager != null)
+            {
+                var seasonLastPlayedDate = CalculateSeasonLastPlayedDate(seasonForDate, user, libraryManager, userDataManager, cache, logger);
+                if (seasonLastPlayedDate.HasValue)
+                {
+                    var unixTimestamp = SafeToUnixTimeSeconds(seasonLastPlayedDate.Value);
+                    logger?.LogDebug("Season '{SeasonName}' LastPlayedDate set to {Date} (Unix: {Unix})", seasonForDate.Name, seasonLastPlayedDate.Value, unixTimestamp);
+                    operand.LastPlayedDateByUser[userId] = unixTimestamp;
+                }
+                else
+                {
+                    logger?.LogDebug("Season '{SeasonName}' has no LastPlayedDate (no episodes watched)", seasonForDate.Name);
+                    operand.LastPlayedDateByUser[userId] = -1;
                 }
             }
             else
@@ -2693,7 +2939,9 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                     {
                         // Fallback when userData is null - treat as never played for playlist user
                         // Normalize to "N" format (no dashes) to match UserPlaylists format
-                        SetUserDataFallbacks(operand, user.Id.ToString("N"), playbackStatus);
+                        var normalizedUserId = user.Id.ToString("N");
+                        SetUserDataFallbacks(operand, normalizedUserId, playbackStatus);
+                        PopulateAggregateUserDataFallbacks(operand, normalizedUserId, baseItem, user, libraryManager, userDataManager, cache, logger);
                     }
                     else
                     {
@@ -2792,6 +3040,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                                     {
                                         // Fallback values when targetUserData is null
                                         SetUserDataFallbacks(operand, normalizedUserId, userPlaybackStatus);
+                                        PopulateAggregateUserDataFallbacks(operand, normalizedUserId, baseItem, targetUser, libraryManager, userDataManager, cache, logger);
                                     }
                                 }
                                 else

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
@@ -744,6 +744,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
             
             // User-specific data cache - keyed by (ItemId, UserId) to support playlist user + additional users in rules
             public ConcurrentDictionary<(Guid ItemId, Guid UserId), MediaBrowser.Controller.Entities.UserItemData> UserDataCache { get; } = new();
+            // Tracks (ItemId, UserId) pairs for which GetUserData returned null, to avoid repeated DB calls.
+            public ConcurrentDictionary<(Guid ItemId, Guid UserId), byte> UserDataNegativeCache { get; } = new();
             
             // Media streams cache - keyed by ItemId only (user-agnostic)
             public ConcurrentDictionary<Guid, IEnumerable<object>> MediaStreamsCache { get; } = new();

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
@@ -725,6 +725,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
         public sealed class RefreshCache
         {
             public ConcurrentDictionary<(Guid SeriesId, Guid UserId), BaseItem[]> SeriesEpisodes { get; } = new();
+            public ConcurrentDictionary<(Guid SeasonId, Guid UserId), BaseItem[]> SeasonEpisodes { get; } = new();
             public ConcurrentDictionary<(Guid AlbumId, Guid UserId), BaseItem[]> AlbumTracks { get; } = new();
             public ConcurrentDictionary<(Guid SeriesId, Guid UserId, bool IncludeUnwatchedSeries), (Guid? NextEpisodeId, int Season, int Episode)> NextUnwatched { get; } = new();
             public ConcurrentDictionary<Guid, List<string>> ItemCollections { get; } = new();

--- a/Jellyfin.Plugin.SmartLists/Utilities/UserDataCacheHelper.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/UserDataCacheHelper.cs
@@ -17,15 +17,28 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
             IUserDataManager userDataManager)
         {
             var cacheKey = (item.Id, user.Id);
+
+            // Positive cache hit
             if (refreshCache.UserDataCache.TryGetValue(cacheKey, out var userData))
             {
                 return userData;
+            }
+
+            // Negative cache hit — we already know this item has no user data row
+            if (refreshCache.UserDataNegativeCache.ContainsKey(cacheKey))
+            {
+                return null;
             }
 
             userData = userDataManager.GetUserData(user, item);
             if (userData != null)
             {
                 refreshCache.UserDataCache[cacheKey] = userData;
+            }
+            else
+            {
+                // Memoize the miss so subsequent calls skip the DB round-trip
+                refreshCache.UserDataNegativeCache[cacheKey] = 0;
             }
 
             return userData;

--- a/Jellyfin.Plugin.SmartLists/Utilities/UserDataCacheHelper.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/UserDataCacheHelper.cs
@@ -1,0 +1,34 @@
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SmartLists.Services.Shared;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+
+namespace Jellyfin.Plugin.SmartLists.Utilities
+{
+    /// <summary>
+    /// Shared helpers for cache-first user data lookups during smart list refreshes.
+    /// </summary>
+    public static class UserDataCacheHelper
+    {
+        public static UserItemData? GetCachedUserData(
+            User user,
+            BaseItem item,
+            RefreshQueueService.RefreshCache refreshCache,
+            IUserDataManager userDataManager)
+        {
+            var cacheKey = (item.Id, user.Id);
+            if (refreshCache.UserDataCache.TryGetValue(cacheKey, out var userData))
+            {
+                return userData;
+            }
+
+            userData = userDataManager.GetUserData(user, item);
+            if (userData != null)
+            {
+                refreshCache.UserDataCache[cacheKey] = userData;
+            }
+
+            return userData;
+        }
+    }
+}

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   jellyfin:
-    image: jellyfin/jellyfin:10.11.9
+    image: jellyfin/jellyfin:10.11.10
     container_name: jellyfin
     user: 1000:1000
     environment:


### PR DESCRIPTION
Closes https://github.com/jyourstone/jellyfin-smartlists-plugin/issues/400

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Seasons are treated as aggregate containers: playback status, last-played date, and play count are now derived from episode data.
  * Per-refresh caching for season episodes and cached user-data retrieval to speed list refreshes.

* **Bug Fixes**
  * More consistent last-played and play-count computation for Season, Series, and MusicAlbum items; safer fallbacks when user data is missing.

* **Chores**
  * Updated base Jellyfin image to 10.11.10.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jyourstone/jellyfin-smartlists-plugin/pull/401?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->