### PR TITLE
Added "only parent" option for tags, studios, and genres rules

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -1481,14 +1481,30 @@
 
                         // Add Tags configuration info
                         let tagsInfo = '';
-                        if (rule.MemberName === 'Tags' && rule.IncludeParentSeriesTags === true) {
-                            tagsInfo = ' (including parent series tags)';
+                        if (rule.MemberName === 'Tags') {
+                            if (rule.OnlyParentTags === true) {
+                                tagsInfo = ' (only parent series/album tags)';
+                            } else if (rule.IncludeParentSeriesTags === true && rule.IncludeParentAlbumTags === true) {
+                                tagsInfo = ' (including parent series/album tags)';
+                            } else if (rule.IncludeParentAlbumTags === true) {
+                                tagsInfo = ' (including parent album tags)';
+                            } else if (rule.IncludeParentSeriesTags === true) {
+                                tagsInfo = ' (including parent series tags)';
+                            }
                         }
 
                         // Add Studios configuration info
                         let studiosInfo = '';
-                        if (rule.MemberName === 'Studios' && rule.IncludeParentSeriesStudios === true) {
-                            studiosInfo = ' (including parent series studios)';
+                        if (rule.MemberName === 'Studios') {
+                            if (rule.OnlyParentStudios === true) {
+                                studiosInfo = ' (only parent series/album studios)';
+                            } else if (rule.IncludeParentSeriesStudios === true && rule.IncludeParentAlbumStudios === true) {
+                                studiosInfo = ' (including parent series/album studios)';
+                            } else if (rule.IncludeParentAlbumStudios === true) {
+                                studiosInfo = ' (including parent album studios)';
+                            } else if (rule.IncludeParentSeriesStudios === true) {
+                                studiosInfo = ' (including parent series studios)';
+                            }
                         }
 
                         // Add Genres configuration info
@@ -1496,7 +1512,9 @@
                         if (rule.MemberName === 'Genres') {
                             const includesParentSeriesGenres = rule.IncludeParentSeriesGenres === true;
                             const includesParentAlbumGenres = rule.IncludeParentAlbumGenres === true;
-                            if (includesParentSeriesGenres && includesParentAlbumGenres) {
+                            if (rule.OnlyParentGenres === true) {
+                                genresInfo = ' (only parent series/album genres)';
+                            } else if (includesParentSeriesGenres && includesParentAlbumGenres) {
                                 genresInfo = ' (including parent series/album genres)';
                             } else if (includesParentAlbumGenres) {
                                 genresInfo = ' (including parent album genres)';

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-rules.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-rules.js
@@ -1529,15 +1529,26 @@
                 expression.IncludePlaylistOnly = true;
             }
         }
-        if (fieldValue === 'Tags' && tagsValue === 'true') {
-            expression.IncludeParentSeriesTags = true;
+        if (fieldValue === 'Tags') {
+            if (tagsValue === 'only') {
+                expression.OnlyParentTags = true;
+            } else if (tagsValue === 'true') {
+                expression.IncludeParentSeriesTags = true;
+            }
         }
-        if (fieldValue === 'Studios' && studiosValue === 'true') {
-            expression.IncludeParentSeriesStudios = true;
+        if (fieldValue === 'Studios') {
+            if (studiosValue === 'only') {
+                expression.OnlyParentStudios = true;
+            } else if (studiosValue === 'true') {
+                expression.IncludeParentSeriesStudios = true;
+            }
         }
-        if (fieldValue === 'Genres' && genresValue === 'true') {
-            expression.IncludeParentSeriesGenres = true;
-            expression.IncludeParentAlbumGenres = true;
+        if (fieldValue === 'Genres') {
+            if (genresValue === 'only') {
+                expression.OnlyParentGenres = true;
+            } else if (genresValue === 'true') {
+                expression.IncludeParentSeriesGenres = true;
+            }
         }
         if (fieldValue === 'AudioLanguages' && audioLanguagesValue === 'true') {
             expression.OnlyDefaultAudioLanguage = true;
@@ -2356,19 +2367,22 @@
 
             const label = genresOptionsDiv.querySelector('label');
             const select = genresOptionsDiv.querySelector('.rule-genres-select');
-            if (label && select && select.options.length >= 2) {
+            if (label && select && select.options.length >= 3) {
                 if (hasEpisode && hasAudio) {
                     label.textContent = 'Include parent series/album genres:';
                     select.options[0].textContent = 'No - Only check item genres';
-                    select.options[1].textContent = 'Yes - Also check genres from parent series/albums';
+                    select.options[1].textContent = 'Yes - Also check genres from parent series/album';
+                    select.options[2].textContent = 'Yes - Only check genres from parent series/album';
                 } else if (hasAudio) {
                     label.textContent = 'Include parent album genres:';
                     select.options[0].textContent = 'No - Only check track genres';
                     select.options[1].textContent = 'Yes - Also check genres from parent album';
+                    select.options[2].textContent = 'Yes - Only check genres from parent album';
                 } else {
                     label.textContent = 'Include parent series genres:';
                     select.options[0].textContent = 'No - Only check episode genres';
                     select.options[1].textContent = 'Yes - Also check genres from parent series';
+                    select.options[2].textContent = 'Yes - Only check genres from parent series';
                 }
             }
 
@@ -2713,6 +2727,8 @@
                         const tagsSelectValue = tagsSelect.value;
                         if (tagsSelectValue === 'only') {
                             expression.OnlyParentTags = true;
+                            if (hasEpisode) expression.IncludeParentSeriesTags = true;
+                            if (hasAudio) expression.IncludeParentAlbumTags = true;
                         } else if (tagsSelectValue === 'true') {
                             if (hasEpisode) expression.IncludeParentSeriesTags = true;
                             if (hasAudio) expression.IncludeParentAlbumTags = true;
@@ -2726,6 +2742,8 @@
                         const studiosSelectValue = studiosSelect.value;
                         if (studiosSelectValue === 'only') {
                             expression.OnlyParentStudios = true;
+                            if (hasEpisode) expression.IncludeParentSeriesStudios = true;
+                            if (hasAudio) expression.IncludeParentAlbumStudios = true;
                         } else if (studiosSelectValue === 'true') {
                             if (hasEpisode) expression.IncludeParentSeriesStudios = true;
                             if (hasAudio) expression.IncludeParentAlbumStudios = true;
@@ -2739,6 +2757,8 @@
                         const genresSelectValue = genresSelect.value;
                         if (genresSelectValue === 'only') {
                             expression.OnlyParentGenres = true;
+                            if (hasEpisode) expression.IncludeParentSeriesGenres = true;
+                            if (hasAudio) expression.IncludeParentAlbumGenres = true;
                         } else if (genresSelectValue === 'true') {
                             if (hasEpisode) expression.IncludeParentSeriesGenres = true;
                             if (hasAudio) expression.IncludeParentAlbumGenres = true;

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-rules.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-rules.js
@@ -1127,20 +1127,22 @@
             '</div>' +
             '<div class="rule-tags-options" style="display: none; margin-bottom: 0.75em; padding: 0.5em; background: var(--jf-palette-background-paper); border: 1px solid var(--jf-palette-divider); border-radius: 4px;">' +
             '<label style="display: block; margin-bottom: 0.25em; font-size: 0.85em; opacity: 0.8; font-weight: 500;">' +
-            'Include parent series tags:' +
+            'Include parent tags:' +
             '</label>' +
             '<select is="emby-select" class="emby-select rule-tags-select" style="width: 100%;">' +
-            '<option value="false">No - Only check episode tags</option>' +
-            '<option value="true">Yes - Also check tags from parent series</option>' +
+            '<option value="false">No - Only check item tags</option>' +
+            '<option value="true">Yes - Also check tags from parent series/album</option>' +
+            '<option value="only">Yes - Only check tags from parent series/album</option>' +
             '</select>' +
             '</div>' +
             '<div class="rule-studios-options" style="display: none; margin-bottom: 0.75em; padding: 0.5em; background: var(--jf-palette-background-paper); border: 1px solid var(--jf-palette-divider); border-radius: 4px;">' +
             '<label style="display: block; margin-bottom: 0.25em; font-size: 0.85em; opacity: 0.8; font-weight: 500;">' +
-            'Include parent series studios:' +
+            'Include parent studios:' +
             '</label>' +
             '<select is="emby-select" class="emby-select rule-studios-select" style="width: 100%;">' +
-            '<option value="false">No - Only check episode studios</option>' +
-            '<option value="true">Yes - Also check studios from parent series</option>' +
+            '<option value="false">No - Only check item studios</option>' +
+            '<option value="true">Yes - Also check studios from parent series/album</option>' +
+            '<option value="only">Yes - Only check studios from parent series/album</option>' +
             '</select>' +
             '</div>' +
             '<div class="rule-genres-options" style="display: none; margin-bottom: 0.75em; padding: 0.5em; background: var(--jf-palette-background-paper); border: 1px solid var(--jf-palette-divider); border-radius: 4px;">' +
@@ -1150,6 +1152,7 @@
             '<select is="emby-select" class="emby-select rule-genres-select" style="width: 100%;">' +
             '<option value="false">No - Only check item genres</option>' +
             '<option value="true">Yes - Also check parent genres</option>' +
+            '<option value="only">Yes - Only check genres from parent series/album</option>' +
             '</select>' +
             '</div>' +
             '<div class="rule-audiolanguages-options" style="display: none; margin-bottom: 0.75em; padding: 0.5em; background: var(--jf-palette-background-paper); border: 1px solid var(--jf-palette-divider); border-radius: 4px;">' +
@@ -2254,12 +2257,34 @@
         const tagsOptionsDiv = ruleRow.querySelector('.rule-tags-options');
 
         if (tagsOptionsDiv) {
-            // Get selected media types to check if Episode is selected
+            // Get selected media types to check if Episode or Audio is selected
             const selectedMediaTypes = page ? SmartLists.getSelectedMediaTypes(page) : [];
             const hasEpisode = selectedMediaTypes.indexOf('Episode') !== -1;
+            const hasAudio = selectedMediaTypes.indexOf('Audio') !== -1;
 
-            // Show only if Tags field is selected AND Episode media type is selected
-            if (isTagsField && hasEpisode) {
+            const label = tagsOptionsDiv.querySelector('label');
+            const select = tagsOptionsDiv.querySelector('.rule-tags-select');
+            if (label && select && select.options.length >= 3) {
+                if (hasEpisode && hasAudio) {
+                    label.textContent = 'Include parent series/album tags:';
+                    select.options[0].textContent = 'No - Only check item tags';
+                    select.options[1].textContent = 'Yes - Also check tags from parent series/album';
+                    select.options[2].textContent = 'Yes - Only check tags from parent series/album';
+                } else if (hasAudio) {
+                    label.textContent = 'Include parent album tags:';
+                    select.options[0].textContent = 'No - Only check track tags';
+                    select.options[1].textContent = 'Yes - Also check tags from parent album';
+                    select.options[2].textContent = 'Yes - Only check tags from parent album';
+                } else {
+                    label.textContent = 'Include parent series tags:';
+                    select.options[0].textContent = 'No - Only check episode tags';
+                    select.options[1].textContent = 'Yes - Also check tags from parent series';
+                    select.options[2].textContent = 'Yes - Only check tags from parent series';
+                }
+            }
+
+            // Show only if Tags field is selected AND Episode or Audio media type is selected
+            if (isTagsField && (hasEpisode || hasAudio)) {
                 tagsOptionsDiv.style.display = 'block';
             } else {
                 // Hide but preserve user's selection - don't reset value
@@ -2278,12 +2303,34 @@
         const studiosOptionsDiv = ruleRow.querySelector('.rule-studios-options');
 
         if (studiosOptionsDiv) {
-            // Get selected media types to check if Episode is selected
+            // Get selected media types to check if Episode or Audio is selected
             const selectedMediaTypes = page ? SmartLists.getSelectedMediaTypes(page) : [];
             const hasEpisode = selectedMediaTypes.indexOf('Episode') !== -1;
+            const hasAudio = selectedMediaTypes.indexOf('Audio') !== -1;
 
-            // Show only if Studios field is selected AND Episode media type is selected
-            if (isStudiosField && hasEpisode) {
+            const label = studiosOptionsDiv.querySelector('label');
+            const select = studiosOptionsDiv.querySelector('.rule-studios-select');
+            if (label && select && select.options.length >= 3) {
+                if (hasEpisode && hasAudio) {
+                    label.textContent = 'Include parent series/album studios:';
+                    select.options[0].textContent = 'No - Only check item studios';
+                    select.options[1].textContent = 'Yes - Also check studios from parent series/album';
+                    select.options[2].textContent = 'Yes - Only check studios from parent series/album';
+                } else if (hasAudio) {
+                    label.textContent = 'Include parent album studios:';
+                    select.options[0].textContent = 'No - Only check track studios';
+                    select.options[1].textContent = 'Yes - Also check studios from parent album';
+                    select.options[2].textContent = 'Yes - Only check studios from parent album';
+                } else {
+                    label.textContent = 'Include parent series studios:';
+                    select.options[0].textContent = 'No - Only check episode studios';
+                    select.options[1].textContent = 'Yes - Also check studios from parent series';
+                    select.options[2].textContent = 'Yes - Only check studios from parent series';
+                }
+            }
+
+            // Show only if Studios field is selected AND Episode or Audio media type is selected
+            if (isStudiosField && (hasEpisode || hasAudio)) {
                 studiosOptionsDiv.style.display = 'block';
             } else {
                 // Hide but preserve user's selection - don't reset value
@@ -2660,40 +2707,43 @@
                         }
                     }
 
-                    // Handle Tags-specific options (only if Episode is selected)
+                    // Handle Tags-specific options (only if Episode or Audio is selected)
                     const tagsSelect = rule.querySelector('.rule-tags-select');
-                    if (tagsSelect && memberName === 'Tags' && hasEpisode) {
-                        // Convert string to boolean and only include if it's explicitly true
-                        const includeParentSeriesTags = tagsSelect.value === 'true';
-                        if (includeParentSeriesTags) {
-                            expression.IncludeParentSeriesTags = true;
+                    if (tagsSelect && memberName === 'Tags' && (hasEpisode || hasAudio)) {
+                        const tagsSelectValue = tagsSelect.value;
+                        if (tagsSelectValue === 'only') {
+                            expression.OnlyParentTags = true;
+                        } else if (tagsSelectValue === 'true') {
+                            if (hasEpisode) expression.IncludeParentSeriesTags = true;
+                            if (hasAudio) expression.IncludeParentAlbumTags = true;
                         }
-                        // If false (default), don't include the parameter to save space
+                        // If 'false' (default), don't include the parameter to save space
                     }
 
-                    // Handle Studios-specific options (only if Episode is selected)
+                    // Handle Studios-specific options (only if Episode or Audio is selected)
                     const studiosSelect = rule.querySelector('.rule-studios-select');
-                    if (studiosSelect && memberName === 'Studios' && hasEpisode) {
-                        // Convert string to boolean and only include if it's explicitly true
-                        const includeParentSeriesStudios = studiosSelect.value === 'true';
-                        if (includeParentSeriesStudios) {
-                            expression.IncludeParentSeriesStudios = true;
+                    if (studiosSelect && memberName === 'Studios' && (hasEpisode || hasAudio)) {
+                        const studiosSelectValue = studiosSelect.value;
+                        if (studiosSelectValue === 'only') {
+                            expression.OnlyParentStudios = true;
+                        } else if (studiosSelectValue === 'true') {
+                            if (hasEpisode) expression.IncludeParentSeriesStudios = true;
+                            if (hasAudio) expression.IncludeParentAlbumStudios = true;
                         }
-                        // If false (default), don't include the parameter to save space
+                        // If 'false' (default), don't include the parameter to save space
                     }
 
                     // Handle Genres-specific options (only if Episode or Audio is selected)
                     const genresSelect = rule.querySelector('.rule-genres-select');
                     if (genresSelect && memberName === 'Genres' && (hasEpisode || hasAudio)) {
-                        // Convert string to boolean and only include if it's explicitly true
-                        const includeParentGenres = genresSelect.value === 'true';
-                        if (includeParentGenres && hasEpisode) {
-                            expression.IncludeParentSeriesGenres = true;
+                        const genresSelectValue = genresSelect.value;
+                        if (genresSelectValue === 'only') {
+                            expression.OnlyParentGenres = true;
+                        } else if (genresSelectValue === 'true') {
+                            if (hasEpisode) expression.IncludeParentSeriesGenres = true;
+                            if (hasAudio) expression.IncludeParentAlbumGenres = true;
                         }
-                        if (includeParentGenres && hasAudio) {
-                            expression.IncludeParentAlbumGenres = true;
-                        }
-                        // If false (default), don't include the parameter to save space
+                        // If 'false' (default), don't include the parameter to save space
                     }
 
                     // Handle AudioLanguages-specific options (only if audio-capable media type is selected)
@@ -2852,21 +2902,36 @@
             if (expression.MemberName === 'Tags') {
                 const tagsSelect = ruleRow.querySelector('.rule-tags-select');
                 if (tagsSelect) {
-                    const includeValue = expression.IncludeParentSeriesTags === true ? 'true' : 'false';
+                    let includeValue = 'false';
+                    if (expression.OnlyParentTags === true) {
+                        includeValue = 'only';
+                    } else if (expression.IncludeParentSeriesTags === true || expression.IncludeParentAlbumTags === true) {
+                        includeValue = 'true';
+                    }
                     tagsSelect.value = includeValue;
                 }
             }
             if (expression.MemberName === 'Studios') {
                 const studiosSelect = ruleRow.querySelector('.rule-studios-select');
                 if (studiosSelect) {
-                    const includeValue = expression.IncludeParentSeriesStudios === true ? 'true' : 'false';
+                    let includeValue = 'false';
+                    if (expression.OnlyParentStudios === true) {
+                        includeValue = 'only';
+                    } else if (expression.IncludeParentSeriesStudios === true || expression.IncludeParentAlbumStudios === true) {
+                        includeValue = 'true';
+                    }
                     studiosSelect.value = includeValue;
                 }
             }
             if (expression.MemberName === 'Genres') {
                 const genresSelect = ruleRow.querySelector('.rule-genres-select');
                 if (genresSelect) {
-                    const includeValue = (expression.IncludeParentSeriesGenres === true || expression.IncludeParentAlbumGenres === true) ? 'true' : 'false';
+                    let includeValue = 'false';
+                    if (expression.OnlyParentGenres === true) {
+                        includeValue = 'only';
+                    } else if (expression.IncludeParentSeriesGenres === true || expression.IncludeParentAlbumGenres === true) {
+                        includeValue = 'true';
+                    }
                     genresSelect.value = includeValue;
                 }
             }

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
@@ -168,109 +168,81 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         {
             if (r.MemberName == "Tags")
             {
-                // "Only parent" mode: skip item's own tags, only check parent tags
-                if (r.OnlyParentTags == true)
-                {
-                    var fields = new List<string>();
-                    if (r.IncludeParentSeriesTags == true)
-                    {
-                        fields.Add("ParentSeriesTags");
-                    }
-                    if (r.IncludeParentAlbumTags == true)
-                    {
-                        fields.Add("ParentAlbumTags");
-                    }
-                    if (fields.Count > 0)
-                    {
-                        logger?.LogDebug("SmartLists building Tags expression with ONLY parent tags: {Fields}", string.Join(", ", fields));
-                        return BuildCombinedStringEnumerableExpression(r, param, logger, [.. fields]);
-                    }
-                }
-                else if (r.IncludeParentSeriesTags == true || r.IncludeParentAlbumTags == true)
-                {
-                    var fields = new List<string> { "Tags" };
-                    if (r.IncludeParentSeriesTags == true)
-                    {
-                        fields.Add("ParentSeriesTags");
-                    }
-                    if (r.IncludeParentAlbumTags == true)
-                    {
-                        fields.Add("ParentAlbumTags");
-                    }
-                    logger?.LogDebug("SmartLists building Tags expression with parent tags inclusion: {Fields}", string.Join(", ", fields));
-                    return BuildCombinedStringEnumerableExpression(r, param, logger, [.. fields]);
-                }
+                return BuildParentAwareFieldExpression(r, param, logger,
+                    baseField: "Tags",
+                    parentSeriesField: "ParentSeriesTags",
+                    parentAlbumField: "ParentAlbumTags",
+                    onlyParent: r.OnlyParentTags == true,
+                    includeParentSeries: r.IncludeParentSeriesTags == true,
+                    includeParentAlbum: r.IncludeParentAlbumTags == true);
             }
 
             if (r.MemberName == "Studios")
             {
-                // "Only parent" mode: skip item's own studios, only check parent studios
-                if (r.OnlyParentStudios == true)
-                {
-                    var fields = new List<string>();
-                    if (r.IncludeParentSeriesStudios == true)
-                    {
-                        fields.Add("ParentSeriesStudios");
-                    }
-                    if (r.IncludeParentAlbumStudios == true)
-                    {
-                        fields.Add("ParentAlbumStudios");
-                    }
-                    if (fields.Count > 0)
-                    {
-                        logger?.LogDebug("SmartLists building Studios expression with ONLY parent studios: {Fields}", string.Join(", ", fields));
-                        return BuildCombinedStringEnumerableExpression(r, param, logger, [.. fields]);
-                    }
-                }
-                else if (r.IncludeParentSeriesStudios == true || r.IncludeParentAlbumStudios == true)
-                {
-                    var fields = new List<string> { "Studios" };
-                    if (r.IncludeParentSeriesStudios == true)
-                    {
-                        fields.Add("ParentSeriesStudios");
-                    }
-                    if (r.IncludeParentAlbumStudios == true)
-                    {
-                        fields.Add("ParentAlbumStudios");
-                    }
-                    logger?.LogDebug("SmartLists building Studios expression with parent studios inclusion: {Fields}", string.Join(", ", fields));
-                    return BuildCombinedStringEnumerableExpression(r, param, logger, [.. fields]);
-                }
+                return BuildParentAwareFieldExpression(r, param, logger,
+                    baseField: "Studios",
+                    parentSeriesField: "ParentSeriesStudios",
+                    parentAlbumField: "ParentAlbumStudios",
+                    onlyParent: r.OnlyParentStudios == true,
+                    includeParentSeries: r.IncludeParentSeriesStudios == true,
+                    includeParentAlbum: r.IncludeParentAlbumStudios == true);
             }
 
             if (r.MemberName == "Genres")
             {
-                bool hasParentGenres = r.IncludeParentSeriesGenres == true || r.IncludeParentAlbumGenres == true;
+                return BuildParentAwareFieldExpression(r, param, logger,
+                    baseField: "Genres",
+                    parentSeriesField: "ParentSeriesGenres",
+                    parentAlbumField: "ParentAlbumGenres",
+                    onlyParent: r.OnlyParentGenres == true,
+                    includeParentSeries: r.IncludeParentSeriesGenres == true,
+                    includeParentAlbum: r.IncludeParentAlbumGenres == true);
+            }
 
-                // "Only parent" mode: skip item's own genres, only check parent genres
-                if (r.OnlyParentGenres == true && hasParentGenres)
+            return null;
+        }
+
+        /// <summary>
+        /// Shared helper for Tags/Studios/Genres parent-aware expression building.
+        /// When onlyParent is true but no parent source flags are set, returns an always-false
+        /// expression rather than null so BuildExpr cannot fall back to item-level fields.
+        /// </summary>
+        private static System.Linq.Expressions.Expression? BuildParentAwareFieldExpression(
+            ModelExpression r,
+            ParameterExpression param,
+            ILogger? logger,
+            string baseField,
+            string parentSeriesField,
+            string parentAlbumField,
+            bool onlyParent,
+            bool includeParentSeries,
+            bool includeParentAlbum)
+        {
+            if (onlyParent)
+            {
+                var fields = new List<string>();
+                if (includeParentSeries) fields.Add(parentSeriesField);
+                if (includeParentAlbum) fields.Add(parentAlbumField);
+
+                if (fields.Count > 0)
                 {
-                    var fields = new List<string>();
-                    if (r.IncludeParentSeriesGenres == true)
-                    {
-                        fields.Add("ParentSeriesGenres");
-                    }
-                    if (r.IncludeParentAlbumGenres == true)
-                    {
-                        fields.Add("ParentAlbumGenres");
-                    }
-                    logger?.LogDebug("SmartLists building Genres expression with ONLY parent genres: {Fields}", string.Join(", ", fields));
+                    logger?.LogDebug("SmartLists building {Field} expression with ONLY parent fields: {Fields}", baseField, string.Join(", ", fields));
                     return BuildCombinedStringEnumerableExpression(r, param, logger, [.. fields]);
                 }
-                else if (hasParentGenres)
-                {
-                    var fields = new List<string> { "Genres" };
-                    if (r.IncludeParentSeriesGenres == true)
-                    {
-                        fields.Add("ParentSeriesGenres");
-                    }
-                    if (r.IncludeParentAlbumGenres == true)
-                    {
-                        fields.Add("ParentAlbumGenres");
-                    }
-                    logger?.LogDebug("SmartLists building Genres expression with parent genre inclusion: {Fields}", string.Join(", ", fields));
-                    return BuildCombinedStringEnumerableExpression(r, param, logger, [.. fields]);
-                }
+
+                // OnlyParent is true but no parent source flags are set — return always-false
+                // so the engine does not fall back to item-level field matching.
+                logger?.LogDebug("SmartLists building {Field} expression: OnlyParent is true but no IncludeParent* flags set — returning always-false", baseField);
+                return System.Linq.Expressions.Expression.Constant(false);
+            }
+
+            if (includeParentSeries || includeParentAlbum)
+            {
+                var fields = new List<string> { baseField };
+                if (includeParentSeries) fields.Add(parentSeriesField);
+                if (includeParentAlbum) fields.Add(parentAlbumField);
+                logger?.LogDebug("SmartLists building {Field} expression with parent inclusion: {Fields}", baseField, string.Join(", ", fields));
+                return BuildCombinedStringEnumerableExpression(r, param, logger, [.. fields]);
             }
 
             return null;

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
@@ -166,33 +166,111 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
 
         private static System.Linq.Expressions.Expression? BuildParentAwareListExpression(ModelExpression r, ParameterExpression param, ILogger? logger)
         {
-            if (r.MemberName == "Tags" && r.IncludeParentSeriesTags == true)
+            if (r.MemberName == "Tags")
             {
-                logger?.LogDebug("SmartLists building Tags expression with parent series tags inclusion");
-                return BuildCombinedStringEnumerableExpression(r, param, logger, "Tags", "ParentSeriesTags");
+                // "Only parent" mode: skip item's own tags, only check parent tags
+                if (r.OnlyParentTags == true)
+                {
+                    var fields = new List<string>();
+                    if (r.IncludeParentSeriesTags == true)
+                    {
+                        fields.Add("ParentSeriesTags");
+                    }
+                    if (r.IncludeParentAlbumTags == true)
+                    {
+                        fields.Add("ParentAlbumTags");
+                    }
+                    if (fields.Count > 0)
+                    {
+                        logger?.LogDebug("SmartLists building Tags expression with ONLY parent tags: {Fields}", string.Join(", ", fields));
+                        return BuildCombinedStringEnumerableExpression(r, param, logger, [.. fields]);
+                    }
+                }
+                else if (r.IncludeParentSeriesTags == true || r.IncludeParentAlbumTags == true)
+                {
+                    var fields = new List<string> { "Tags" };
+                    if (r.IncludeParentSeriesTags == true)
+                    {
+                        fields.Add("ParentSeriesTags");
+                    }
+                    if (r.IncludeParentAlbumTags == true)
+                    {
+                        fields.Add("ParentAlbumTags");
+                    }
+                    logger?.LogDebug("SmartLists building Tags expression with parent tags inclusion: {Fields}", string.Join(", ", fields));
+                    return BuildCombinedStringEnumerableExpression(r, param, logger, [.. fields]);
+                }
             }
 
-            if (r.MemberName == "Studios" && r.IncludeParentSeriesStudios == true)
+            if (r.MemberName == "Studios")
             {
-                logger?.LogDebug("SmartLists building Studios expression with parent series studios inclusion");
-                return BuildCombinedStringEnumerableExpression(r, param, logger, "Studios", "ParentSeriesStudios");
+                // "Only parent" mode: skip item's own studios, only check parent studios
+                if (r.OnlyParentStudios == true)
+                {
+                    var fields = new List<string>();
+                    if (r.IncludeParentSeriesStudios == true)
+                    {
+                        fields.Add("ParentSeriesStudios");
+                    }
+                    if (r.IncludeParentAlbumStudios == true)
+                    {
+                        fields.Add("ParentAlbumStudios");
+                    }
+                    if (fields.Count > 0)
+                    {
+                        logger?.LogDebug("SmartLists building Studios expression with ONLY parent studios: {Fields}", string.Join(", ", fields));
+                        return BuildCombinedStringEnumerableExpression(r, param, logger, [.. fields]);
+                    }
+                }
+                else if (r.IncludeParentSeriesStudios == true || r.IncludeParentAlbumStudios == true)
+                {
+                    var fields = new List<string> { "Studios" };
+                    if (r.IncludeParentSeriesStudios == true)
+                    {
+                        fields.Add("ParentSeriesStudios");
+                    }
+                    if (r.IncludeParentAlbumStudios == true)
+                    {
+                        fields.Add("ParentAlbumStudios");
+                    }
+                    logger?.LogDebug("SmartLists building Studios expression with parent studios inclusion: {Fields}", string.Join(", ", fields));
+                    return BuildCombinedStringEnumerableExpression(r, param, logger, [.. fields]);
+                }
             }
 
-            if (r.MemberName == "Genres" && (r.IncludeParentSeriesGenres == true || r.IncludeParentAlbumGenres == true))
+            if (r.MemberName == "Genres")
             {
-                var fields = new List<string> { "Genres" };
-                if (r.IncludeParentSeriesGenres == true)
-                {
-                    fields.Add("ParentSeriesGenres");
-                }
+                bool hasParentGenres = r.IncludeParentSeriesGenres == true || r.IncludeParentAlbumGenres == true;
 
-                if (r.IncludeParentAlbumGenres == true)
+                // "Only parent" mode: skip item's own genres, only check parent genres
+                if (r.OnlyParentGenres == true && hasParentGenres)
                 {
-                    fields.Add("ParentAlbumGenres");
+                    var fields = new List<string>();
+                    if (r.IncludeParentSeriesGenres == true)
+                    {
+                        fields.Add("ParentSeriesGenres");
+                    }
+                    if (r.IncludeParentAlbumGenres == true)
+                    {
+                        fields.Add("ParentAlbumGenres");
+                    }
+                    logger?.LogDebug("SmartLists building Genres expression with ONLY parent genres: {Fields}", string.Join(", ", fields));
+                    return BuildCombinedStringEnumerableExpression(r, param, logger, [.. fields]);
                 }
-
-                logger?.LogDebug("SmartLists building Genres expression with parent genre inclusion: {Fields}", string.Join(", ", fields));
-                return BuildCombinedStringEnumerableExpression(r, param, logger, [.. fields]);
+                else if (hasParentGenres)
+                {
+                    var fields = new List<string> { "Genres" };
+                    if (r.IncludeParentSeriesGenres == true)
+                    {
+                        fields.Add("ParentSeriesGenres");
+                    }
+                    if (r.IncludeParentAlbumGenres == true)
+                    {
+                        fields.Add("ParentAlbumGenres");
+                    }
+                    logger?.LogDebug("SmartLists building Genres expression with parent genre inclusion: {Fields}", string.Join(", ", fields));
+                    return BuildCombinedStringEnumerableExpression(r, param, logger, [.. fields]);
+                }
             }
 
             return null;

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Expression.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Expression.cs
@@ -32,9 +32,25 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? IncludeParentSeriesTags { get; set; } = null;
 
+        // Tags-specific option for audio tracks - only serialize when meaningful
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? IncludeParentAlbumTags { get; set; } = null;
+
+        // Tags-specific option to only check parent tags (skip item's own tags) - only serialize when meaningful
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? OnlyParentTags { get; set; } = null;
+
         // Studios-specific option - only serialize when meaningful
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? IncludeParentSeriesStudios { get; set; } = null;
+
+        // Studios-specific option for audio tracks - only serialize when meaningful
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? IncludeParentAlbumStudios { get; set; } = null;
+
+        // Studios-specific option to only check parent studios (skip item's own studios) - only serialize when meaningful
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? OnlyParentStudios { get; set; } = null;
 
         // Genres-specific option - only serialize when meaningful
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -43,6 +59,10 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         // Genres-specific option for audio tracks - only serialize when meaningful
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? IncludeParentAlbumGenres { get; set; } = null;
+
+        // Genres-specific option to only check parent genres (skip item's own genres) - only serialize when meaningful
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? OnlyParentGenres { get; set; } = null;
 
         // AudioLanguages-specific option - only serialize when meaningful
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
@@ -118,6 +118,18 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             set => RequiredGroups = value ? RequiredGroups | ExtractionGroup.ParentAlbumGenres : RequiredGroups & ~ExtractionGroup.ParentAlbumGenres;
         }
 
+        public bool ExtractParentAlbumTags
+        {
+            get => RequiredGroups.HasFlag(ExtractionGroup.ParentAlbumTags);
+            set => RequiredGroups = value ? RequiredGroups | ExtractionGroup.ParentAlbumTags : RequiredGroups & ~ExtractionGroup.ParentAlbumTags;
+        }
+
+        public bool ExtractParentAlbumStudios
+        {
+            get => RequiredGroups.HasFlag(ExtractionGroup.ParentAlbumStudios);
+            set => RequiredGroups = value ? RequiredGroups | ExtractionGroup.ParentAlbumStudios : RequiredGroups & ~ExtractionGroup.ParentAlbumStudios;
+        }
+
         public bool ExtractLastEpisodeAirDate
         {
             get => RequiredGroups.HasFlag(ExtractionGroup.LastEpisodeAirDate);
@@ -2443,6 +2455,116 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         }
 
         /// <summary>
+        /// Extracts parent album tags for audio tracks with per-refresh caching.
+        /// This is an expensive operation as it requires a database lookup, so caching is critical for performance.
+        /// </summary>
+        private static void ExtractParentAlbumTags(Operand operand, BaseItem baseItem, ILibraryManager libraryManager, RefreshQueueServiceRefreshCache cache, ILogger? logger)
+        {
+            operand.ParentAlbumTags = [];
+            try
+            {
+                if (baseItem is not Audio)
+                {
+                    logger?.LogDebug("Item '{ItemName}' is not an audio track, parent album tags remain empty", baseItem.Name);
+                    return;
+                }
+
+                var albumTags = GetOrFetchParentValues(
+                    baseItem,
+                    TryGetAudioAlbumGuid,
+                    cache.AlbumTagsById,
+                    albumGuid =>
+                    {
+                        var parentAlbum = libraryManager.GetItemById(albumGuid);
+                        return (parentAlbum?.Tags?.ToList() ?? [], parentAlbum?.Name ?? "Unknown");
+                    },
+                    (albumGuid, cachedTags) =>
+                    {
+                        logger?.LogDebug("Using cached parent album tags for audio track '{TrackName}' (album ID: {AlbumId}): [{Tags}]",
+                            baseItem.Name, albumGuid, string.Join(", ", cachedTags));
+                    },
+                    (albumGuid, albumName, fetchedTags) =>
+                    {
+                        logger?.LogDebug("Extracted and cached parent album tags for audio track '{TrackName}' (album: '{AlbumName}'): [{Tags}]",
+                            baseItem.Name, albumName, string.Join(", ", fetchedTags));
+                    },
+                    (ex, albumGuid) =>
+                    {
+                        logger?.LogDebug(ex, "Failed to get parent album tags for audio track '{TrackName}' with AlbumId {AlbumId}",
+                            baseItem.Name, albumGuid);
+                    });
+
+                if (albumTags != null)
+                {
+                    operand.ParentAlbumTags = albumTags;
+                }
+                else
+                {
+                    logger?.LogDebug("Could not extract valid AlbumId or ParentId from audio track '{TrackName}'", baseItem.Name);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex, "Failed to extract parent album tags for item '{ItemName}'", baseItem.Name);
+            }
+        }
+
+        /// <summary>
+        /// Extracts parent album studios for audio tracks with per-refresh caching.
+        /// This is an expensive operation as it requires a database lookup, so caching is critical for performance.
+        /// </summary>
+        private static void ExtractParentAlbumStudios(Operand operand, BaseItem baseItem, ILibraryManager libraryManager, RefreshQueueServiceRefreshCache cache, ILogger? logger)
+        {
+            operand.ParentAlbumStudios = [];
+            try
+            {
+                if (baseItem is not Audio)
+                {
+                    logger?.LogDebug("Item '{ItemName}' is not an audio track, parent album studios remain empty", baseItem.Name);
+                    return;
+                }
+
+                var albumStudios = GetOrFetchParentValues(
+                    baseItem,
+                    TryGetAudioAlbumGuid,
+                    cache.AlbumStudiosById,
+                    albumGuid =>
+                    {
+                        var parentAlbum = libraryManager.GetItemById(albumGuid);
+                        return (parentAlbum?.Studios?.ToList() ?? [], parentAlbum?.Name ?? "Unknown");
+                    },
+                    (albumGuid, cachedStudios) =>
+                    {
+                        logger?.LogDebug("Using cached parent album studios for audio track '{TrackName}' (album ID: {AlbumId}): [{Studios}]",
+                            baseItem.Name, albumGuid, string.Join(", ", cachedStudios));
+                    },
+                    (albumGuid, albumName, fetchedStudios) =>
+                    {
+                        logger?.LogDebug("Extracted and cached parent album studios for audio track '{TrackName}' (album: '{AlbumName}'): [{Studios}]",
+                            baseItem.Name, albumName, string.Join(", ", fetchedStudios));
+                    },
+                    (ex, albumGuid) =>
+                    {
+                        logger?.LogDebug(ex, "Failed to get parent album studios for audio track '{TrackName}' with AlbumId {AlbumId}",
+                            baseItem.Name, albumGuid);
+                    });
+
+                if (albumStudios != null)
+                {
+                    operand.ParentAlbumStudios = albumStudios;
+                }
+                else
+                {
+                    logger?.LogDebug("Could not extract valid AlbumId or ParentId from audio track '{TrackName}'", baseItem.Name);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex, "Failed to extract parent album studios for item '{ItemName}'", baseItem.Name);
+            }
+        }
+
+        /// <summary>
         /// Extracts people (actors, directors, producers, etc.) associated with the item.
         /// </summary>
         private static void ExtractPeople(Operand operand, BaseItem baseItem, ILibraryManager libraryManager, RefreshQueueServiceRefreshCache cache, ILogger? logger)
@@ -3261,6 +3383,28 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             else
             {
                 operand.ParentAlbumGenres = [];
+            }
+
+            // Extract parent album tags for audio tracks - only when needed for performance
+            // This is an expensive operation (database lookup), so we use caching
+            if (options.ExtractParentAlbumTags)
+            {
+                ExtractParentAlbumTags(operand, baseItem, libraryManager, cache, logger);
+            }
+            else
+            {
+                operand.ParentAlbumTags = [];
+            }
+
+            // Extract parent album studios for audio tracks - only when needed for performance
+            // This is an expensive operation (database lookup), so we use caching
+            if (options.ExtractParentAlbumStudios)
+            {
+                ExtractParentAlbumStudios(operand, baseItem, libraryManager, cache, logger);
+            }
+            else
+            {
+                operand.ParentAlbumStudios = [];
             }
 
             // AudioMetadata extraction - conditionally extracted for performance optimization

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/FieldRegistry.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/FieldRegistry.cs
@@ -47,11 +47,13 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
     /// - Playlists: ItemPlaylists, PlaylistMembershipCache
     /// - NextUnwatched: NextUnwatched cache
     /// - SeriesName: SeriesNameById
-    /// - ParentSeriesTags: SeriesTagsById
-    /// - ParentSeriesStudios: SeriesStudiosById
-    /// - ParentSeriesGenres: SeriesGenresById
-    /// - ParentAlbumGenres: AlbumGenresById
-    /// - LastEpisodeAirDate: LastEpisodeAirDateById
+        /// - ParentSeriesTags: SeriesTagsById
+        /// - ParentSeriesStudios: SeriesStudiosById
+        /// - ParentSeriesGenres: SeriesGenresById
+        /// - ParentAlbumGenres: AlbumGenresById
+        /// - ParentAlbumTags: AlbumTagsById
+        /// - ParentAlbumStudios: AlbumStudiosById
+        /// - LastEpisodeAirDate: LastEpisodeAirDateById
     /// - LibraryInfo: LibraryNameById
     /// </summary>
     [Flags]
@@ -76,6 +78,8 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         LastEpisodeAirDate = 1 << 12, // Fields: LastEpisodeAirDate | Cache: LastEpisodeAirDateById
         ExternalLists = 1 << 20,      // Fields: ExternalList | Cache: ExternalListData, ItemExternalLists
         ParentAlbumGenres = 1 << 21,  // Fields: Genres (with IncludeParentAlbumGenres) | Cache: AlbumGenresById
+        ParentAlbumTags = 1 << 22,    // Fields: Tags (with IncludeParentAlbumTags) | Cache: AlbumTagsById
+        ParentAlbumStudios = 1 << 23, // Fields: Studios (with IncludeParentAlbumStudios) | Cache: AlbumStudiosById
 
         // Cheap extraction groups (conditional but fast - don't trigger two-phase filtering)
         // Defined in FieldRegistry.CheapExtractionGroups

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Operand.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Operand.cs
@@ -26,7 +26,9 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         public double ReleaseDate { get; set; } = 0;
         public List<string> Tags { get; set; } = [];
         public List<string> ParentSeriesTags { get; set; } = [];
+        public List<string> ParentAlbumTags { get; set; } = [];
         public List<string> ParentSeriesStudios { get; set; } = [];
+        public List<string> ParentAlbumStudios { get; set; } = [];
         public List<string> ParentSeriesGenres { get; set; } = [];
         public List<string> ParentAlbumGenres { get; set; } = [];
         public double RuntimeMinutes { get; set; } = 0;

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -481,11 +481,21 @@ namespace Jellyfin.Plugin.SmartLists.Core
                         hashBuilder.Append(':');
                         hashBuilder.Append(expr.IncludeParentSeriesTags?.ToString() ?? "null");
                         hashBuilder.Append(':');
+                        hashBuilder.Append(expr.IncludeParentAlbumTags?.ToString() ?? "null");
+                        hashBuilder.Append(':');
+                        hashBuilder.Append(expr.OnlyParentTags?.ToString() ?? "null");
+                        hashBuilder.Append(':');
                         hashBuilder.Append(expr.IncludeParentSeriesStudios?.ToString() ?? "null");
+                        hashBuilder.Append(':');
+                        hashBuilder.Append(expr.IncludeParentAlbumStudios?.ToString() ?? "null");
+                        hashBuilder.Append(':');
+                        hashBuilder.Append(expr.OnlyParentStudios?.ToString() ?? "null");
                         hashBuilder.Append(':');
                         hashBuilder.Append(expr.IncludeParentSeriesGenres?.ToString() ?? "null");
                         hashBuilder.Append(':');
                         hashBuilder.Append(expr.IncludeParentAlbumGenres?.ToString() ?? "null");
+                        hashBuilder.Append(':');
+                        hashBuilder.Append(expr.OnlyParentGenres?.ToString() ?? "null");
                         hashBuilder.Append(':');
                         hashBuilder.Append(expr.IncludeCollectionOnly?.ToString() ?? "null");
                         hashBuilder.Append(':');
@@ -3067,18 +3077,20 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 var group = FieldRegistry.GetExtractionGroup(expr.MemberName);
                 requirements.RequiredGroups |= group;
 
-                // Handle special cases for parent series/album fields (conditional on expression flags)
-                if (expr.MemberName == "Tags" && (expr.IncludeParentSeriesTags == true || expr.OnlyParentTags == true))
+                // Handle special cases for parent series/album fields (conditional on expression flags).
+                // Only add each parent group when its corresponding IncludeParent* flag is explicitly true.
+                // OnlyParent* alone does NOT trigger extraction of both groups — use IncludeParent* to decide which.
+                if (expr.MemberName == "Tags" && expr.IncludeParentSeriesTags == true)
                     requirements.RequiredGroups |= ExtractionGroup.ParentSeriesTags;
-                if (expr.MemberName == "Tags" && (expr.IncludeParentAlbumTags == true || expr.OnlyParentTags == true))
+                if (expr.MemberName == "Tags" && expr.IncludeParentAlbumTags == true)
                     requirements.RequiredGroups |= ExtractionGroup.ParentAlbumTags;
-                if (expr.MemberName == "Studios" && (expr.IncludeParentSeriesStudios == true || expr.OnlyParentStudios == true))
+                if (expr.MemberName == "Studios" && expr.IncludeParentSeriesStudios == true)
                     requirements.RequiredGroups |= ExtractionGroup.ParentSeriesStudios;
-                if (expr.MemberName == "Studios" && (expr.IncludeParentAlbumStudios == true || expr.OnlyParentStudios == true))
+                if (expr.MemberName == "Studios" && expr.IncludeParentAlbumStudios == true)
                     requirements.RequiredGroups |= ExtractionGroup.ParentAlbumStudios;
-                if (expr.MemberName == "Genres" && (expr.IncludeParentSeriesGenres == true || expr.OnlyParentGenres == true))
+                if (expr.MemberName == "Genres" && expr.IncludeParentSeriesGenres == true)
                     requirements.RequiredGroups |= ExtractionGroup.ParentSeriesGenres;
-                if (expr.MemberName == "Genres" && (expr.IncludeParentAlbumGenres == true || expr.OnlyParentGenres == true))
+                if (expr.MemberName == "Genres" && expr.IncludeParentAlbumGenres == true)
                     requirements.RequiredGroups |= ExtractionGroup.ParentAlbumGenres;
 
                 // Collect SimilarTo expressions for reference item lookup

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -3054,6 +3054,21 @@ namespace Jellyfin.Plugin.SmartLists.Core
         public bool NeedsTextContent => RequiredGroups.HasFlag(ExtractionGroup.TextContent);
 
         /// <summary>
+        /// Adds a parent extraction group to requirements when the expression targets the given
+        /// member name and the corresponding IncludeParent* flag is explicitly true.
+        /// </summary>
+        private static void AddParentGroupIfIncluded(
+            FieldRequirements requirements,
+            string exprMemberName,
+            string targetMemberName,
+            bool? includeFlag,
+            ExtractionGroup group)
+        {
+            if (exprMemberName == targetMemberName && includeFlag == true)
+                requirements.RequiredGroups |= group;
+        }
+
+        /// <summary>
         /// Analyzes expression sets to determine field requirements.
         /// Uses FieldRegistry for efficient extraction group lookup.
         /// </summary>
@@ -3080,18 +3095,12 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 // Handle special cases for parent series/album fields (conditional on expression flags).
                 // Only add each parent group when its corresponding IncludeParent* flag is explicitly true.
                 // OnlyParent* alone does NOT trigger extraction of both groups — use IncludeParent* to decide which.
-                if (expr.MemberName == "Tags" && expr.IncludeParentSeriesTags == true)
-                    requirements.RequiredGroups |= ExtractionGroup.ParentSeriesTags;
-                if (expr.MemberName == "Tags" && expr.IncludeParentAlbumTags == true)
-                    requirements.RequiredGroups |= ExtractionGroup.ParentAlbumTags;
-                if (expr.MemberName == "Studios" && expr.IncludeParentSeriesStudios == true)
-                    requirements.RequiredGroups |= ExtractionGroup.ParentSeriesStudios;
-                if (expr.MemberName == "Studios" && expr.IncludeParentAlbumStudios == true)
-                    requirements.RequiredGroups |= ExtractionGroup.ParentAlbumStudios;
-                if (expr.MemberName == "Genres" && expr.IncludeParentSeriesGenres == true)
-                    requirements.RequiredGroups |= ExtractionGroup.ParentSeriesGenres;
-                if (expr.MemberName == "Genres" && expr.IncludeParentAlbumGenres == true)
-                    requirements.RequiredGroups |= ExtractionGroup.ParentAlbumGenres;
+                AddParentGroupIfIncluded(requirements, expr.MemberName, "Tags",    expr.IncludeParentSeriesTags,    ExtractionGroup.ParentSeriesTags);
+                AddParentGroupIfIncluded(requirements, expr.MemberName, "Tags",    expr.IncludeParentAlbumTags,     ExtractionGroup.ParentAlbumTags);
+                AddParentGroupIfIncluded(requirements, expr.MemberName, "Studios", expr.IncludeParentSeriesStudios, ExtractionGroup.ParentSeriesStudios);
+                AddParentGroupIfIncluded(requirements, expr.MemberName, "Studios", expr.IncludeParentAlbumStudios,  ExtractionGroup.ParentAlbumStudios);
+                AddParentGroupIfIncluded(requirements, expr.MemberName, "Genres",  expr.IncludeParentSeriesGenres,  ExtractionGroup.ParentSeriesGenres);
+                AddParentGroupIfIncluded(requirements, expr.MemberName, "Genres",  expr.IncludeParentAlbumGenres,   ExtractionGroup.ParentAlbumGenres);
 
                 // Collect SimilarTo expressions for reference item lookup
                 if (expr.MemberName == "SimilarTo")

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -61,9 +61,9 @@ namespace Jellyfin.Plugin.SmartLists.Core
 
         private static bool IsParentAwareListExpression(Expression expr)
         {
-            return (expr.MemberName == "Tags" && expr.IncludeParentSeriesTags == true) ||
-                   (expr.MemberName == "Studios" && expr.IncludeParentSeriesStudios == true) ||
-                   (expr.MemberName == "Genres" && (expr.IncludeParentSeriesGenres == true || expr.IncludeParentAlbumGenres == true));
+            return (expr.MemberName == "Tags" && (expr.IncludeParentSeriesTags == true || expr.IncludeParentAlbumTags == true || expr.OnlyParentTags == true)) ||
+                   (expr.MemberName == "Studios" && (expr.IncludeParentSeriesStudios == true || expr.IncludeParentAlbumStudios == true || expr.OnlyParentStudios == true)) ||
+                   (expr.MemberName == "Genres" && (expr.IncludeParentSeriesGenres == true || expr.IncludeParentAlbumGenres == true || expr.OnlyParentGenres == true));
         }
 
         public SmartList(SmartPlaylistDto dto)
@@ -3023,7 +3023,9 @@ namespace Jellyfin.Plugin.SmartLists.Core
         public bool NeedsNextUnwatched => RequiredGroups.HasFlag(ExtractionGroup.NextUnwatched);
         public bool NeedsSeriesName => RequiredGroups.HasFlag(ExtractionGroup.SeriesName);
         public bool NeedsParentSeriesTags => RequiredGroups.HasFlag(ExtractionGroup.ParentSeriesTags);
+        public bool NeedsParentAlbumTags => RequiredGroups.HasFlag(ExtractionGroup.ParentAlbumTags);
         public bool NeedsParentSeriesStudios => RequiredGroups.HasFlag(ExtractionGroup.ParentSeriesStudios);
+        public bool NeedsParentAlbumStudios => RequiredGroups.HasFlag(ExtractionGroup.ParentAlbumStudios);
         public bool NeedsParentSeriesGenres => RequiredGroups.HasFlag(ExtractionGroup.ParentSeriesGenres);
         public bool NeedsParentAlbumGenres => RequiredGroups.HasFlag(ExtractionGroup.ParentAlbumGenres);
         public bool NeedsSimilarTo => RequiredGroups.HasFlag(ExtractionGroup.SimilarTo);
@@ -3065,14 +3067,18 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 var group = FieldRegistry.GetExtractionGroup(expr.MemberName);
                 requirements.RequiredGroups |= group;
 
-                // Handle special cases for parent series fields (conditional on expression flags)
-                if (expr.MemberName == "Tags" && expr.IncludeParentSeriesTags == true)
+                // Handle special cases for parent series/album fields (conditional on expression flags)
+                if (expr.MemberName == "Tags" && (expr.IncludeParentSeriesTags == true || expr.OnlyParentTags == true))
                     requirements.RequiredGroups |= ExtractionGroup.ParentSeriesTags;
-                if (expr.MemberName == "Studios" && expr.IncludeParentSeriesStudios == true)
+                if (expr.MemberName == "Tags" && (expr.IncludeParentAlbumTags == true || expr.OnlyParentTags == true))
+                    requirements.RequiredGroups |= ExtractionGroup.ParentAlbumTags;
+                if (expr.MemberName == "Studios" && (expr.IncludeParentSeriesStudios == true || expr.OnlyParentStudios == true))
                     requirements.RequiredGroups |= ExtractionGroup.ParentSeriesStudios;
-                if (expr.MemberName == "Genres" && expr.IncludeParentSeriesGenres == true)
+                if (expr.MemberName == "Studios" && (expr.IncludeParentAlbumStudios == true || expr.OnlyParentStudios == true))
+                    requirements.RequiredGroups |= ExtractionGroup.ParentAlbumStudios;
+                if (expr.MemberName == "Genres" && (expr.IncludeParentSeriesGenres == true || expr.OnlyParentGenres == true))
                     requirements.RequiredGroups |= ExtractionGroup.ParentSeriesGenres;
-                if (expr.MemberName == "Genres" && expr.IncludeParentAlbumGenres == true)
+                if (expr.MemberName == "Genres" && (expr.IncludeParentAlbumGenres == true || expr.OnlyParentGenres == true))
                     requirements.RequiredGroups |= ExtractionGroup.ParentAlbumGenres;
 
                 // Collect SimilarTo expressions for reference item lookup

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
@@ -740,6 +740,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
             public ConcurrentDictionary<Guid, List<string>> SeriesStudiosById { get; } = new();
             public ConcurrentDictionary<Guid, List<string>> SeriesGenresById { get; } = new();
             public ConcurrentDictionary<Guid, List<string>> AlbumGenresById { get; } = new();
+            public ConcurrentDictionary<Guid, List<string>> AlbumTagsById { get; } = new();
+            public ConcurrentDictionary<Guid, List<string>> AlbumStudiosById { get; } = new();
             public ConcurrentDictionary<Guid, CategorizedPeople> ItemPeople { get; } = new();
             
             // User-specific data cache - keyed by (ItemId, UserId) to support playlist user + additional users in rules

--- a/docs/content/user-guide/fields-and-operators.md
+++ b/docs/content/user-guide/fields-and-operators.md
@@ -182,13 +182,15 @@ Filter by cast and crew members. Select "People" in the field dropdown, then cho
 | **Album Artists** | Album-level primary artists (music) |
 | **External List** | Match items from an external list (e.g., MDBList). [See details below.](#external-list) |
 
-**Episode-specific options** for Tags, Studios, and Genres:
+**Parent metadata options** for Tags, Studios, and Genres (shown when Episode or Audio media type is selected):
 
-- **Include parent series [tags/studios/genres]** (default: No) - When enabled, episodes match if either the episode or its parent series has the specified value. Useful when series-level metadata is more complete.
+Each of these fields has three options:
 
-**Audio-specific option** for Genres:
+- **No - Only check item [tags/studios/genres]** (default) - Only checks the item's own metadata.
+- **Yes - Also check [tags/studios/genres] from parent series/album** - Matches if either the item or its parent series/album has the specified value. Useful when parent-level metadata is more complete.
+- **Yes - Only check [tags/studios/genres] from parent series/album** - Skips the item's own metadata entirely and only checks the parent series/album. Useful when you want to filter purely by series/album-level metadata.
 
-- **Include parent album genres** (default: No) - When enabled, audio tracks match if either the track or its parent album has the specified genre. Useful when album-level genre metadata is more complete than track-level metadata.
+The label and option text adapts based on the selected media type (e.g., "parent series" for episodes, "parent album" for audio tracks).
 
 #### Collection Name
 


### PR DESCRIPTION
Extend the parent metadata options for Tags, Studios, and Genres rules to support an "only parent" mode, allowing users to filter items based exclusively on parent series/album metadata rather than the item's own.

- Add `OnlyParentTags`, `OnlyParentStudios`, and `OnlyParentGenres` options to the rule selectors in config-rules.js
- Update config-lists.js summary display to reflect the new "only parent series/album" state for Tags, Studios, and Genres
- Rename "Include parent series tags/studios" labels to the more generic "Include parent tags/studios" to cover albums as well
- Add new dropdown options: "Only check tags/studios/genres from parent series/album"

Closes https://github.com/jyourstone/jellyfin-smartlists-plugin/issues/402

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a three-state "Include parent…" option (item-only / include parent / parent-only) for Tags, Studios and Genres, with labels that adapt to selected media types.
  * Added album-level parent metadata support for audio items and improved parent-aware rule evaluation and caching.

* **Documentation**
  * Updated user guide to explain unified parent metadata options and behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jyourstone/jellyfin-smartlists-plugin/pull/403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->