### PR TITLE
Added support for seconds with the Runtime filter

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -1401,6 +1401,7 @@
 
                         let fieldName = rule.MemberName;
                         if (fieldName === 'ItemType') fieldName = 'Media Type';
+                        if (fieldName === 'RuntimeMinutes') fieldName = 'Runtime';
 
                         // Map people field names to friendly display names
                         const displayName = SmartLists.getPeopleFieldDisplayName(fieldName);
@@ -1434,6 +1435,9 @@
                         // Format weekday operator value to show day name instead of number
                         if (rule.Operator === 'Weekday') {
                             value = SmartLists.getDayNameFromValue(value);
+                        }
+                        if (rule.MemberName === 'RuntimeMinutes') {
+                            value = value + ' ' + (String(rule.RuntimeUnit).toLowerCase() === 'seconds' ? 'seconds' : 'minutes');
                         }
 
                         // Check if this rule has a specific user and resolve username

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-rules.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-rules.js
@@ -136,10 +136,11 @@
     };
 
     // ===== VALUE INPUT MANAGEMENT =====
-    SmartLists.setValueInput = function (fieldValue, valueContainer, operatorValue, explicitCurrentValue) {
+    SmartLists.setValueInput = function (fieldValue, valueContainer, operatorValue, explicitCurrentValue, explicitRuntimeUnit) {
         // Store the current value before clearing the container
         // For relative date operators, we need to capture both number and unit
         let currentValue = explicitCurrentValue;
+        let currentRuntimeUnit = explicitRuntimeUnit;
 
         // Only auto-capture value from DOM if explicitCurrentValue was not provided (null/undefined)
         // An explicit empty string means "clear the value"
@@ -154,6 +155,7 @@
             } else {
                 const currentValueInput = valueContainer.querySelector('.rule-value-input');
                 const currentUnitSelect = valueContainer.querySelector('.rule-value-unit');
+                const currentRuntimeUnitSelect = valueContainer.querySelector('.rule-runtime-unit');
 
                 if (currentValueInput) {
                     if (currentUnitSelect && currentUnitSelect.value) {
@@ -164,8 +166,12 @@
                         currentValue = currentValueInput.value;
                     }
                 }
+                if (currentRuntimeUnitSelect && currentRuntimeUnitSelect.value) {
+                    currentRuntimeUnit = currentRuntimeUnitSelect.value;
+                }
             }
         }
+        currentRuntimeUnit = currentRuntimeUnit || 'minutes';
 
         valueContainer.innerHTML = '';
 
@@ -189,7 +195,7 @@
         } else if (SmartLists.FIELD_TYPES.BOOLEAN_FIELDS.indexOf(fieldValue) !== -1) {
             SmartLists.handleBooleanFieldInput(valueContainer, fieldValue, currentValue);
         } else if (SmartLists.FIELD_TYPES.NUMERIC_FIELDS.indexOf(fieldValue) !== -1) {
-            SmartLists.handleNumericFieldInput(valueContainer, fieldValue, currentValue);
+            SmartLists.handleNumericFieldInput(valueContainer, fieldValue, currentValue, currentRuntimeUnit);
         } else if (SmartLists.FIELD_TYPES.DATE_FIELDS.indexOf(fieldValue) !== -1) {
             SmartLists.handleDateFieldInput(valueContainer, currentOperator, currentValue);
         } else if (SmartLists.FIELD_TYPES.RESOLUTION_FIELDS.indexOf(fieldValue) !== -1) {
@@ -199,7 +205,7 @@
         }
 
         // Restore the current value if it exists and is valid for the new field type
-        SmartLists.restoreFieldValue(valueContainer, fieldValue, currentOperator, currentValue, isMultiValueOperator);
+        SmartLists.restoreFieldValue(valueContainer, fieldValue, currentOperator, currentValue, isMultiValueOperator, currentRuntimeUnit);
     };
 
     SmartLists.handleSimpleFieldInput = function (valueContainer, currentValue) {
@@ -303,7 +309,16 @@
         valueContainer.appendChild(select);
     };
 
-    SmartLists.handleNumericFieldInput = function (valueContainer, fieldValue, currentValue) {
+    SmartLists.handleNumericFieldInput = function (valueContainer, fieldValue, currentValue, currentRuntimeUnit) {
+        const inputParent = fieldValue === 'RuntimeMinutes' ? document.createElement('div') : valueContainer;
+        if (fieldValue === 'RuntimeMinutes') {
+            inputParent.style.display = 'flex';
+            inputParent.style.gap = '0.5em';
+            inputParent.style.alignItems = 'center';
+            inputParent.style.width = '100%';
+            valueContainer.appendChild(inputParent);
+        }
+
         const input = document.createElement('input');
         input.type = 'number';
         input.className = 'emby-input rule-value-input';
@@ -311,16 +326,38 @@
         input.style.width = '100%';
 
         // Set appropriate step for decimal fields like Framerate
-        if (fieldValue === 'Framerate' || fieldValue === 'CommunityRating' || fieldValue === 'CriticRating') {
+        if (fieldValue === 'Framerate' || fieldValue === 'CommunityRating' || fieldValue === 'CriticRating' || fieldValue === 'RuntimeMinutes') {
             input.step = 'any'; // Allow any decimal precision
         } else {
-            input.step = '1'; // Integer fields like ProductionYear, RuntimeMinutes, PlayCount
+            input.step = '1'; // Integer fields like ProductionYear and PlayCount
         }
 
         if (currentValue) {
             input.value = currentValue;
         }
-        valueContainer.appendChild(input);
+        inputParent.appendChild(input);
+
+        if (fieldValue === 'RuntimeMinutes') {
+            input.style.flex = '1 1 auto';
+
+            const unitSelect = document.createElement('select');
+            unitSelect.className = 'emby-select rule-runtime-unit';
+            unitSelect.setAttribute('is', 'emby-select');
+            unitSelect.style.flex = '0 0 8.5em';
+
+            [
+                { value: 'minutes', label: 'Minutes' },
+                { value: 'seconds', label: 'Seconds' }
+            ].forEach(function (opt) {
+                const option = document.createElement('option');
+                option.value = opt.value;
+                option.textContent = opt.label;
+                unitSelect.appendChild(option);
+            });
+
+            unitSelect.value = String(currentRuntimeUnit).toLowerCase() === 'seconds' ? 'seconds' : 'minutes';
+            inputParent.appendChild(unitSelect);
+        }
     };
 
     SmartLists.handleDateFieldInput = function (valueContainer, currentOperator, currentValue) {
@@ -463,8 +500,13 @@
     };
 
     // ===== VALUE RESTORATION =====
-    SmartLists.restoreFieldValue = function (valueContainer, fieldValue, currentOperator, currentValue, isMultiValueOperator) {
+    SmartLists.restoreFieldValue = function (valueContainer, fieldValue, currentOperator, currentValue, isMultiValueOperator, currentRuntimeUnit) {
         const newValueInput = valueContainer.querySelector('.rule-value-input');
+        const runtimeUnitSelect = valueContainer.querySelector('.rule-runtime-unit');
+        if (runtimeUnitSelect) {
+            runtimeUnitSelect.value = String(currentRuntimeUnit).toLowerCase() === 'seconds' ? 'seconds' : 'minutes';
+        }
+
         if (newValueInput && currentValue) {
             // Store the original value as a data attribute for potential restoration
             newValueInput.setAttribute('data-original-value', currentValue);
@@ -1487,6 +1529,8 @@
         const genresValue = genresSelect ? genresSelect.value : '';
         const audioLanguagesSelect = ruleRow.querySelector('.rule-audiolanguages-select');
         const audioLanguagesValue = audioLanguagesSelect ? audioLanguagesSelect.value : '';
+        const runtimeUnitSelect = ruleRow.querySelector('.rule-runtime-unit');
+        const runtimeUnitValue = runtimeUnitSelect ? runtimeUnitSelect.value : '';
 
         // Extract Similarity options (checkboxes)
         const similarityOptionsDiv = ruleRow.querySelector('.rule-similarity-options');
@@ -1524,6 +1568,9 @@
         // Add optional fields
         if (userId) {
             expression.UserId = userId;
+        }
+        if (actualMemberName === 'RuntimeMinutes' && runtimeUnitValue === 'seconds') {
+            expression.RuntimeUnit = 'seconds';
         }
         if (fieldValue === 'NextUnwatched' && nextUnwatchedValue === 'false') {
             expression.IncludeUnwatchedSeries = false;
@@ -2725,6 +2772,11 @@
                 if (memberName && operator && targetValue) {
                     const expression = { MemberName: memberName, Operator: operator, TargetValue: targetValue };
 
+                    const runtimeUnitSelect = rule.querySelector('.rule-runtime-unit');
+                    if (memberName === 'RuntimeMinutes' && runtimeUnitSelect && runtimeUnitSelect.value === 'seconds') {
+                        expression.RuntimeUnit = 'seconds';
+                    }
+
                     // Check if a specific user is selected for user data fields
                     const userSelect = rule.querySelector('.rule-user-select');
                     if (userSelect && userSelect.value) {
@@ -2936,7 +2988,7 @@
             }
 
             if (valueContainer && expression.TargetValue !== undefined) {
-                SmartLists.setValueInput(actualMemberName, valueContainer, expression.Operator, expression.TargetValue);
+                SmartLists.setValueInput(actualMemberName, valueContainer, expression.Operator, expression.TargetValue, expression.RuntimeUnit || 'minutes');
             }
 
             // Handle user-specific rules

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-rules.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-rules.js
@@ -331,6 +331,9 @@
         } else {
             input.step = '1'; // Integer fields like ProductionYear and PlayCount
         }
+        if (fieldValue === 'RuntimeMinutes') {
+            input.min = '0';
+        }
 
         if (currentValue) {
             input.value = currentValue;

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
@@ -1292,12 +1292,20 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         /// </summary>
         private static BinaryExpression BuildStandardOperatorExpression(Expression r, MemberExpression left, Type tProp, ILogger? logger)
         {
+            if (r.MemberName == "RuntimeMinutes" &&
+                string.Equals(r.RuntimeUnit, "seconds", StringComparison.OrdinalIgnoreCase) &&
+                (r.Operator == "Equal" || r.Operator == "NotEqual"))
+            {
+                return BuildRuntimeSecondsEqualityExpression(r, left, logger);
+            }
+
             // Check if the operator is a known .NET operator
             logger?.LogDebug("SmartLists checking if {Operator} is a built-in .NET ExpressionType", r.Operator);
             if (Enum.TryParse(r.Operator, out ExpressionType tBinary))
             {
                 logger?.LogDebug("SmartLists {Operator} IS a built-in ExpressionType: {ExpressionType}", r.Operator, tBinary);
-                var right = System.Linq.Expressions.Expression.Constant(Convert.ChangeType(r.TargetValue, tProp, System.Globalization.CultureInfo.InvariantCulture));
+                var targetValue = GetStandardComparisonTargetValue(r, logger);
+                var right = System.Linq.Expressions.Expression.Constant(Convert.ChangeType(targetValue, tProp, System.Globalization.CultureInfo.InvariantCulture));
                 // use a binary operation, e.g. 'Equal' -> 'u.Age == 15'
                 return System.Linq.Expressions.Expression.MakeBinary(tBinary, left, right);
             }
@@ -1307,6 +1315,49 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             logger?.LogError("SmartLists unsupported operator '{Operator}' for field '{Field}' of type '{Type}'", r.Operator, r.MemberName, tProp.Name);
             var supportedOperators = Operators.GetSupportedOperatorsString(r.MemberName);
             throw new ArgumentException($"Operator '{r.Operator}' is not supported for field '{r.MemberName}' of type '{tProp.Name}'. Supported operators: {supportedOperators}");
+        }
+
+        private static BinaryExpression BuildRuntimeSecondsEqualityExpression(Expression r, MemberExpression left, ILogger? logger)
+        {
+            if (!double.TryParse(r.TargetValue, NumberStyles.Float, CultureInfo.InvariantCulture, out var seconds))
+            {
+                logger?.LogError("SmartLists runtime comparison failed: Invalid seconds value '{Value}'", r.TargetValue);
+                throw new ArgumentException($"Invalid runtime seconds value '{r.TargetValue}'. Expected a decimal number.");
+            }
+
+            var lowerBoundMinutes = Math.Max(0, seconds - 0.5) / 60.0;
+            var upperBoundMinutes = (seconds + 0.5) / 60.0;
+            var lowerBound = System.Linq.Expressions.Expression.Constant(lowerBoundMinutes, typeof(double));
+            var upperBound = System.Linq.Expressions.Expression.Constant(upperBoundMinutes, typeof(double));
+
+            var greaterThanOrEqualLower = System.Linq.Expressions.Expression.GreaterThanOrEqual(left, lowerBound);
+            var lessThanUpper = System.Linq.Expressions.Expression.LessThan(left, upperBound);
+
+            if (r.Operator == "Equal")
+            {
+                return System.Linq.Expressions.Expression.AndAlso(greaterThanOrEqualLower, lessThanUpper);
+            }
+
+            var lessThanLower = System.Linq.Expressions.Expression.LessThan(left, lowerBound);
+            var greaterThanOrEqualUpper = System.Linq.Expressions.Expression.GreaterThanOrEqual(left, upperBound);
+            return System.Linq.Expressions.Expression.OrElse(lessThanLower, greaterThanOrEqualUpper);
+        }
+
+        private static string GetStandardComparisonTargetValue(Expression r, ILogger? logger)
+        {
+            if (r.MemberName != "RuntimeMinutes" ||
+                !string.Equals(r.RuntimeUnit, "seconds", StringComparison.OrdinalIgnoreCase))
+            {
+                return r.TargetValue;
+            }
+
+            if (!double.TryParse(r.TargetValue, NumberStyles.Float, CultureInfo.InvariantCulture, out var seconds))
+            {
+                logger?.LogError("SmartLists runtime comparison failed: Invalid seconds value '{Value}'", r.TargetValue);
+                throw new ArgumentException($"Invalid runtime seconds value '{r.TargetValue}'. Expected a decimal number.");
+            }
+
+            return (seconds / 60.0).ToString(CultureInfo.InvariantCulture);
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
@@ -1319,11 +1319,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
 
         private static BinaryExpression BuildRuntimeSecondsEqualityExpression(Expression r, MemberExpression left, ILogger? logger)
         {
-            if (!double.TryParse(r.TargetValue, NumberStyles.Float, CultureInfo.InvariantCulture, out var seconds))
-            {
-                logger?.LogError("SmartLists runtime comparison failed: Invalid seconds value '{Value}'", r.TargetValue);
-                throw new ArgumentException($"Invalid runtime seconds value '{r.TargetValue}'. Expected a decimal number.");
-            }
+            var seconds = ParseNonNegativeSeconds(r.TargetValue, logger);
 
             var lowerBoundMinutes = Math.Max(0, seconds - 0.5) / 60.0;
             var upperBoundMinutes = (seconds + 0.5) / 60.0;
@@ -1343,6 +1339,20 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             return System.Linq.Expressions.Expression.OrElse(lessThanLower, greaterThanOrEqualUpper);
         }
 
+        private static double ParseNonNegativeSeconds(string value, ILogger? logger)
+        {
+            if (!double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var seconds) ||
+                double.IsNaN(seconds) ||
+                double.IsInfinity(seconds) ||
+                seconds < 0)
+            {
+                logger?.LogError("SmartLists runtime comparison failed: Invalid non-negative seconds value '{Value}'", value);
+                throw new ArgumentException($"Invalid runtime seconds value '{value}'. Expected a non-negative decimal number.");
+            }
+
+            return seconds;
+        }
+
         private static string GetStandardComparisonTargetValue(Expression r, ILogger? logger)
         {
             if (r.MemberName != "RuntimeMinutes" ||
@@ -1351,11 +1361,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                 return r.TargetValue;
             }
 
-            if (!double.TryParse(r.TargetValue, NumberStyles.Float, CultureInfo.InvariantCulture, out var seconds))
-            {
-                logger?.LogError("SmartLists runtime comparison failed: Invalid seconds value '{Value}'", r.TargetValue);
-                throw new ArgumentException($"Invalid runtime seconds value '{r.TargetValue}'. Expected a decimal number.");
-            }
+            var seconds = ParseNonNegativeSeconds(r.TargetValue, logger);
 
             return (seconds / 60.0).ToString(CultureInfo.InvariantCulture);
         }

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Expression.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Expression.cs
@@ -68,6 +68,10 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? OnlyDefaultAudioLanguage { get; set; } = null;
 
+        // RuntimeMinutes-specific option - only serialize when meaningful
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? RuntimeUnit { get; set; } = null;
+
         // Collections-specific depth option - only serialize when meaningful
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public int? CollectionSearchDepth { get; set; } = null;

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/FieldRegistry.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/FieldRegistry.cs
@@ -262,7 +262,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             AddField(fields, "LastPlayedDate", "Last Played", FieldType.Date, FieldCategory.RatingsPlayback, DateOperators, ExtractionGroup.UserData, isUserSpecific: true);
             AddField(fields, "NextUnwatched", "Next Unwatched", FieldType.Boolean, FieldCategory.RatingsPlayback, BooleanOperators, ExtractionGroup.NextUnwatched, isUserSpecific: true);
             AddField(fields, "PlayCount", "Play Count", FieldType.Numeric, FieldCategory.RatingsPlayback, NumericOperators, ExtractionGroup.UserData, isUserSpecific: true);
-            AddField(fields, "RuntimeMinutes", "Runtime (Minutes)", FieldType.Numeric, FieldCategory.RatingsPlayback, NumericOperators, ExtractionGroup.TextContent);
+            AddField(fields, "RuntimeMinutes", "Runtime", FieldType.Numeric, FieldCategory.RatingsPlayback, NumericOperators, ExtractionGroup.TextContent);
 
             // File Fields - conditionally extracted via ExtractionGroup.FileInfo
             AddField(fields, "FileName", "File Name", FieldType.Text, FieldCategory.File, StringOperators, ExtractionGroup.FileInfo);

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -503,6 +503,8 @@ namespace Jellyfin.Plugin.SmartLists.Core
                         hashBuilder.Append(':');
                         hashBuilder.Append(expr.OnlyDefaultAudioLanguage?.ToString() ?? "null");
                         hashBuilder.Append(':');
+                        hashBuilder.Append(expr.RuntimeUnit ?? "");
+                        hashBuilder.Append(':');
                         hashBuilder.Append(expr.IncludeUnwatchedSeries?.ToString() ?? "null");
                         hashBuilder.Append(':');
                         hashBuilder.Append(expr.IncludeEpisodesWithinSeries?.ToString() ?? "null");

--- a/docs/content/user-guide/fields-and-operators.md
+++ b/docs/content/user-guide/fields-and-operators.md
@@ -73,7 +73,7 @@ The audio language tracks available for the media item.
 |-------|-------------|
 | **Community Rating** | User ratings (0-10) |
 | **Critic Rating** | Professional critic ratings |
-| **Runtime (Minutes)** | Duration of the content |
+| **Runtime** | Duration of the content. Runtime rules can use minutes or seconds. |
 
 #### User-Specific Fields
 


### PR DESCRIPTION
Closes https://github.com/jyourstone/jellyfin-smartlists-plugin/issues/405

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime rules support explicit unit selection — enter and evaluate runtime in minutes or seconds.

* **Improvements**
  * Field label simplified from "Runtime (Minutes)" to "Runtime".
  * Rule displays now show a unit suffix (minutes or seconds) for clarity.
  * The runtime unit selector is preserved when editing rules and restored when loading saved rules.
  * Equality checks for seconds use a small ±0.5s window to ensure precise matching across minute/second inputs.

* **Documentation**
  * User guide updated to reflect minute/second support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jyourstone/jellyfin-smartlists-plugin/pull/409?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->