### PR TITLE
Added support for Jellyfin 12.0-rc1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         id: check_preview
         run: |
           # Check if tag name contains "preview" or "rc" after version
-          TAG_NAME="${{ github.ref_name }}"
+          TAG_NAME="$GITHUB_REF_NAME"
           if echo "$TAG_NAME" | grep -E "preview|rc" > /dev/null; then
             echo "is_preview=true" >> $GITHUB_OUTPUT
             echo "Preview tag detected: $TAG_NAME"
@@ -47,8 +47,8 @@ jobs:
       - name: Build plugin
         run: |
           # Strip preview/rc suffixes for .NET versioning
-          VERSION=$(echo "${{ github.ref_name }}" | sed -E 's/(preview|rc).*$//' | sed 's/v//' | sed 's/-$//')
-          echo "Building version: $VERSION (stripped from tag: ${{ github.ref_name }})"
+          VERSION=$(echo "$GITHUB_REF_NAME" | sed -E 's/(preview|rc).*$//' | sed 's/v//' | sed 's/-$//')
+          echo "Building version: $VERSION (stripped from tag: $GITHUB_REF_NAME)"
           echo "$TARGETS" | jq -c '.[]' | while read -r target; do
             TARGET_ABI=$(echo "$target" | jq -r '.abi')
             TARGET_FRAMEWORK=$(echo "$target" | jq -r '.framework')
@@ -70,13 +70,13 @@ jobs:
             cp "./build_output/${TARGET_ABI}/Jellyfin.Plugin.SmartLists.deps.json" "$STAGING_DIR/"
             cp images/logo.jpg "$STAGING_DIR/logo.jpg"
             cd "$STAGING_DIR"
-            zip -X "../../Jellyfin.Plugin.SmartLists_${{ github.ref_name }}_${TARGET_ABI}.zip" *
+            zip -X "../../Jellyfin.Plugin.SmartLists_${GITHUB_REF_NAME}_${TARGET_ABI}.zip" *
             cd ../..
           done
 
       - name: Create Release (auto notes from PRs)
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:
           name: Release ${{ github.ref_name }}
           files: ./Jellyfin.Plugin.SmartLists_${{ github.ref_name }}_*.zip
@@ -93,7 +93,7 @@ jobs:
         run: |
           set -e
           resp=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-                 "https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ github.ref_name }}")
+                 "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${GITHUB_REF_NAME}")
           body=$(echo "$resp" | jq -r '.body // ""')
           {
             echo 'body<<EOM'
@@ -108,7 +108,7 @@ jobs:
           CHANGELOG_BODY: ${{ steps.read_release.outputs.body }}
         run: |
           # Strip preview/rc suffixes for .NET versioning
-          VERSION=$(echo "${{ github.ref_name }}" | sed -E 's/(preview|rc).*$//' | sed 's/v//' | sed 's/-$//')
+          VERSION=$(echo "$GITHUB_REF_NAME" | sed -E 's/(preview|rc).*$//' | sed 's/v//' | sed 's/-$//')
           ASSEMBLY_VERSION="${VERSION}"
           TIMESTAMP=$(date -u +'%Y-%m-%d')
           # Sanitize changelog: remove trailing "by @user in <link>" fragments GitHub adds
@@ -139,9 +139,9 @@ jobs:
 
           echo "$TARGETS" | jq -c '.[]' | while read -r target; do
             TARGET_ABI=$(echo "$target" | jq -r '.abi')
-            ZIP_NAME="Jellyfin.Plugin.SmartLists_${{ github.ref_name }}_${TARGET_ABI}.zip"
+            ZIP_NAME="Jellyfin.Plugin.SmartLists_${GITHUB_REF_NAME}_${TARGET_ABI}.zip"
             CHECKSUM=$(md5sum "../${ZIP_NAME}" | cut -d' ' -f1 | tr '[:lower:]' '[:upper:]')
-            DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${ZIP_NAME}"
+            DOWNLOAD_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/${ZIP_NAME}"
             NEW_PACKAGE=$(jq -n \
               --arg version "$ASSEMBLY_VERSION" \
               --arg abi "$TARGET_ABI" \
@@ -168,8 +168,8 @@ jobs:
           CHANGELOG_BODY: ${{ steps.read_release.outputs.body }}
         run: |
           # Strip preview/rc suffixes for .NET versioning
-          VERSION=$(echo "${{ github.ref_name }}" | sed -E 's/(preview|rc).*$//' | sed 's/v//' | sed 's/-$//')
-          FULL_VERSION=$(echo "${{ github.ref_name }}" | sed 's/v//')
+          VERSION=$(echo "$GITHUB_REF_NAME" | sed -E 's/(preview|rc).*$//' | sed 's/v//' | sed 's/-$//')
+          FULL_VERSION=$(echo "$GITHUB_REF_NAME" | sed 's/v//')
           TIMESTAMP=$(date -u +'%Y-%m-%d')
           # Sanitize changelog: remove trailing "by @user in <link>" fragments GitHub adds
           CLEAN_CHANGELOG=$(echo "$CHANGELOG_BODY" | sed -E 's/[[:space:]]*by @[[:alnum:]-]+ in https?:\/\/[^[:space:]]+//g')
@@ -203,9 +203,9 @@ jobs:
 
           echo "$TARGETS" | jq -c '.[]' | while read -r target; do
             TARGET_ABI=$(echo "$target" | jq -r '.abi')
-            ZIP_NAME="Jellyfin.Plugin.SmartLists_${{ github.ref_name }}_${TARGET_ABI}.zip"
+            ZIP_NAME="Jellyfin.Plugin.SmartLists_${GITHUB_REF_NAME}_${TARGET_ABI}.zip"
             CHECKSUM=$(md5sum "../${ZIP_NAME}" | cut -d' ' -f1 | tr '[:lower:]' '[:upper:]')
-            DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${ZIP_NAME}"
+            DOWNLOAD_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/${ZIP_NAME}"
             NEW_PACKAGE=$(jq -n \
               --arg version "$VERSION" \
               --arg abi "$TARGET_ABI" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,9 @@ on:
       - 'v*'
 
 env:
-  DOTNET_VERSION: 9.0.x
+  DOTNET_VERSION: 10.0.x
   PRERELEASE_STR: false
-  TARGET_ABI: 10.11.0
+  TARGETS: '[{"abi":"10.11.0","framework":"net9.0"},{"abi":"12.0.0","framework":"net10.0"}]'
 
 jobs:
   build:
@@ -49,27 +49,37 @@ jobs:
           # Strip preview/rc suffixes for .NET versioning
           VERSION=$(echo "${{ github.ref_name }}" | sed -E 's/(preview|rc).*$//' | sed 's/v//' | sed 's/-$//')
           echo "Building version: $VERSION (stripped from tag: ${{ github.ref_name }})"
-          dotnet build Jellyfin.Plugin.SmartLists/Jellyfin.Plugin.SmartLists.csproj \
-            --configuration Release --no-restore -o ./build_output \
-            /p:Version=$VERSION /p:AssemblyVersion=$VERSION
+          echo "$TARGETS" | jq -c '.[]' | while read -r target; do
+            TARGET_ABI=$(echo "$target" | jq -r '.abi')
+            TARGET_FRAMEWORK=$(echo "$target" | jq -r '.framework')
+            echo "Building Jellyfin ABI ${TARGET_ABI} (${TARGET_FRAMEWORK})"
+            dotnet build Jellyfin.Plugin.SmartLists/Jellyfin.Plugin.SmartLists.csproj \
+              --framework "$TARGET_FRAMEWORK" \
+              --configuration Release --no-restore -o "./build_output/${TARGET_ABI}" \
+              /p:Version=$VERSION /p:AssemblyVersion=$VERSION
+          done
 
       - name: Create Plugin Zip
         run: |
-          mkdir -p staging
-          cp ./build_output/Jellyfin.Plugin.SmartLists.dll staging/
-          cp ./build_output/SixLabors.ImageSharp.dll staging/
-          cp ./build_output/Jellyfin.Plugin.SmartLists.deps.json staging/
-          cp images/logo.jpg staging/logo.jpg
-          cd staging
-          zip -X ../Jellyfin.Plugin.SmartLists_${{ github.ref_name }}.zip *
-          cd ..
+          echo "$TARGETS" | jq -c '.[]' | while read -r target; do
+            TARGET_ABI=$(echo "$target" | jq -r '.abi')
+            STAGING_DIR="staging/${TARGET_ABI}"
+            mkdir -p "$STAGING_DIR"
+            cp "./build_output/${TARGET_ABI}/Jellyfin.Plugin.SmartLists.dll" "$STAGING_DIR/"
+            cp "./build_output/${TARGET_ABI}/SixLabors.ImageSharp.dll" "$STAGING_DIR/"
+            cp "./build_output/${TARGET_ABI}/Jellyfin.Plugin.SmartLists.deps.json" "$STAGING_DIR/"
+            cp images/logo.jpg "$STAGING_DIR/logo.jpg"
+            cd "$STAGING_DIR"
+            zip -X "../../Jellyfin.Plugin.SmartLists_${{ github.ref_name }}_${TARGET_ABI}.zip" *
+            cd ../..
+          done
 
       - name: Create Release (auto notes from PRs)
         id: create_release
         uses: softprops/action-gh-release@v2
         with:
           name: Release ${{ github.ref_name }}
-          files: ./Jellyfin.Plugin.SmartLists_${{ github.ref_name }}.zip
+          files: ./Jellyfin.Plugin.SmartLists_${{ github.ref_name }}_*.zip
           draft: false
           # Use the dynamically determined prerelease status
           prerelease: ${{ steps.check_preview.outputs.is_preview }}
@@ -100,10 +110,6 @@ jobs:
           # Strip preview/rc suffixes for .NET versioning
           VERSION=$(echo "${{ github.ref_name }}" | sed -E 's/(preview|rc).*$//' | sed 's/v//' | sed 's/-$//')
           ASSEMBLY_VERSION="${VERSION}"
-          ZIP_NAME="Jellyfin.Plugin.SmartLists_${{ github.ref_name }}.zip"
-          CHECKSUM=$(md5sum ${ZIP_NAME} | cut -d' ' -f1 | tr '[:lower:]' '[:upper:]')
-          DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${ZIP_NAME}"
-          TARGET_ABI="${{ env.TARGET_ABI }}"
           TIMESTAMP=$(date -u +'%Y-%m-%d')
           # Sanitize changelog: remove trailing "by @user in <link>" fragments GitHub adds
           CLEAN_CHANGELOG=$(echo "$CHANGELOG_BODY" | sed -E 's/[[:space:]]*by @[[:alnum:]-]+ in https?:\/\/[^[:space:]]+//g')
@@ -118,15 +124,6 @@ jobs:
             echo "[]" > "$MANIFEST_FILE"
           fi
 
-          NEW_PACKAGE=$(jq -n \
-            --arg version "$ASSEMBLY_VERSION" \
-            --arg abi "$TARGET_ABI" \
-            --arg url "$DOWNLOAD_URL" \
-            --arg checksum "$CHECKSUM" \
-            --arg changelog "$CLEAN_CHANGELOG" \
-            --arg timestamp "$TIMESTAMP" \
-            '{version: $version, targetAbi: $abi, sourceUrl: $url, checksum: $checksum, changelog: $changelog, timestamp: $timestamp}')
-
           if ! jq -e --arg guid "$PLUGIN_GUID" 'any(.[]; .guid == $guid)' "$MANIFEST_FILE" > /dev/null; then
             PLUGIN_ENTRY=$(jq -n \
               --arg name "SmartLists" \
@@ -140,9 +137,23 @@ jobs:
             jq --argjson new_entry "$PLUGIN_ENTRY" '. += [$new_entry]' "$MANIFEST_FILE" > tmp && mv tmp "$MANIFEST_FILE"
           fi
 
-          jq --argjson new_package "$NEW_PACKAGE" --arg guid "$PLUGIN_GUID" \
-            '(.[] | select(.guid == $guid).versions) |= [$new_package] + .' \
-            "$MANIFEST_FILE" > tmp_manifest.json && mv tmp_manifest.json "$MANIFEST_FILE"
+          echo "$TARGETS" | jq -c '.[]' | while read -r target; do
+            TARGET_ABI=$(echo "$target" | jq -r '.abi')
+            ZIP_NAME="Jellyfin.Plugin.SmartLists_${{ github.ref_name }}_${TARGET_ABI}.zip"
+            CHECKSUM=$(md5sum "../${ZIP_NAME}" | cut -d' ' -f1 | tr '[:lower:]' '[:upper:]')
+            DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${ZIP_NAME}"
+            NEW_PACKAGE=$(jq -n \
+              --arg version "$ASSEMBLY_VERSION" \
+              --arg abi "$TARGET_ABI" \
+              --arg url "$DOWNLOAD_URL" \
+              --arg checksum "$CHECKSUM" \
+              --arg changelog "$CLEAN_CHANGELOG" \
+              --arg timestamp "$TIMESTAMP" \
+              '{version: $version, targetAbi: $abi, sourceUrl: $url, checksum: $checksum, changelog: $changelog, timestamp: $timestamp}')
+            jq --argjson new_package "$NEW_PACKAGE" --arg guid "$PLUGIN_GUID" \
+              '(.[] | select(.guid == $guid).versions) |= [$new_package] + .' \
+              "$MANIFEST_FILE" > tmp_manifest.json && mv tmp_manifest.json "$MANIFEST_FILE"
+          done
 
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
@@ -159,10 +170,6 @@ jobs:
           # Strip preview/rc suffixes for .NET versioning
           VERSION=$(echo "${{ github.ref_name }}" | sed -E 's/(preview|rc).*$//' | sed 's/v//' | sed 's/-$//')
           FULL_VERSION=$(echo "${{ github.ref_name }}" | sed 's/v//')
-          ZIP_NAME="Jellyfin.Plugin.SmartLists_${{ github.ref_name }}.zip"
-          CHECKSUM=$(md5sum ${ZIP_NAME} | cut -d' ' -f1 | tr '[:lower:]' '[:upper:]')
-          DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${ZIP_NAME}"
-          TARGET_ABI="${{ env.TARGET_ABI }}"
           TIMESTAMP=$(date -u +'%Y-%m-%d')
           # Sanitize changelog: remove trailing "by @user in <link>" fragments GitHub adds
           CLEAN_CHANGELOG=$(echo "$CHANGELOG_BODY" | sed -E 's/[[:space:]]*by @[[:alnum:]-]+ in https?:\/\/[^[:space:]]+//g')
@@ -181,15 +188,6 @@ jobs:
             echo "[]" > "$MANIFEST_FILE"
           fi
 
-          NEW_PACKAGE=$(jq -n \
-            --arg version "$VERSION" \
-            --arg abi "$TARGET_ABI" \
-            --arg url "$DOWNLOAD_URL" \
-            --arg checksum "$CHECKSUM" \
-            --arg changelog "$CLEAN_CHANGELOG" \
-            --arg timestamp "$TIMESTAMP" \
-            '{version: $version, targetAbi: $abi, sourceUrl: $url, checksum: $checksum, changelog: $changelog, timestamp: $timestamp}')
-
           if ! jq -e --arg guid "$PLUGIN_GUID" 'any(.[]; .guid == $guid)' "$MANIFEST_FILE" > /dev/null; then
             PLUGIN_ENTRY=$(jq -n \
               --arg name "SmartLists" \
@@ -203,9 +201,23 @@ jobs:
             jq --argjson new_entry "$PLUGIN_ENTRY" '. += [$new_entry]' "$MANIFEST_FILE" > tmp && mv tmp "$MANIFEST_FILE"
           fi
 
-          jq --argjson new_package "$NEW_PACKAGE" --arg guid "$PLUGIN_GUID" \
-            '(.[] | select(.guid == $guid).versions) |= [$new_package] + .' \
-            "$MANIFEST_FILE" > tmp_manifest.json && mv tmp_manifest.json "$MANIFEST_FILE"
+          echo "$TARGETS" | jq -c '.[]' | while read -r target; do
+            TARGET_ABI=$(echo "$target" | jq -r '.abi')
+            ZIP_NAME="Jellyfin.Plugin.SmartLists_${{ github.ref_name }}_${TARGET_ABI}.zip"
+            CHECKSUM=$(md5sum "../${ZIP_NAME}" | cut -d' ' -f1 | tr '[:lower:]' '[:upper:]')
+            DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${ZIP_NAME}"
+            NEW_PACKAGE=$(jq -n \
+              --arg version "$VERSION" \
+              --arg abi "$TARGET_ABI" \
+              --arg url "$DOWNLOAD_URL" \
+              --arg checksum "$CHECKSUM" \
+              --arg changelog "$CLEAN_CHANGELOG" \
+              --arg timestamp "$TIMESTAMP" \
+              '{version: $version, targetAbi: $abi, sourceUrl: $url, checksum: $checksum, changelog: $changelog, timestamp: $timestamp}')
+            jq --argjson new_package "$NEW_PACKAGE" --arg guid "$PLUGIN_GUID" \
+              '(.[] | select(.guid == $guid).versions) |= [$new_package] + .' \
+              "$MANIFEST_FILE" > tmp_manifest.json && mv tmp_manifest.json "$MANIFEST_FILE"
+          done
 
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'

--- a/Jellyfin.Plugin.SmartLists/Core/Models/SmartListDto.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Models/SmartListDto.cs
@@ -12,9 +12,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.Models
     /// Contains all shared properties and logic
     /// </summary>
     [Serializable]
-    [JsonPolymorphic(TypeDiscriminatorPropertyName = "Type")]
-    [JsonDerivedType(typeof(SmartPlaylistDto), typeDiscriminator: "Playlist")]
-    [JsonDerivedType(typeof(SmartCollectionDto), typeDiscriminator: "Collection")]
+    [JsonConverter(typeof(SmartListDtoJsonConverter))]
     public abstract class SmartListDto
     {
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Core/Models/SmartListDtoJsonConverter.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Models/SmartListDtoJsonConverter.cs
@@ -39,26 +39,50 @@ namespace Jellyfin.Plugin.SmartLists.Core.Models
 
         private static SmartListType GetListType(JsonElement root)
         {
-            if (!root.TryGetProperty("Type", out var typeElement))
+            if (!TryGetProperty(root, "Type", out var typeElement))
             {
-                return SmartListType.Playlist;
+                throw new JsonException("Smart list JSON is missing required Type property.");
             }
 
             if (typeElement.ValueKind == JsonValueKind.String
                 && Enum.TryParse<SmartListType>(typeElement.GetString(), ignoreCase: true, out var stringType))
             {
+                if (!Enum.IsDefined(stringType))
+                {
+                    throw new JsonException($"Smart list Type value '{typeElement.GetString()}' is not supported.");
+                }
+
                 return stringType;
             }
 
             if (typeElement.ValueKind == JsonValueKind.Number
                 && typeElement.TryGetInt32(out var numericType))
             {
-                return numericType == (int)SmartListType.Collection
-                    ? SmartListType.Collection
-                    : SmartListType.Playlist;
+                var listType = (SmartListType)numericType;
+                if (!Enum.IsDefined(listType))
+                {
+                    throw new JsonException($"Smart list Type value '{numericType}' is not supported.");
+                }
+
+                return listType;
             }
 
-            return SmartListType.Playlist;
+            throw new JsonException("Smart list Type must be either a string or numeric SmartListType value.");
+        }
+
+        private static bool TryGetProperty(JsonElement root, string propertyName, out JsonElement value)
+        {
+            foreach (var property in root.EnumerateObject())
+            {
+                if (property.Name.Equals(propertyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    value = property.Value;
+                    return true;
+                }
+            }
+
+            value = default;
+            return false;
         }
     }
 }

--- a/Jellyfin.Plugin.SmartLists/Core/Models/SmartListDtoJsonConverter.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Models/SmartListDtoJsonConverter.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Jellyfin.Plugin.SmartLists.Core.Enums;
+
+namespace Jellyfin.Plugin.SmartLists.Core.Models
+{
+    /// <summary>
+    /// Converts the abstract SmartListDto using the existing public Type property.
+    /// </summary>
+    public class SmartListDtoJsonConverter : JsonConverter<SmartListDto>
+    {
+        public override SmartListDto? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            using var document = JsonDocument.ParseValue(ref reader);
+            var root = document.RootElement;
+            var listType = GetListType(root);
+            var json = root.GetRawText();
+
+            return listType == SmartListType.Collection
+                ? JsonSerializer.Deserialize<SmartCollectionDto>(json, options)
+                : JsonSerializer.Deserialize<SmartPlaylistDto>(json, options);
+        }
+
+        public override void Write(Utf8JsonWriter writer, SmartListDto value, JsonSerializerOptions options)
+        {
+            switch (value)
+            {
+                case SmartCollectionDto collection:
+                    JsonSerializer.Serialize(writer, collection, options);
+                    break;
+                case SmartPlaylistDto playlist:
+                    JsonSerializer.Serialize(writer, playlist, options);
+                    break;
+                default:
+                    throw new JsonException($"Unsupported smart list type: {value.GetType().FullName}");
+            }
+        }
+
+        private static SmartListType GetListType(JsonElement root)
+        {
+            if (!root.TryGetProperty("Type", out var typeElement))
+            {
+                return SmartListType.Playlist;
+            }
+
+            if (typeElement.ValueKind == JsonValueKind.String
+                && Enum.TryParse<SmartListType>(typeElement.GetString(), ignoreCase: true, out var stringType))
+            {
+                return stringType;
+            }
+
+            if (typeElement.ValueKind == JsonValueKind.Number
+                && typeElement.TryGetInt32(out var numericType))
+            {
+                return numericType == (int)SmartListType.Collection
+                    ? SmartListType.Collection
+                    : SmartListType.Playlist;
+            }
+
+            return SmartListType.Playlist;
+        }
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Jellyfin.Plugin.SmartLists.csproj
+++ b/Jellyfin.Plugin.SmartLists/Jellyfin.Plugin.SmartLists.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <RootNamespace>Jellyfin.Plugin.SmartLists</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn Condition="'$(TargetFramework)' == 'net10.0'">$(NoWarn);CA1873</NoWarn>
     <Nullable>enable</Nullable>
     <AnalysisMode>Recommended</AnalysisMode>
     <!-- Version will be set dynamically during build from git tag -->
@@ -58,8 +59,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.11.0" />
-    <PackageReference Include="Jellyfin.Model" Version="10.11.0" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.11.0" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="Jellyfin.Model" Version="10.11.0" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="Jellyfin.Controller" Version="12.0.0-rc1" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Jellyfin.Model" Version="12.0.0-rc1" Condition="'$(TargetFramework)' == 'net10.0'" />
     <!-- ImageSharp is bundled with the plugin as Jellyfin doesn't provide it -->
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12">
       <Private>true</Private>
@@ -81,4 +84,3 @@
   </ItemGroup>
 
 </Project>
-

--- a/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
@@ -293,7 +293,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
 
                 var newLinkedChildren = distinctNewItems
                     .Where(itemId => mediaLookup.ContainsKey(itemId))
-                    .Select(itemId => new LinkedChild { ItemId = itemId, Path = mediaLookup[itemId].Path })
+                    .Select(itemId => CreateLinkedChild(itemId, mediaLookup[itemId]))
                     .ToArray();
 
                 // Calculate collection statistics from the same filtered list used for the actual collection
@@ -2278,6 +2278,12 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                 mediaLookup[item.Id] = item;
             }
         }
+
+#if NET10_0_OR_GREATER
+        private static LinkedChild CreateLinkedChild(Guid itemId, BaseItem item) => new() { ItemId = itemId };
+#else
+        private static LinkedChild CreateLinkedChild(Guid itemId, BaseItem item) => new() { ItemId = itemId, Path = item.Path };
+#endif
 
     }
 }

--- a/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
@@ -293,7 +293,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
 
                 var newLinkedChildren = distinctNewItems
                     .Where(itemId => mediaLookup.ContainsKey(itemId))
-                    .Select(itemId => CreateLinkedChild(itemId, mediaLookup[itemId]))
+                    .Select(itemId => LinkedChildFactory.Create(itemId, mediaLookup[itemId]))
                     .ToArray();
 
                 // Calculate collection statistics from the same filtered list used for the actual collection
@@ -2278,12 +2278,6 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                 mediaLookup[item.Id] = item;
             }
         }
-
-#if NET10_0_OR_GREATER
-        private static LinkedChild CreateLinkedChild(Guid itemId, BaseItem item) => new() { ItemId = itemId };
-#else
-        private static LinkedChild CreateLinkedChild(Guid itemId, BaseItem item) => new() { ItemId = itemId, Path = item.Path };
-#endif
 
     }
 }

--- a/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
@@ -183,7 +183,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                 var newLinkedChildren = newItems
                     .Distinct()
                     .Where(itemId => mediaLookup.ContainsKey(itemId))
-                    .Select(itemId => CreateLinkedChild(itemId, mediaLookup[itemId]))
+                    .Select(itemId => LinkedChildFactory.Create(itemId, mediaLookup[itemId]))
                     .ToArray();
 
                 // Calculate playlist statistics from the same filtered list used for the actual playlist
@@ -1211,12 +1211,6 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                 }
             }
         }
-
-#if NET10_0_OR_GREATER
-        private static LinkedChild CreateLinkedChild(Guid itemId, BaseItem item) => new() { ItemId = itemId };
-#else
-        private static LinkedChild CreateLinkedChild(Guid itemId, BaseItem item) => new() { ItemId = itemId, Path = item.Path };
-#endif
 
     }
 }

--- a/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
@@ -183,7 +183,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                 var newLinkedChildren = newItems
                     .Distinct()
                     .Where(itemId => mediaLookup.ContainsKey(itemId))
-                    .Select(itemId => new LinkedChild { ItemId = itemId, Path = mediaLookup[itemId].Path })
+                    .Select(itemId => CreateLinkedChild(itemId, mediaLookup[itemId]))
                     .ToArray();
 
                 // Calculate playlist statistics from the same filtered list used for the actual playlist
@@ -1211,6 +1211,12 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                 }
             }
         }
+
+#if NET10_0_OR_GREATER
+        private static LinkedChild CreateLinkedChild(Guid itemId, BaseItem item) => new() { ItemId = itemId };
+#else
+        private static LinkedChild CreateLinkedChild(Guid itemId, BaseItem item) => new() { ItemId = itemId, Path = item.Path };
+#endif
 
     }
 }

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/BasicDirectoryService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/BasicDirectoryService.cs
@@ -17,7 +17,10 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
         public FileSystemMetadata? GetDirectory(string path) => null;
         public FileSystemMetadata? GetFileSystemEntry(string path) => null;
         public IReadOnlyList<string> GetFilePaths(string path) => [];
-        public IReadOnlyList<string> GetFilePaths(string path, bool clearCache, bool sort) => [];
+#if NET10_0_OR_GREATER
+        public IReadOnlyList<string> GetFilePaths(string path, bool clearCache) => GetFilePaths(path);
+#endif
+        public IReadOnlyList<string> GetFilePaths(string path, bool clearCache, bool sort) => GetFilePaths(path);
         public bool IsAccessible(string path) => false;
     }
 }

--- a/Jellyfin.Plugin.SmartLists/Utilities/LibraryManagerHelper.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/LibraryManagerHelper.cs
@@ -209,7 +209,8 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
 
             foreach (var parent in parents)
             {
-                if (parent.ExtraIds == null || parent.ExtraIds.Length == 0)
+                var extras = parent.GetExtras().ToArray();
+                if (extras.Length == 0)
                 {
                     continue;
                 }
@@ -228,7 +229,7 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
                     }
                 }
 
-                foreach (var extra in parent.GetExtras())
+                foreach (var extra in extras)
                 {
                     if (seenIds.Add(extra.Id))
                     {

--- a/Jellyfin.Plugin.SmartLists/Utilities/LinkedChildFactory.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/LinkedChildFactory.cs
@@ -1,0 +1,23 @@
+using System;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Model.Entities;
+
+namespace Jellyfin.Plugin.SmartLists.Utilities
+{
+    /// <summary>
+    /// Creates LinkedChild instances with the correct shape for the target Jellyfin ABI.
+    /// </summary>
+    public static class LinkedChildFactory
+    {
+        public static LinkedChild Create(Guid itemId, BaseItem item)
+        {
+            ArgumentNullException.ThrowIfNull(item);
+
+#if NET10_0_OR_GREATER
+            return new LinkedChild { ItemId = itemId };
+#else
+            return new LinkedChild { ItemId = itemId, Path = item.Path };
+#endif
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <div align="center">
     <p>
         <img alt="Logo" src="https://raw.githubusercontent.com/jyourstone/jellyfin-smartlists-plugin/main/images/logo.jpg" height="350"/><br />
-        <a href="https://github.com/jyourstone/jellyfin-smartlists-plugin/releases"><img alt="Total GitHub Downloads" src="https://img.shields.io/github/downloads/jyourstone/jellyfin-smartlists-plugin/total"/></a> <a href="https://github.com/jyourstone/jellyfin-smartlists-plugin/issues"><img alt="GitHub Issues or Pull Requests" src="https://img.shields.io/github/issues/jyourstone/jellyfin-smartlists-plugin"/></a> <a href="https://github.com/jyourstone/jellyfin-smartlists-plugin/releases"><img alt="Build and Release" src="https://github.com/jyourstone/jellyfin-smartlists-plugin/actions/workflows/release.yml/badge.svg"/></a> <a href="https://jellyfin.org/"><img alt="Jellyfin Version" src="https://img.shields.io/badge/Jellyfin-10.11-blue.svg"/></a>
+        <a href="https://github.com/jyourstone/jellyfin-smartlists-plugin/releases"><img alt="Total GitHub Downloads" src="https://img.shields.io/github/downloads/jyourstone/jellyfin-smartlists-plugin/total"/></a> <a href="https://github.com/jyourstone/jellyfin-smartlists-plugin/issues"><img alt="GitHub Issues or Pull Requests" src="https://img.shields.io/github/issues/jyourstone/jellyfin-smartlists-plugin"/></a> <a href="https://github.com/jyourstone/jellyfin-smartlists-plugin/releases"><img alt="Build and Release" src="https://github.com/jyourstone/jellyfin-smartlists-plugin/actions/workflows/release.yml/badge.svg"/></a> <a href="https://jellyfin.org/"><img alt="Jellyfin Version" src="https://img.shields.io/badge/Jellyfin-10.11%20%7C%2012.x-blue.svg"/></a>
     </p>        
 </div>
 

--- a/dev/build-local.ps1
+++ b/dev/build-local.ps1
@@ -5,11 +5,31 @@
 
 $ErrorActionPreference = "Stop" # Exit immediately if a command fails
 
-# Set the version for the build. For local testing, this can be a static string.
-$VERSION = "10.11.0.0"
+# Set the Jellyfin ABI for local testing. Defaults to Jellyfin 12 RC/dev.
+$JellyfinAbi = $env:JELLYFIN_ABI
+if ([string]::IsNullOrWhiteSpace($JellyfinAbi)) {
+    $JellyfinAbi = "12.0.0"
+}
+
+$VERSION = $env:VERSION
+if ([string]::IsNullOrWhiteSpace($VERSION)) {
+    $VERSION = "$JellyfinAbi.0"
+}
+
+$TargetFramework = $env:TARGET_FRAMEWORK
+if ([string]::IsNullOrWhiteSpace($TargetFramework)) {
+    if ($JellyfinAbi.StartsWith("10.11.")) {
+        $TargetFramework = "net9.0"
+    } elseif ($JellyfinAbi.StartsWith("12.")) {
+        $TargetFramework = "net10.0"
+    } else {
+        throw "Unsupported JELLYFIN_ABI '$JellyfinAbi'. Expected 10.11.x or 12.x."
+    }
+}
+
 $OUTPUT_DIR = "..\build_output"
 
-Write-Host "Building SmartLists plugin version for local development..."
+Write-Host "Building SmartLists plugin for Jellyfin ABI $JellyfinAbi ($TargetFramework)..."
 
 # Clean the previous build output
 if (Test-Path $OUTPUT_DIR) {
@@ -18,10 +38,16 @@ if (Test-Path $OUTPUT_DIR) {
 New-Item -ItemType Directory -Path $OUTPUT_DIR -Force | Out-Null
 
 # Build the project
-dotnet build ..\Jellyfin.Plugin.SmartLists\Jellyfin.Plugin.SmartLists.csproj --configuration Release -o $OUTPUT_DIR /p:Version=$VERSION /p:AssemblyVersion=$VERSION
+dotnet build ..\Jellyfin.Plugin.SmartLists\Jellyfin.Plugin.SmartLists.csproj --framework $TargetFramework --configuration Release -o $OUTPUT_DIR /p:Version=$VERSION /p:AssemblyVersion=$VERSION
 
-# Copy the dev meta.json file, as it's required by Jellyfin to load the plugin
-Copy-Item -Path "meta-dev.json" -Destination "$OUTPUT_DIR\meta.json"
+# Write the dev meta.json file, as it's required by Jellyfin to load the plugin
+$meta = [ordered]@{
+    guid = "A0A2A7B2-747A-4113-8B39-757A9D267C79"
+    version = $VERSION
+    targetAbi = $JellyfinAbi
+    imagePath = "logo.jpg"
+}
+$meta | ConvertTo-Json | Set-Content -Path "$OUTPUT_DIR\meta.json" -Encoding UTF8
 
 # Copy the logo image for local plugin display
 Copy-Item -Path "..\images\logo.jpg" -Destination "$OUTPUT_DIR\logo.jpg"

--- a/dev/build-local.sh
+++ b/dev/build-local.sh
@@ -5,21 +5,41 @@
 
 set -e # Exit immediately if a command exits with a non-zero status.
 
-# Set the version for the build. For local testing, this can be a static string.
-VERSION="10.11.0.0"
+# Set the Jellyfin ABI for local testing. Defaults to Jellyfin 12 RC/dev.
+JELLYFIN_ABI="${JELLYFIN_ABI:-12.0.0}"
+VERSION="${VERSION:-${JELLYFIN_ABI}.0}"
+case "$JELLYFIN_ABI" in
+    10.11.*)
+        TARGET_FRAMEWORK="${TARGET_FRAMEWORK:-net9.0}"
+        ;;
+    12.*)
+        TARGET_FRAMEWORK="${TARGET_FRAMEWORK:-net10.0}"
+        ;;
+    *)
+        echo "Unsupported JELLYFIN_ABI '$JELLYFIN_ABI'. Expected 10.11.x or 12.x."
+        exit 1
+        ;;
+esac
 OUTPUT_DIR="../build_output"
 
-echo "Building SmartLists plugin version for local development..."
+echo "Building SmartLists plugin for Jellyfin ABI $JELLYFIN_ABI ($TARGET_FRAMEWORK)..."
 
 # Clean the previous build output
 rm -rf $OUTPUT_DIR
 mkdir -p $OUTPUT_DIR
 
 # Build the project
-dotnet build ../Jellyfin.Plugin.SmartLists/Jellyfin.Plugin.SmartLists.csproj --configuration Release -o $OUTPUT_DIR /p:Version=$VERSION /p:AssemblyVersion=$VERSION
+dotnet build ../Jellyfin.Plugin.SmartLists/Jellyfin.Plugin.SmartLists.csproj --framework "$TARGET_FRAMEWORK" --configuration Release -o "$OUTPUT_DIR" /p:Version="$VERSION" /p:AssemblyVersion="$VERSION"
 
-# Copy the dev meta.json file, as it's required by Jellyfin to load the plugin
-cp meta-dev.json $OUTPUT_DIR/meta.json
+# Write the dev meta.json file, as it's required by Jellyfin to load the plugin
+cat > "$OUTPUT_DIR/meta.json" <<EOF
+{
+  "guid": "A0A2A7B2-747A-4113-8B39-757A9D267C79",
+  "version": "$VERSION",
+  "targetAbi": "$JELLYFIN_ABI",
+  "imagePath": "logo.jpg"
+}
+EOF
 
 # Copy the logo image for local plugin display
 cp ../images/logo.jpg $OUTPUT_DIR/logo.jpg
@@ -40,4 +60,4 @@ docker compose up --detach
 
 echo ""
 echo "Jellyfin container is up and running."
-echo "You can access it at: http://localhost:8096" 
+echo "You can access it at: http://localhost:8096"

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   jellyfin:
-    image: jellyfin/jellyfin:10.11.10
+    image: jellyfin/jellyfin:12.0-rc1
     container_name: jellyfin
     user: 1000:1000
     environment:

--- a/dev/meta-dev.json
+++ b/dev/meta-dev.json
@@ -1,6 +1,6 @@
 {
   "guid": "A0A2A7B2-747A-4113-8B39-757A9D267C79",
-  "version": "10.11.0.0",
-  "targetAbi": "10.11.0",
+  "version": "12.0.0.0",
+  "targetAbi": "12.0.0",
   "imagePath": "logo.jpg"
 }

--- a/docs/content/development/building-locally.md
+++ b/docs/content/development/building-locally.md
@@ -44,9 +44,22 @@ cd dev
 ```
 
 The build scripts automatically:
-- Build the plugin
+- Build the plugin for the configured Jellyfin ABI
 - Restart the Jellyfin Docker container
 - Make the plugin available in your local Jellyfin instance
+
+By default, the scripts build for Jellyfin ABI `12.0.0` using `net10.0`, which matches the Jellyfin 12 RC development container. To test against Jellyfin 10.11, set `JELLYFIN_ABI=10.11.0` before running the script:
+
+```bash
+cd dev
+JELLYFIN_ABI=10.11.0 ./build-local.sh
+```
+
+```powershell
+cd dev
+$env:JELLYFIN_ABI = "10.11.0"
+.\build-local.ps1
+```
 
 ### 2. Access Jellyfin
 
@@ -86,4 +99,4 @@ dev/jellyfin-data/config/log/
 
 ### Development Metadata
 
-**`meta-dev.json`** is a development-specific plugin manifest. It overrides the main `meta.json` during local builds to ensure the plugin works correctly in the development environment.
+**`meta-dev.json`** is a development-specific plugin manifest for the default Jellyfin 12 development setup. The build scripts generate `build_output/meta.json` from the selected `JELLYFIN_ABI` value during local builds.

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -6,7 +6,7 @@
         <a href="https://github.com/jyourstone/jellyfin-smartlists-plugin/releases"><img alt="Total GitHub Downloads" src="https://img.shields.io/github/downloads/jyourstone/jellyfin-smartlists-plugin/total"/></a> 
         <a href="https://github.com/jyourstone/jellyfin-smartlists-plugin/issues"><img alt="GitHub Issues or Pull Requests" src="https://img.shields.io/github/issues/jyourstone/jellyfin-smartlists-plugin"/></a> 
         <a href="https://github.com/jyourstone/jellyfin-smartlists-plugin/releases"><img alt="Build and Release" src="https://github.com/jyourstone/jellyfin-smartlists-plugin/actions/workflows/release.yml/badge.svg"/></a> 
-        <a href="https://jellyfin.org/"><img alt="Jellyfin Version" src="https://img.shields.io/badge/Jellyfin-10.11-blue.svg"/></a>
+        <a href="https://jellyfin.org/"><img alt="Jellyfin Version" src="https://img.shields.io/badge/Jellyfin-10.11%20%7C%2012.x-blue.svg"/></a>
     </p>        
 </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-ABI support: builds and packages framework-optimized artifacts for Jellyfin 10.11 and 12.x, with ABI-specific ZIPs and release uploads.
* **Bug Fixes**
  * Updated SmartList DTO JSON handling to correctly serialize/deserialize smart playlists and collections via a dedicated converter.
  * Improved refresh and extra-fetch logic to better handle linked items and extras.
* **Documentation**
  * Expanded local build docs and version badge to reflect multiple supported Jellyfin ranges.
* **Chores**
  * Refined build/release automation to iterate per-ABI and generate per-ABI manifest updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->