### PR TITLE
Enhanced support for virtual folders in movie libraries

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
@@ -3961,19 +3961,28 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
 
             try
             {
+                var libraryNames = new List<string>();
                 var collectionFolders = libraryManager.GetCollectionFolders(baseItem);
 
                 if (collectionFolders != null && collectionFolders.Count > 0)
                 {
-                    var libraryNames = collectionFolders
+                    libraryNames.AddRange(collectionFolders
                         .Select(folder => folder.Name)
                         .Where(name => !string.IsNullOrWhiteSpace(name))
+                        .Select(name => name!));
+                }
+
+                libraryNames.AddRange(LibraryManagerHelper.GetLibraryNamesForItemPath(libraryManager, baseItem));
+
+                if (libraryNames.Count > 0)
+                {
+                    var distinctLibraryNames = libraryNames
                         .Distinct(StringComparer.OrdinalIgnoreCase)
                         .ToList()
                         .AsReadOnly();
 
-                    cache.LibraryNamesByItemKey[cacheKey] = libraryNames;
-                    return libraryNames;
+                    cache.LibraryNamesByItemKey[cacheKey] = distinctLibraryNames;
+                    return distinctLibraryNames;
                 }
             }
             catch (Exception ex)

--- a/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
@@ -1133,13 +1133,9 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
             {
                 IncludeItemTypes = baseItemKinds,
                 Recursive = true,
-                IsVirtualItem = includeVirtualItems ? null : false,
             };
 
-            if (!includeVirtualItems)
-            {
-                query.TopParentIds = validTopParentIds;
-            }
+            LibraryManagerHelper.ApplyVirtualItemQueryScope(query, includeVirtualItems, validTopParentIds);
 
             var items = _libraryManager.GetItemsResult(query).Items;
 

--- a/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
@@ -1134,8 +1134,12 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                 IncludeItemTypes = baseItemKinds,
                 Recursive = true,
                 IsVirtualItem = includeVirtualItems ? null : false,
-                TopParentIds = validTopParentIds,
             };
+
+            if (!includeVirtualItems)
+            {
+                query.TopParentIds = validTopParentIds;
+            }
 
             var items = _libraryManager.GetItemsResult(query).Items;
 

--- a/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
@@ -980,13 +980,9 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
             {
                 IncludeItemTypes = baseItemKinds,
                 Recursive = true,
-                IsVirtualItem = includeVirtualItems ? null : false,
             };
 
-            if (!includeVirtualItems)
-            {
-                query.TopParentIds = validTopParentIds;
-            }
+            LibraryManagerHelper.ApplyVirtualItemQueryScope(query, includeVirtualItems, validTopParentIds);
 
             var items = _libraryManager.GetItemsResult(query).Items;
 

--- a/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
@@ -981,8 +981,12 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                 IncludeItemTypes = baseItemKinds,
                 Recursive = true,
                 IsVirtualItem = includeVirtualItems ? null : false,
-                TopParentIds = validTopParentIds,
             };
+
+            if (!includeVirtualItems)
+            {
+                query.TopParentIds = validTopParentIds;
+            }
 
             var items = _libraryManager.GetItemsResult(query).Items;
 

--- a/Jellyfin.Plugin.SmartLists/Utilities/LibraryManagerHelper.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/LibraryManagerHelper.cs
@@ -130,6 +130,16 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
                 .AsReadOnly();
         }
 
+        public static void ApplyVirtualItemQueryScope(InternalItemsQuery query, bool includeVirtualItems, Guid[] validTopParentIds)
+        {
+            query.IsVirtualItem = includeVirtualItems ? null : false;
+
+            if (!includeVirtualItems)
+            {
+                query.TopParentIds = validTopParentIds;
+            }
+        }
+
         private static bool IsPathInLocation(string? itemPath, string location)
         {
             if (string.IsNullOrWhiteSpace(itemPath))
@@ -146,7 +156,8 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
 
         private static string NormalizePathForPrefixMatch(string path)
         {
-            return path.Replace('\\', '/').TrimEnd('/');
+            var normalizedPath = path.Replace('\\', '/').TrimEnd('/');
+            return normalizedPath.Length == 0 ? "/" : normalizedPath;
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Utilities/LibraryManagerHelper.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/LibraryManagerHelper.cs
@@ -96,6 +96,60 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
         }
 
         /// <summary>
+        /// Resolves library names by comparing an item's file path with configured virtual folder locations.
+        /// This supplements GetCollectionFolders for symlinked libraries whose collection-folder lookup may
+        /// resolve to the source item instead of the virtual recommendation library.
+        /// </summary>
+        public static IReadOnlyList<string> GetLibraryNamesForItemPath(ILibraryManager libraryManager, BaseItem item)
+        {
+            var names = new List<string>();
+            var itemPaths = new[]
+            {
+                item.Path,
+                item.ContainingFolderPath,
+            };
+
+            foreach (var vf in libraryManager.GetVirtualFolders())
+            {
+                if (string.IsNullOrWhiteSpace(vf.Name) || vf.Locations == null)
+                {
+                    continue;
+                }
+
+                if (vf.Locations.Any(location =>
+                    !string.IsNullOrWhiteSpace(location) &&
+                    itemPaths.Any(itemPath => IsPathInLocation(itemPath, location))))
+                {
+                    names.Add(vf.Name);
+                }
+            }
+
+            return names
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList()
+                .AsReadOnly();
+        }
+
+        private static bool IsPathInLocation(string? itemPath, string location)
+        {
+            if (string.IsNullOrWhiteSpace(itemPath))
+            {
+                return false;
+            }
+
+            var normalizedPath = NormalizePathForPrefixMatch(itemPath);
+            var normalizedLocation = NormalizePathForPrefixMatch(location);
+
+            return normalizedPath.Equals(normalizedLocation, StringComparison.OrdinalIgnoreCase) ||
+                normalizedPath.StartsWith(normalizedLocation + "/", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string NormalizePathForPrefixMatch(string path)
+        {
+            return path.Replace('\\', '/').TrimEnd('/');
+        }
+
+        /// <summary>
         /// Parent item kinds that can own extras (behind the scenes, deleted scenes, featurettes, etc.).
         /// </summary>
         private static readonly BaseItemKind[] ExtrasParentKinds =


### PR DESCRIPTION
Should hopefully fix https://github.com/jyourstone/jellyfin-smartlists-plugin/issues/418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved library name detection to better reflect both collection sources and virtual folder mappings, including more accurate path-based matching and de-duplication.
  * Updated media and playlist queries to apply virtual-item scoping consistently, ensuring virtual and non-virtual items are filtered as expected based on current settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->