### PR TITLE
Added support for virtual movie libraries

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
@@ -101,6 +101,16 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                 return parentAwareExpression;
             }
 
+            if (r.MemberName == "LibraryName")
+            {
+                var libraryNamesProperty = System.Linq.Expressions.Expression.PropertyOrField(param, "LibraryNames");
+                var enumerableExpr = BuildEnumerableExpression(r, libraryNamesProperty, libraryNamesProperty.Type, logger);
+                if (enumerableExpr != null)
+                {
+                    return enumerableExpr;
+                }
+            }
+
             // Special handling for AudioLanguages field with OnlyDefaultAudioLanguage option
             if (r.MemberName == "AudioLanguages" && r.OnlyDefaultAudioLanguage == true)
             {

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
@@ -3333,11 +3333,15 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             // LibraryInfo extraction - conditionally extracted for performance optimization
             if (extractLibraryInfo)
             {
-                operand.LibraryName = ExtractLibraryName(baseItem, libraryManager, cache, logger);
+                operand.LibraryNames = ExtractLibraryNames(baseItem, libraryManager, cache, logger);
+                operand.LibraryName = operand.LibraryNames.Count > 0
+                    ? string.Join("; ", operand.LibraryNames)
+                    : string.Empty;
             }
             else
             {
                 operand.LibraryName = string.Empty;
+                operand.LibraryNames = [];
                 logger?.LogDebug("LibraryInfo extraction skipped for item {Name} - not needed by rules", baseItem.Name);
             }
 
@@ -3941,13 +3945,18 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         /// <param name="libraryManager">Library manager for library lookups</param>
         /// <param name="cache">Cache for storing library name lookups</param>
         /// <param name="logger">Logger for debugging</param>
-        /// <returns>The library name this item belongs to, or empty string if not found</returns>
-        private static string ExtractLibraryName(BaseItem baseItem, ILibraryManager libraryManager, RefreshQueueServiceRefreshCache cache, ILogger? logger)
+        /// <returns>The library names this item belongs to, or an empty list if not found</returns>
+        private static List<string> ExtractLibraryNames(BaseItem baseItem, ILibraryManager libraryManager, RefreshQueueServiceRefreshCache cache, ILogger? logger)
         {
+            var cacheKey = (
+                baseItem.Id,
+                baseItem.Path ?? string.Empty,
+                baseItem.ContainingFolderPath ?? string.Empty);
+
             // Check cache first
-            if (cache.LibraryNameById.TryGetValue(baseItem.Id, out var cachedName))
+            if (cache.LibraryNamesByItemKey.TryGetValue(cacheKey, out var cachedNames))
             {
-                return cachedName;
+                return cachedNames;
             }
 
             try
@@ -3956,9 +3965,14 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
 
                 if (collectionFolders != null && collectionFolders.Count > 0)
                 {
-                    var libraryName = collectionFolders[0].Name;
-                    cache.LibraryNameById[baseItem.Id] = libraryName;
-                    return libraryName;
+                    var libraryNames = collectionFolders
+                        .Select(folder => folder.Name)
+                        .Where(name => !string.IsNullOrWhiteSpace(name))
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .ToList();
+
+                    cache.LibraryNamesByItemKey[cacheKey] = libraryNames;
+                    return libraryNames;
                 }
             }
             catch (Exception ex)
@@ -3967,8 +3981,8 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             }
 
             // Cache empty result too to avoid repeated failed lookups
-            cache.LibraryNameById[baseItem.Id] = string.Empty;
-            return string.Empty;
+            cache.LibraryNamesByItemKey[cacheKey] = [];
+            return [];
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
@@ -3946,7 +3946,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         /// <param name="cache">Cache for storing library name lookups</param>
         /// <param name="logger">Logger for debugging</param>
         /// <returns>The library names this item belongs to, or an empty list if not found</returns>
-        private static List<string> ExtractLibraryNames(BaseItem baseItem, ILibraryManager libraryManager, RefreshQueueServiceRefreshCache cache, ILogger? logger)
+        private static IReadOnlyList<string> ExtractLibraryNames(BaseItem baseItem, ILibraryManager libraryManager, RefreshQueueServiceRefreshCache cache, ILogger? logger)
         {
             var cacheKey = (
                 baseItem.Id,
@@ -3969,7 +3969,8 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                         .Select(folder => folder.Name)
                         .Where(name => !string.IsNullOrWhiteSpace(name))
                         .Distinct(StringComparer.OrdinalIgnoreCase)
-                        .ToList();
+                        .ToList()
+                        .AsReadOnly();
 
                     cache.LibraryNamesByItemKey[cacheKey] = libraryNames;
                     return libraryNames;
@@ -3981,8 +3982,9 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             }
 
             // Cache empty result too to avoid repeated failed lookups
-            cache.LibraryNamesByItemKey[cacheKey] = [];
-            return [];
+            var emptyLibraryNames = Array.Empty<string>();
+            cache.LibraryNamesByItemKey[cacheKey] = emptyLibraryNames;
+            return emptyLibraryNames;
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Operand.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Operand.cs
@@ -107,7 +107,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
 
         // Library name - the Jellyfin library this item belongs to (e.g., "Movies", "TV Shows", "Music")
         public string LibraryName { get; set; } = string.Empty;
-        public List<string> LibraryNames { get; set; } = [];
+        public IReadOnlyList<string> LibraryNames { get; set; } = [];
 
         // Custom rating - user-defined rating field (can be text or numeric)
         public string CustomRating { get; set; } = string.Empty;

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Operand.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Operand.cs
@@ -107,6 +107,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
 
         // Library name - the Jellyfin library this item belongs to (e.g., "Movies", "TV Shows", "Music")
         public string LibraryName { get; set; } = string.Empty;
+        public List<string> LibraryNames { get; set; } = [];
 
         // Custom rating - user-defined rating field (can be text or numeric)
         public string CustomRating { get; set; } = string.Empty;

--- a/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
@@ -1101,7 +1101,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
             var validTopParentIds = GetLibraryTopParentIds();
 
             // Query all items the owner user has access to
-            var includeVirtualItems = UsesLibraryNameRule(dto);
+            var includeVirtualItems = SmartListUtilities.UsesLibraryNameRule(dto);
             var query = new InternalItemsQuery(ownerUser)
             {
                 IncludeItemTypes = baseItemKinds,
@@ -1124,13 +1124,6 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
         }
 
         private Guid[] GetLibraryTopParentIds() => LibraryManagerHelper.GetLibraryTopParentIds(_libraryManager);
-
-        private static bool UsesLibraryNameRule(SmartListDto? dto)
-        {
-            return dto?.ExpressionSets?.Any(set =>
-                set.Expressions?.Any(expr =>
-                    string.Equals(expr.MemberName, "LibraryName", StringComparison.OrdinalIgnoreCase)) == true) == true;
-        }
 
         /// <summary>
         /// Refreshes collection metadata including cover image generation.

--- a/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
@@ -258,13 +258,40 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
 
                 // Create a lookup dictionary for O(1) access while preserving order from newItems
                 // Include both media items and collections (if IncludeCollectionOnly is enabled) and playlists (if IncludePlaylistOnly is enabled)
-                var mediaLookup = allMedia
-                    .GroupBy(m => m.Id)
-                    .ToDictionary(g => g.Key, g => g.First());
+                var groupedMedia = allMedia.GroupBy(m => m.Id).ToList();
+                var duplicateMediaGroups = groupedMedia.Where(g => g.Count() > 1).ToList();
+                if (duplicateMediaGroups.Count > 0 && SmartListUtilities.UsesLibraryNameRule(dto))
+                {
+                    var sampleIds = duplicateMediaGroups
+                        .Take(10)
+                        .Select(g => $"{g.Key} ({g.Count()} copies)");
+                    _logger.LogDebug(
+                        "Collection '{CollectionName}' GetAllMedia returned {DuplicateGroupCount} duplicate item id groups while LibraryName virtual-library matching is enabled (TopParentIds={TopParentCount}); mediaLookup will keep the first item for each id. Sample duplicate ids: {DuplicateIds}",
+                        dto.Name,
+                        duplicateMediaGroups.Count,
+                        GetLibraryTopParentIds().Length,
+                        string.Join(", ", sampleIds));
+                }
+
+                var mediaLookup = groupedMedia.ToDictionary(g => g.Key, g => g.First());
                 AddIncludeOnlyItemsToLookup(mediaLookup, allCollections);
                 AddIncludeOnlyItemsToLookup(mediaLookup, allPlaylists);
-                var newLinkedChildren = newItems
-                    .Distinct()
+                var distinctNewItems = newItems.Distinct().ToArray();
+                if (distinctNewItems.Length != newItems.Length)
+                {
+                    var duplicateIds = newItems
+                        .GroupBy(itemId => itemId)
+                        .Where(g => g.Count() > 1)
+                        .Take(10)
+                        .Select(g => $"{g.Key} ({g.Count()} copies)");
+                    _logger.LogDebug(
+                        "Collection '{CollectionName}' filtered newItems contained {DuplicateItemCount} duplicate ids before LinkedChild creation; using Distinct() for linked children. Sample duplicate ids: {DuplicateIds}",
+                        dto.Name,
+                        newItems.Length - distinctNewItems.Length,
+                        string.Join(", ", duplicateIds));
+                }
+
+                var newLinkedChildren = distinctNewItems
                     .Where(itemId => mediaLookup.ContainsKey(itemId))
                     .Select(itemId => new LinkedChild { ItemId = itemId, Path = mediaLookup[itemId].Path })
                     .ToArray();

--- a/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
@@ -258,10 +258,13 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
 
                 // Create a lookup dictionary for O(1) access while preserving order from newItems
                 // Include both media items and collections (if IncludeCollectionOnly is enabled) and playlists (if IncludePlaylistOnly is enabled)
-                var mediaLookup = allMedia.ToDictionary(m => m.Id, m => m);
+                var mediaLookup = allMedia
+                    .GroupBy(m => m.Id)
+                    .ToDictionary(g => g.Key, g => g.First());
                 AddIncludeOnlyItemsToLookup(mediaLookup, allCollections);
                 AddIncludeOnlyItemsToLookup(mediaLookup, allPlaylists);
                 var newLinkedChildren = newItems
+                    .Distinct()
                     .Where(itemId => mediaLookup.ContainsKey(itemId))
                     .Select(itemId => new LinkedChild { ItemId = itemId, Path = mediaLookup[itemId].Path })
                     .ToArray();
@@ -1098,11 +1101,12 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
             var validTopParentIds = GetLibraryTopParentIds();
 
             // Query all items the owner user has access to
+            var includeVirtualItems = UsesLibraryNameRule(dto);
             var query = new InternalItemsQuery(ownerUser)
             {
                 IncludeItemTypes = baseItemKinds,
                 Recursive = true,
-                IsVirtualItem = false,
+                IsVirtualItem = includeVirtualItems ? null : false,
                 TopParentIds = validTopParentIds,
             };
 
@@ -1120,6 +1124,13 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
         }
 
         private Guid[] GetLibraryTopParentIds() => LibraryManagerHelper.GetLibraryTopParentIds(_libraryManager);
+
+        private static bool UsesLibraryNameRule(SmartListDto? dto)
+        {
+            return dto?.ExpressionSets?.Any(set =>
+                set.Expressions?.Any(expr =>
+                    string.Equals(expr.MemberName, "LibraryName", StringComparison.OrdinalIgnoreCase)) == true) == true;
+        }
 
         /// <summary>
         /// Refreshes collection metadata including cover image generation.

--- a/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
@@ -177,8 +177,11 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                     dto.Name, newItems.Length, allUserMedia.Length);
 
                 // Create a lookup dictionary for O(1) access while preserving order from newItems
-                var mediaLookup = allUserMedia.ToDictionary(m => m.Id, m => m);
+                var mediaLookup = allUserMedia
+                    .GroupBy(m => m.Id)
+                    .ToDictionary(g => g.Key, g => g.First());
                 var newLinkedChildren = newItems
+                    .Distinct()
                     .Where(itemId => mediaLookup.ContainsKey(itemId))
                     .Select(itemId => new LinkedChild { ItemId = itemId, Path = mediaLookup[itemId].Path })
                     .ToArray();
@@ -972,11 +975,12 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
             // (which points to the physical folder). We resolve physical folder IDs via FindByPath.
             var validTopParentIds = GetLibraryTopParentIds();
 
+            var includeVirtualItems = UsesLibraryNameRule(dto);
             var query = new InternalItemsQuery(user)
             {
                 IncludeItemTypes = baseItemKinds,
                 Recursive = true,
-                IsVirtualItem = false,
+                IsVirtualItem = includeVirtualItems ? null : false,
                 TopParentIds = validTopParentIds,
             };
 
@@ -994,6 +998,13 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
         }
 
         private Guid[] GetLibraryTopParentIds() => LibraryManagerHelper.GetLibraryTopParentIds(_libraryManager);
+
+        private static bool UsesLibraryNameRule(SmartListDto? dto)
+        {
+            return dto?.ExpressionSets?.Any(set =>
+                set.Expressions?.Any(expr =>
+                    string.Equals(expr.MemberName, "LibraryName", StringComparison.OrdinalIgnoreCase)) == true) == true;
+        }
 
         /// <summary>
         /// Refreshes playlist metadata to trigger Jellyfin's auto-generation of cover images.

--- a/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
@@ -975,7 +975,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
             // (which points to the physical folder). We resolve physical folder IDs via FindByPath.
             var validTopParentIds = GetLibraryTopParentIds();
 
-            var includeVirtualItems = UsesLibraryNameRule(dto);
+            var includeVirtualItems = SmartListUtilities.UsesLibraryNameRule(dto);
             var query = new InternalItemsQuery(user)
             {
                 IncludeItemTypes = baseItemKinds,
@@ -998,13 +998,6 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
         }
 
         private Guid[] GetLibraryTopParentIds() => LibraryManagerHelper.GetLibraryTopParentIds(_libraryManager);
-
-        private static bool UsesLibraryNameRule(SmartListDto? dto)
-        {
-            return dto?.ExpressionSets?.Any(set =>
-                set.Expressions?.Any(expr =>
-                    string.Equals(expr.MemberName, "LibraryName", StringComparison.OrdinalIgnoreCase)) == true) == true;
-        }
 
         /// <summary>
         /// Refreshes playlist metadata to trigger Jellyfin's auto-generation of cover images.

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
@@ -772,7 +772,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
             public ConcurrentDictionary<Guid, double> LastEpisodeAirDateById { get; } = new();
 
             // Library name cache - maps item identity/path → library names (from GetCollectionFolders API)
-            public ConcurrentDictionary<(Guid ItemId, string Path, string FolderPath), List<string>> LibraryNamesByItemKey { get; } = new();
+            public ConcurrentDictionary<(Guid ItemId, string Path, string FolderPath), IReadOnlyList<string>> LibraryNamesByItemKey { get; } = new();
 
             // Extra → owning Series ID cache (reverse lookup from extra ID to its parent Series)
             // Populated by PlaylistService/CollectionService when fetching extras

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
@@ -771,8 +771,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
             // Last episode air date cache for Series items - maps SeriesId → Unix timestamp of most recent episode
             public ConcurrentDictionary<Guid, double> LastEpisodeAirDateById { get; } = new();
 
-            // Library name cache - maps ItemId → library name (from GetCollectionFolders API)
-            public ConcurrentDictionary<Guid, string> LibraryNameById { get; } = new();
+            // Library name cache - maps item identity/path → library names (from GetCollectionFolders API)
+            public ConcurrentDictionary<(Guid ItemId, string Path, string FolderPath), List<string>> LibraryNamesByItemKey { get; } = new();
 
             // Extra → owning Series ID cache (reverse lookup from extra ID to its parent Series)
             // Populated by PlaylistService/CollectionService when fetching extras

--- a/Jellyfin.Plugin.SmartLists/Utilities/SmartListUtilities.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/SmartListUtilities.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Linq;
+using Jellyfin.Plugin.SmartLists.Core.Models;
+
+namespace Jellyfin.Plugin.SmartLists.Utilities
+{
+    public static class SmartListUtilities
+    {
+        public static bool UsesLibraryNameRule(SmartListDto? dto)
+        {
+            return dto?.ExpressionSets?.Any(set =>
+                set.Expressions?.Any(expr =>
+                    string.Equals(expr.MemberName, "LibraryName", StringComparison.OrdinalIgnoreCase)) == true) == true;
+        }
+    }
+}


### PR DESCRIPTION
Hopefully fixes https://github.com/jyourstone/jellyfin-smartlists-plugin/issues/418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-library matching: rules can target multiple libraries for more accurate results.
  * Added a utility to detect when lists use library-based rules.

* **Bug Fixes**
  * Prevented duplicate items during collection and playlist refreshes.
  * Improved handling of virtual items when library rules are present.
  * Enhanced library-name caching to reduce repeated lookups and improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->