### PR TITLE
Added a new random group selection feature

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Configuration/config-core.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-core.js
@@ -102,6 +102,16 @@
         { value: 'Studios', label: 'Studio (first)', mediaTypes: null }
     ];
 
+    SmartLists.RANDOM_GROUP_FIELDS = [
+        { value: 'Artists', label: 'Artist', mediaTypes: ['Audio', 'MusicVideo'] },
+        { value: 'AlbumArtists', label: 'Album Artist', mediaTypes: ['Audio', 'MusicVideo'] },
+        { value: 'Album', label: 'Album', mediaTypes: ['Audio', 'MusicVideo'] },
+        { value: 'SeriesName', label: 'Series Name', mediaTypes: ['Episode'] },
+        { value: 'Genres', label: 'Genre', mediaTypes: null },
+        { value: 'Studios', label: 'Studio', mediaTypes: null },
+        { value: 'Tags', label: 'Tag', mediaTypes: null }
+    ];
+
     // Sort fields that support child value aggregation (for collections containing collections/playlists)
     // When enabled, sort values are calculated from the Max of child items (e.g., newest DateCreated among children)
     SmartLists.CHILD_VALUE_SORT_FIELDS = ['ProductionYear', 'CommunityRating', 'DateCreated', 'ReleaseDate'];

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
@@ -337,6 +337,9 @@
             if (SmartLists.updateAllSortOptionsVisibility) {
                 SmartLists.updateAllSortOptionsVisibility(page);
             }
+            if (SmartLists.syncRandomGroupSelectionUI) {
+                SmartLists.syncRandomGroupSelectionUI(page);
+            }
 
             // 4) Update Include Extras checkbox visibility based on media types
             if (SmartLists.updateIncludeExtrasVisibility) {
@@ -1254,6 +1257,15 @@
                 e.preventDefault();
                 if (SmartLists.createPlaylist) {
                     SmartLists.createPlaylist(page);
+                }
+            }, SmartLists.getEventListenerOptions(pageSignal));
+        }
+
+        const randomGroupSelectionEnabled = page.querySelector('#randomGroupSelectionEnabled');
+        if (randomGroupSelectionEnabled) {
+            randomGroupSelectionEnabled.addEventListener('change', function () {
+                if (SmartLists.syncRandomGroupSelectionUI) {
+                    SmartLists.syncRandomGroupSelectionUI(page);
                 }
             }, SmartLists.getEventListenerOptions(pageSignal));
         }
@@ -2710,6 +2722,9 @@
         // Update "Use Child Values" checkbox visibility in sort boxes when switching between Playlist/Collection
         if (SmartLists.updateUseChildValuesVisibility) {
             SmartLists.updateUseChildValuesVisibility(page);
+        }
+        if (SmartLists.syncRandomGroupSelectionUI) {
+            SmartLists.syncRandomGroupSelectionUI(page);
         }
 
         // Update Include Extras checkbox visibility based on media types

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -76,6 +76,10 @@
         if (!enabled) return null;
 
         var groupBy = SmartLists.getElementValue(page, '#randomGroupSelectionGroupBy', '');
+        // Guard against an incomplete config reaching the server: Random Group Selection
+        // is only valid when a non-empty Group By field is selected.
+        if (!groupBy) return null;
+
         var minimumItemsInput = SmartLists.getElementValue(page, '#randomGroupSelectionMinimumItems', '');
         var minimumItems = 0;
         if (minimumItemsInput !== '') {

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -19,6 +19,99 @@
         return userId.replace(/-/g, '').toLowerCase();
     };
 
+    SmartLists.getFilteredRandomGroupFields = function (page) {
+        var selectedMediaTypes = SmartLists.getSelectedMediaTypes(page);
+        return (SmartLists.RANDOM_GROUP_FIELDS || []).filter(function (field) {
+            if (!field.mediaTypes) return true;
+            if (!selectedMediaTypes || selectedMediaTypes.length === 0) return true;
+            for (var i = 0; i < field.mediaTypes.length; i++) {
+                if (selectedMediaTypes.indexOf(field.mediaTypes[i]) !== -1) return true;
+            }
+            return false;
+        });
+    };
+
+    SmartLists.getRandomGroupFieldLabel = function (fieldValue) {
+        var fields = SmartLists.RANDOM_GROUP_FIELDS || [];
+        for (var i = 0; i < fields.length; i++) {
+            if (fields[i].value === fieldValue) {
+                return fields[i].label;
+            }
+        }
+        return fieldValue || '';
+    };
+
+    SmartLists.syncRandomGroupSelectionUI = function (page, selectedGroupBy) {
+        var enabledCheckbox = page.querySelector('#randomGroupSelectionEnabled');
+        var fieldsContainer = page.querySelector('#randomGroupSelectionFields');
+        var groupBySelect = page.querySelector('#randomGroupSelectionGroupBy');
+        if (!enabledCheckbox || !fieldsContainer || !groupBySelect) return;
+
+        fieldsContainer.style.display = enabledCheckbox.checked ? '' : 'none';
+
+        var currentValue = selectedGroupBy || groupBySelect.value;
+        var filteredFields = SmartLists.getFilteredRandomGroupFields(page);
+        var options = filteredFields.map(function (field) {
+            return {
+                value: field.value,
+                label: field.label,
+                selected: field.value === currentValue
+            };
+        });
+
+        SmartLists.populateSelectElement(groupBySelect, options);
+
+        var isCurrentValueValid = filteredFields.some(function (field) {
+            return field.value === currentValue;
+        });
+        if (isCurrentValueValid) {
+            groupBySelect.value = currentValue;
+        } else if (filteredFields.length > 0) {
+            groupBySelect.value = filteredFields[0].value;
+        }
+    };
+
+    SmartLists.collectRandomGroupSelectionFromForm = function (page) {
+        var enabled = SmartLists.getElementChecked(page, '#randomGroupSelectionEnabled', false);
+        if (!enabled) return null;
+
+        var groupBy = SmartLists.getElementValue(page, '#randomGroupSelectionGroupBy', '');
+        var minimumItemsInput = SmartLists.getElementValue(page, '#randomGroupSelectionMinimumItems', '');
+        var minimumItems = 0;
+        if (minimumItemsInput !== '') {
+            var parsedMinimum = parseInt(minimumItemsInput, 10);
+            minimumItems = (isNaN(parsedMinimum) || parsedMinimum < 0) ? 0 : parsedMinimum;
+        }
+
+        return {
+            Enabled: true,
+            GroupBy: groupBy,
+            MinimumItems: minimumItems
+        };
+    };
+
+    SmartLists.loadRandomGroupSelectionIntoUI = function (page, playlist) {
+        var selection = playlist && playlist.RandomGroupSelection ? playlist.RandomGroupSelection : null;
+        var enabled = selection && selection.Enabled === true;
+
+        SmartLists.setElementChecked(page, '#randomGroupSelectionEnabled', enabled);
+        SmartLists.setElementValue(page, '#randomGroupSelectionMinimumItems', enabled && selection.MinimumItems ? selection.MinimumItems : '');
+        SmartLists.syncRandomGroupSelectionUI(page, enabled ? selection.GroupBy : null);
+    };
+
+    SmartLists.formatRandomGroupSelectionDisplay = function (playlist) {
+        var selection = playlist && playlist.RandomGroupSelection ? playlist.RandomGroupSelection : null;
+        if (!selection || selection.Enabled !== true || !selection.GroupBy) {
+            return 'Disabled';
+        }
+
+        var text = 'Random ' + SmartLists.getRandomGroupFieldLabel(selection.GroupBy);
+        if (selection.MinimumItems && selection.MinimumItems > 0) {
+            text += ' (min ' + selection.MinimumItems + ' items)';
+        }
+        return text;
+    };
+
     // ===== USER MANAGEMENT =====
     // Note: loadUsers, loadUsersForRule, and setCurrentUserAsDefault are defined in config-api.js to avoid duplication
 
@@ -291,6 +384,7 @@
             var overviewVal = SmartLists.getElementValue(page, '#metadataOverview');
             var tagsVal = SmartLists.getMetadataTags ? SmartLists.getMetadataTags(page) : [];
             var favoriteVal = SmartLists.getElementValue(page, '#metadataFavorite', '');
+            var randomGroupSelection = SmartLists.collectRandomGroupSelectionFromForm(page);
 
             const playlistDto = {
                 Type: listType,
@@ -317,6 +411,9 @@
                 playlistDto.Favorite = true;
             } else if (favoriteVal === 'false') {
                 playlistDto.Favorite = false;
+            }
+            if (randomGroupSelection) {
+                playlistDto.RandomGroupSelection = randomGroupSelection;
             }
 
             // Add type-specific fields
@@ -557,6 +654,7 @@
 
         // Clear media type selections
         SmartLists.setSelectedItems(page, 'mediaTypesMultiSelect', [], 'media-type-multi-select-checkbox', 'Select media types...');
+        SmartLists.loadRandomGroupSelectionIntoUI(page, null);
 
         // Apply all form defaults using shared helper (DRY)
         // Skip loading config on user pages (admin-only endpoint)
@@ -683,6 +781,8 @@
                 // Handle visibility schedule settings
                 SmartLists.loadVisibilitySchedulesIntoUI(page, playlist);
 
+                SmartLists.loadRandomGroupSelectionIntoUI(page, playlist);
+
                 // Handle MaxItems with backward compatibility for existing playlists
                 // Default to 0 (unlimited) for old playlists that didn't have this setting
                 const maxItemsValue = (playlist.MaxItems !== undefined && playlist.MaxItems !== null) ? playlist.MaxItems : 0;
@@ -720,6 +820,7 @@
                 if (SmartLists.updateIncludeExtrasVisibility) {
                     SmartLists.updateIncludeExtrasVisibility(page);
                 }
+                SmartLists.loadRandomGroupSelectionIntoUI(page, playlist);
 
                 // Set the list owner (for both playlists and collections)
                 // isCollection is already declared above on line 425
@@ -969,6 +1070,8 @@
                 // Handle visibility schedule settings (same as editPlaylist)
                 SmartLists.loadVisibilitySchedulesIntoUI(page, playlist);
 
+                SmartLists.loadRandomGroupSelectionIntoUI(page, playlist);
+
                 // Handle MaxItems
                 const maxItemsValue = (playlist.MaxItems !== undefined && playlist.MaxItems !== null) ? playlist.MaxItems : 0;
                 const maxItemsElement = page.querySelector('#playlistMaxItems');
@@ -995,6 +1098,7 @@
                 if (SmartLists.updateIncludeExtrasVisibility) {
                     SmartLists.updateIncludeExtrasVisibility(page);
                 }
+                SmartLists.loadRandomGroupSelectionIntoUI(page, playlist);
 
                 // Set the list owner (for both playlists and collections)
                 // isCollection is already declared above on line 650
@@ -1656,6 +1760,7 @@
             (playlist.Favorite === false ? 'Mark as not favorite' : 'Leave unchanged');
         const eTagsDisplayText = SmartLists.escapeHtml(tagsDisplayText);
         const eFavoriteDisplayText = SmartLists.escapeHtml(favoriteDisplayText);
+        const eRandomGroupSelectionDisplay = SmartLists.escapeHtml(SmartLists.formatRandomGroupSelectionDisplay(playlist));
 
         // Build custom images display
         var customImagesHtml = '';
@@ -1909,6 +2014,10 @@
             '<tr style="border-bottom: 1px solid var(--jf-palette-divider);">' +
             '<td style="padding: 0.5em 0.75em; font-weight: bold; opacity: 0.8; width: 40%; border-right: 1px solid var(--jf-palette-divider);">Sort</td>' +
             '<td style="padding: 0.5em 0.75em; ">' + eSortName + '</td>' +
+            '</tr>' +
+            '<tr style="border-bottom: 1px solid var(--jf-palette-divider);">' +
+            '<td style="padding: 0.5em 0.75em; font-weight: bold; opacity: 0.8; width: 40%; border-right: 1px solid var(--jf-palette-divider);">Random Group Selection</td>' +
+            '<td style="padding: 0.5em 0.75em; ">' + eRandomGroupSelectionDisplay + '</td>' +
             '</tr>' +
             '<tr style="border-bottom: 1px solid var(--jf-palette-divider);">' +
             '<td style="padding: 0.5em 0.75em; font-weight: bold; opacity: 0.8; width: 40%; border-right: 1px solid var(--jf-palette-divider);">Max Items</td>' +

--- a/Jellyfin.Plugin.SmartLists/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config.html
@@ -149,6 +149,45 @@
                             <div id="sorts-container"></div>
                         </div>
 
+                        <div class="checkboxList paperList"
+                            style="padding: 0.5em 1em; margin-bottom: 1em; margin-top: 1em;">
+                            <label class="emby-checkbox-label">
+                                <input type="checkbox" is="emby-checkbox" id="randomGroupSelectionEnabled"
+                                    data-embycheckbox="true" class="emby-checkbox">
+                                <span class="checkboxLabel">
+                                    Random Group Selection
+                                    <a href="https://jellyfin-smartlists-plugin.dinsten.se/user-guide/sorting-and-limits/#random-group-selection"
+                                        target="_blank" rel="noopener noreferrer" title="Documentation"
+                                        style="margin-left: 0.5em; text-decoration: none; color: inherit; display: inline-flex; align-items: center;">
+                                        <span class="material-icons" aria-hidden="true"
+                                            style="font-size: 1.1em; line-height: 0;">info_outline</span>
+                                    </a>
+                                </span>
+                                <span class="checkboxOutline">
+                                    <span class="material-icons checkboxIcon checkboxIcon-checked check"
+                                        aria-hidden="true"></span>
+                                    <span class="material-icons checkboxIcon checkboxIcon-unchecked"
+                                        aria-hidden="true"></span>
+                                </span>
+                            </label>
+                            <div class="fieldDescription">Randomly choose one group from the filtered item pool before
+                                sorting and limits are applied.</div>
+                            <div id="randomGroupSelectionFields" style="display: none; margin-top: 0.75em;">
+                                <div class="selectContainer" style="margin-bottom: 0.75em;">
+                                    <label class="selectLabel" for="randomGroupSelectionGroupBy">Group By</label>
+                                    <select id="randomGroupSelectionGroupBy" is="emby-select"
+                                        class="emby-select-withcolor emby-select"></select>
+                                </div>
+                                <div class="inputContainer" style="margin-bottom: 0;">
+                                    <label class="inputLabel" for="randomGroupSelectionMinimumItems">Minimum Items in Group</label>
+                                    <input type="number" id="randomGroupSelectionMinimumItems" class="emby-input"
+                                        min="0" step="1">
+                                    <div class="fieldDescription">Only consider groups with at least this many items. Leave blank or set to 0 to include all groups.</div>
+                                </div>
+                            </div>
+                        </div>
+
+
                         <div class="inputContainer" style="margin-bottom: 1em;">
                             <label class="inputLabel" for="playlistUser" style="display: flex; align-items: center;">
                                 <span class="playlist-only-label">Playlist Users</span>

--- a/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
@@ -135,6 +135,45 @@
                             <div id="sorts-container"></div>
                         </div>
 
+                        <div class="checkboxList paperList"
+                            style="padding: 0.5em 1em; margin-bottom: 1em; margin-top: 1em;">
+                            <label class="emby-checkbox-label">
+                                <input type="checkbox" is="emby-checkbox" id="randomGroupSelectionEnabled"
+                                    data-embycheckbox="true" class="emby-checkbox">
+                                <span class="checkboxLabel">
+                                    Random Group Selection
+                                    <a href="https://jellyfin-smartlists-plugin.dinsten.se/user-guide/sorting-and-limits/#random-group-selection"
+                                        target="_blank" rel="noopener noreferrer" title="Documentation"
+                                        style="margin-left: 0.5em; text-decoration: none; color: inherit; display: inline-flex; align-items: center;">
+                                        <span class="material-icons" aria-hidden="true"
+                                            style="font-size: 1.1em; line-height: 0;">info_outline</span>
+                                    </a>
+                                </span>
+                                <span class="checkboxOutline">
+                                    <span class="material-icons checkboxIcon checkboxIcon-checked check"
+                                        aria-hidden="true"></span>
+                                    <span class="material-icons checkboxIcon checkboxIcon-unchecked"
+                                        aria-hidden="true"></span>
+                                </span>
+                            </label>
+                            <div class="fieldDescription">Randomly choose one group from the filtered item pool before
+                                sorting and limits are applied.</div>
+                            <div id="randomGroupSelectionFields" style="display: none; margin-top: 0.75em;">
+                                <div class="selectContainer" style="margin-bottom: 0.75em;">
+                                    <label class="selectLabel" for="randomGroupSelectionGroupBy">Group By</label>
+                                    <select id="randomGroupSelectionGroupBy" is="emby-select"
+                                        class="emby-select-withcolor emby-select"></select>
+                                </div>
+                                <div class="inputContainer" style="margin-bottom: 0;">
+                                    <label class="inputLabel" for="randomGroupSelectionMinimumItems">Minimum Items in Group</label>
+                                    <input type="number" id="randomGroupSelectionMinimumItems" class="emby-input"
+                                        min="0" step="1">
+                                    <div class="fieldDescription">Only consider groups with at least this many items. Leave blank or set to 0 to include all groups.</div>
+                                </div>
+                            </div>
+                        </div>
+
+
                         <!-- User selection hidden for user pages - user is always themselves -->
                         <input type="hidden" id="playlistUser" value="">
 

--- a/Jellyfin.Plugin.SmartLists/Core/Models/RandomGroupSelectionDto.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Models/RandomGroupSelectionDto.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Jellyfin.Plugin.SmartLists.Core.Models
+{
+    /// <summary>
+    /// Optional post-filter grouping configuration. When enabled, the filtered item pool
+    /// is scoped to one randomly selected group before sorting and limits are applied.
+    /// </summary>
+    [Serializable]
+    public class RandomGroupSelectionDto
+    {
+        public bool Enabled { get; set; }
+
+        public string? GroupBy { get; set; }
+
+        public int? MinimumItems { get; set; }
+
+        private static readonly HashSet<string> _supportedGroupByFields = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "Artists",
+            "AlbumArtists",
+            "Album",
+            "SeriesName",
+            "Genres",
+            "Studios",
+            "Tags",
+        };
+
+        public static IReadOnlyCollection<string> SupportedGroupByFields => _supportedGroupByFields.ToArray();
+
+        public static bool IsSupportedGroupByField(string? fieldName)
+        {
+            return !string.IsNullOrWhiteSpace(fieldName) && _supportedGroupByFields.Contains(fieldName);
+        }
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Core/Models/RandomGroupSelectionDto.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Models/RandomGroupSelectionDto.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Jellyfin.Plugin.SmartLists.Core.QueryEngine;
 
 namespace Jellyfin.Plugin.SmartLists.Core.Models
 {
@@ -33,6 +34,24 @@ namespace Jellyfin.Plugin.SmartLists.Core.Models
         public static bool IsSupportedGroupByField(string? fieldName)
         {
             return !string.IsNullOrWhiteSpace(fieldName) && _supportedGroupByFields.Contains(fieldName);
+        }
+
+        /// <summary>
+        /// Maps a supported GroupBy field to the extraction group required to derive its grouping keys.
+        /// This is the single source of truth for the GroupBy-to-ExtractionGroup mapping, used both when
+        /// analyzing field requirements and when deriving group keys, so they stay in sync.
+        /// </summary>
+        /// <param name="groupBy">The GroupBy field name.</param>
+        /// <returns>The required <see cref="ExtractionGroup"/>, or <see cref="ExtractionGroup.None"/> if unsupported.</returns>
+        public static ExtractionGroup GetExtractionGroup(string? groupBy)
+        {
+            return groupBy switch
+            {
+                "Artists" or "AlbumArtists" or "Album" => ExtractionGroup.AudioMetadata,
+                "SeriesName" => ExtractionGroup.SeriesName,
+                "Genres" or "Studios" or "Tags" => ExtractionGroup.ItemLists,
+                _ => ExtractionGroup.None,
+            };
         }
     }
 }

--- a/Jellyfin.Plugin.SmartLists/Core/Models/SmartListDto.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Models/SmartListDto.cs
@@ -79,6 +79,12 @@ namespace Jellyfin.Plugin.SmartLists.Core.Models
         public int? MaxItems { get; set; } // Nullable to support backwards compatibility
         public int? MaxPlayTimeMinutes { get; set; } // Nullable to support backwards compatibility
 
+        /// <summary>
+        /// Optional post-filter grouping step that randomly selects one group before sorting and limits.
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public RandomGroupSelectionDto? RandomGroupSelection { get; set; }
+
         // Auto-refresh
         public AutoRefreshMode AutoRefresh { get; set; } = AutoRefreshMode.Never; // Default to never for backward compatibility
 

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -31,6 +31,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
         public List<ExpressionSet> ExpressionSets { get; set; }
         public int MaxItems { get; set; }
         public int MaxPlayTimeMinutes { get; set; }
+        public RandomGroupSelectionDto? RandomGroupSelection { get; set; }
         public List<string>? SimilarityComparisonFields { get; set; }
 
         // UserManager for resolving user-specific queries (Jellyfin 10.11+)
@@ -157,6 +158,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
             MediaTypes = dto.MediaTypes != null ? new List<string>(dto.MediaTypes) : null; // Create defensive copy to prevent corruption
             MaxItems = dto.MaxItems ?? 0; // Default to 0 (unlimited) for backwards compatibility
             MaxPlayTimeMinutes = dto.MaxPlayTimeMinutes ?? 0; // Default to 0 (unlimited) for backwards compatibility
+            RandomGroupSelection = dto.RandomGroupSelection;
             SimilarityComparisonFields = dto.SimilarityComparisonFields != null ? new List<string>(dto.SimilarityComparisonFields) : null; // Create defensive copy
 
             if (dto.ExpressionSets != null && dto.ExpressionSets.Count > 0)
@@ -783,7 +785,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 {
                     if (ExpressionSets != null)
                     {
-                        fieldReqs = FieldRequirements.Analyze(ExpressionSets, Orders);
+                        fieldReqs = FieldRequirements.Analyze(ExpressionSets, Orders, RandomGroupSelection);
                         // Set collection recursion depth from list-level setting
                         fieldReqs.CollectionRecursionDepth = collectionRecursionDepth;
 
@@ -1075,6 +1077,8 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 logger?.LogDebug("Playlist '{PlaylistName}' expanded from {OriginalCount} items to {ExpandedCount} items after Collections processing",
                     Name, results.Count, expandedResults.Count);
 
+                expandedResults = ApplyRandomGroupSelection(expandedResults, libraryManager, user, userDataManager, logger, refreshCache);
+
                 // Apply per-group limits if configured (before sorting and global limits)
                 if (HasPerGroupLimits())
                 {
@@ -1189,6 +1193,130 @@ namespace Jellyfin.Plugin.SmartLists.Core
         private bool NeedsGroupTracking()
         {
             return HasPerGroupLimits() || UsesRuleBlockOrdering();
+        }
+
+        private bool HasRandomGroupSelection()
+        {
+            return RandomGroupSelection?.Enabled == true
+                && !string.IsNullOrWhiteSpace(RandomGroupSelection.GroupBy)
+                && RandomGroupSelectionDto.IsSupportedGroupByField(RandomGroupSelection.GroupBy);
+        }
+
+        private List<BaseItem> ApplyRandomGroupSelection(
+            List<BaseItem> items,
+            ILibraryManager libraryManager,
+            User user,
+            IUserDataManager? userDataManager,
+            ILogger? logger,
+            RefreshQueueService.RefreshCache refreshCache)
+        {
+            try
+            {
+                if (!HasRandomGroupSelection() || items == null || items.Count == 0)
+                {
+                    return items ?? new List<BaseItem>();
+                }
+
+                var groupBy = RandomGroupSelection!.GroupBy!;
+                var requiredGroup = GetRandomGroupSelectionExtractionGroup(groupBy);
+                if (requiredGroup == ExtractionGroup.None)
+                {
+                    logger?.LogWarning("Random Group Selection for playlist '{PlaylistName}' uses unsupported field '{GroupBy}'. Skipping group selection.", Name, groupBy);
+                    return items;
+                }
+
+                var extractionOptions = new MediaTypeExtractionOptions
+                {
+                    RequiredGroups = requiredGroup,
+                    IncludeUnwatchedSeries = true,
+                    OriginListName = Name,
+                };
+
+                var groups = new Dictionary<string, List<BaseItem>>(StringComparer.OrdinalIgnoreCase);
+
+                foreach (var item in items)
+                {
+                    try
+                    {
+                        var operand = OperandFactory.GetMediaType(libraryManager, item, user, userDataManager, UserManager, logger, extractionOptions, refreshCache);
+                        var keys = GetRandomGroupKeys(operand, groupBy);
+
+                        foreach (var key in keys)
+                        {
+                            if (!groups.TryGetValue(key, out var groupItems))
+                            {
+                                groupItems = new List<BaseItem>();
+                                groups[key] = groupItems;
+                            }
+
+                            groupItems.Add(item);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        logger?.LogDebug(ex, "Error extracting Random Group Selection key '{GroupBy}' for item '{ItemName}'. Skipping item for grouping.", groupBy, item.Name);
+                    }
+                }
+
+                var minimumItems = RandomGroupSelection.MinimumItems.GetValueOrDefault();
+                var eligibleGroups = groups
+                    .Where(kvp => minimumItems <= 0 || kvp.Value.Count >= minimumItems)
+                    .ToList();
+
+                if (eligibleGroups.Count == 0)
+                {
+                    logger?.LogInformation("Random Group Selection for playlist '{PlaylistName}' found no eligible '{GroupBy}' groups from {GroupCount} total groups (MinimumItems: {MinimumItems}). Returning no items.",
+                        Name, groupBy, groups.Count, minimumItems);
+                    return [];
+                }
+
+#pragma warning disable CA5394
+                var random = new Random((int)(DateTime.Now.Ticks & 0x7FFFFFFF));
+                var selectedGroup = eligibleGroups[random.Next(eligibleGroups.Count)];
+#pragma warning restore CA5394
+
+                logger?.LogInformation("Random Group Selection for playlist '{PlaylistName}' selected {GroupBy} '{GroupName}' with {ItemCount} items from {EligibleGroupCount} eligible groups",
+                    Name, groupBy, selectedGroup.Key, selectedGroup.Value.Count, eligibleGroups.Count);
+
+                return selectedGroup.Value;
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, "Error applying Random Group Selection for playlist '{PlaylistName}'. Returning ungrouped items.", Name);
+                return items;
+            }
+        }
+
+        private static ExtractionGroup GetRandomGroupSelectionExtractionGroup(string groupBy)
+        {
+            return groupBy switch
+            {
+                "Artists" or "AlbumArtists" or "Album" => ExtractionGroup.AudioMetadata,
+                "SeriesName" => ExtractionGroup.SeriesName,
+                "Genres" or "Studios" or "Tags" => ExtractionGroup.ItemLists,
+                _ => ExtractionGroup.None,
+            };
+        }
+
+        private static List<string> GetRandomGroupKeys(Operand operand, string groupBy)
+        {
+            IEnumerable<string> values = groupBy switch
+            {
+                "Artists" => operand.Artists,
+                "AlbumArtists" => operand.AlbumArtists,
+                "Album" => [operand.Album],
+                "SeriesName" => [operand.SeriesName],
+                "Genres" => operand.Genres,
+                "Studios" => operand.Studios,
+                "Tags" => operand.Tags,
+                _ => [],
+            };
+
+            return values
+                .Where(value => !string.IsNullOrWhiteSpace(value))
+                .Select(value => value.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
         }
 
         /// <summary>
@@ -3076,9 +3204,20 @@ namespace Jellyfin.Plugin.SmartLists.Core
         /// </summary>
         /// <param name="expressionSets">Filter expression sets to analyze</param>
         /// <param name="orders">Optional sorting orders to check for field requirements</param>
-        public static FieldRequirements Analyze(List<ExpressionSet> expressionSets, List<Order>? orders = null)
+        public static FieldRequirements Analyze(List<ExpressionSet> expressionSets, List<Order>? orders = null, RandomGroupSelectionDto? randomGroupSelection = null)
         {
             var requirements = new FieldRequirements();
+
+            if (randomGroupSelection?.Enabled == true && !string.IsNullOrWhiteSpace(randomGroupSelection.GroupBy))
+            {
+                requirements.RequiredGroups |= randomGroupSelection.GroupBy switch
+                {
+                    "Artists" or "AlbumArtists" or "Album" => ExtractionGroup.AudioMetadata,
+                    "SeriesName" => ExtractionGroup.SeriesName,
+                    "Genres" or "Studios" or "Tags" => ExtractionGroup.ItemLists,
+                    _ => ExtractionGroup.None,
+                };
+            }
 
             if (expressionSets == null) return requirements;
 

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -1218,7 +1218,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 }
 
                 var groupBy = RandomGroupSelection!.GroupBy!;
-                var requiredGroup = GetRandomGroupSelectionExtractionGroup(groupBy);
+                var requiredGroup = RandomGroupSelectionDto.GetExtractionGroup(groupBy);
                 if (requiredGroup == ExtractionGroup.None)
                 {
                     logger?.LogWarning("Random Group Selection for playlist '{PlaylistName}' uses unsupported field '{GroupBy}'. Skipping group selection.", Name, groupBy);
@@ -1285,17 +1285,6 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 logger?.LogError(ex, "Error applying Random Group Selection for playlist '{PlaylistName}'. Returning ungrouped items.", Name);
                 return items;
             }
-        }
-
-        private static ExtractionGroup GetRandomGroupSelectionExtractionGroup(string groupBy)
-        {
-            return groupBy switch
-            {
-                "Artists" or "AlbumArtists" or "Album" => ExtractionGroup.AudioMetadata,
-                "SeriesName" => ExtractionGroup.SeriesName,
-                "Genres" or "Studios" or "Tags" => ExtractionGroup.ItemLists,
-                _ => ExtractionGroup.None,
-            };
         }
 
         private static List<string> GetRandomGroupKeys(Operand operand, string groupBy)
@@ -3210,13 +3199,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
 
             if (randomGroupSelection?.Enabled == true && !string.IsNullOrWhiteSpace(randomGroupSelection.GroupBy))
             {
-                requirements.RequiredGroups |= randomGroupSelection.GroupBy switch
-                {
-                    "Artists" or "AlbumArtists" or "Album" => ExtractionGroup.AudioMetadata,
-                    "SeriesName" => ExtractionGroup.SeriesName,
-                    "Genres" or "Studios" or "Tags" => ExtractionGroup.ItemLists,
-                    _ => ExtractionGroup.None,
-                };
+                requirements.RequiredGroups |= RandomGroupSelectionDto.GetExtractionGroup(randomGroupSelection.GroupBy);
             }
 
             if (expressionSets == null) return requirements;

--- a/Jellyfin.Plugin.SmartLists/Utilities/DtoMapper.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/DtoMapper.cs
@@ -47,6 +47,7 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
                 Enabled = source.Enabled,
                 MaxItems = source.MaxItems,
                 MaxPlayTimeMinutes = source.MaxPlayTimeMinutes,
+                RandomGroupSelection = source.RandomGroupSelection,
                 
                 // Auto-refresh
                 AutoRefresh = source.AutoRefresh,
@@ -120,6 +121,7 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
                 Enabled = source.Enabled,
                 MaxItems = source.MaxItems,
                 MaxPlayTimeMinutes = source.MaxPlayTimeMinutes,
+                RandomGroupSelection = source.RandomGroupSelection,
                 
                 // Auto-refresh
                 AutoRefresh = source.AutoRefresh,

--- a/Jellyfin.Plugin.SmartLists/Utilities/InputValidator.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/InputValidator.cs
@@ -312,6 +312,12 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
                 return maxPlayTimeResult;
             }
 
+            var randomGroupSelectionResult = ValidateRandomGroupSelection(list.RandomGroupSelection);
+            if (!randomGroupSelectionResult.IsValid)
+            {
+                return randomGroupSelectionResult;
+            }
+
             // Validate schedules count
             if (list.Schedules != null && list.Schedules.Count > MaxSchedulesCount)
             {
@@ -351,6 +357,26 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
             }
 
             return SmartListValidationResult.Success();
+        }
+
+        private static SmartListValidationResult ValidateRandomGroupSelection(RandomGroupSelectionDto? randomGroupSelection)
+        {
+            if (randomGroupSelection == null || !randomGroupSelection.Enabled)
+            {
+                return SmartListValidationResult.Success();
+            }
+
+            if (string.IsNullOrWhiteSpace(randomGroupSelection.GroupBy))
+            {
+                return SmartListValidationResult.Failure("RandomGroupSelection.GroupBy is required when random group selection is enabled");
+            }
+
+            if (!RandomGroupSelectionDto.IsSupportedGroupByField(randomGroupSelection.GroupBy))
+            {
+                return SmartListValidationResult.Failure($"Invalid RandomGroupSelection.GroupBy value: {randomGroupSelection.GroupBy}");
+            }
+
+            return ValidateInteger(randomGroupSelection.MinimumItems, min: 0, max: 100000, fieldName: "RandomGroupSelection.MinimumItems");
         }
 
         /// <summary>

--- a/docs/content/user-guide/sorting-and-limits.md
+++ b/docs/content/user-guide/sorting-and-limits.md
@@ -184,6 +184,58 @@ Next refresh:
 !!! tip "Simulating a TV channel"
     Combine with **Auto Refresh** to get a different "channel lineup" on a schedule. Each refresh reshuffles which show appears first while keeping episodes in order within each show.
 
+## Random Group Selection
+
+Random Group Selection chooses one random group from the items that already matched your rules, then continues with your normal sort and limit settings.
+
+**How it works**:
+
+1. Your rules create the eligible item pool
+2. One group is selected at random
+3. Items outside that group are removed
+4. Sort options and limits are applied to the selected group
+
+**Supported groups**:
+
+- Artist
+- Album Artist
+- Album
+- Series Name
+- Genre
+- Studio
+- Tag
+
+For fields with multiple values, such as Artists, Genres, Studios, and Tags, an item can belong to every value it has.
+
+**Example: 50 random tracks from one random artist**
+
+1. Select **Audio (Music)** as the media type
+2. Enable **Random Group Selection**
+3. Set **Group By** to **Artist**
+4. Set **Minimum Items in Group** to `50`
+5. Set **Sort By** to **Random**
+6. Set **Max Items** to `50`
+
+One refresh might choose Eminem and return 50 Eminem tracks. The next refresh might choose Katy Perry and return 50 Katy Perry tracks.
+
+**Example: least-listened tracks from one random artist**
+
+Use the same settings as above, but set **Sort By** to **Play Count (owner)** and **Sort Order** to **Ascending**.
+
+**Example: most-listened tracks from one random artist**
+
+Use the same settings as above, but set **Sort By** to **Play Count (owner)** and **Sort Order** to **Descending**.
+
+**Other examples**:
+
+- Random series, then episodes from that series
+- Random genre, then movies from that genre
+- Random studio, then movies from that studio
+- Random tag, then items with that tag
+
+!!! tip "Minimum Items"
+    Set **Minimum Items in Group** when you need a full list. For example, set it to `50` if you only want artists with at least 50 matching tracks.
+
 ### External List Order
 Sort items in the same order as the external list they were matched from. Only available when using the "External List" filter field in your rules.
 


### PR DESCRIPTION
https://github.com/jyourstone/jellyfin-smartlists-plugin/issues/435

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Random Group Selection** to SmartLists, randomly choosing one eligible group before sorting and limits are applied.
  * Added configuration controls for **Group By** and **Minimum Items in Group**.
  * SmartLists playlist and collection cards now display the saved random-group setting.
* **Bug Fixes**
  * Improved UI synchronization so Random Group Selection stays consistent when switching media types, list type, or enabling/disabling the option.
* **Documentation**
  * Added a new “Random Group Selection” guide with examples and setup tips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->