### PR TITLE
Added Least Recently Watched Round Robin sort

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Configuration/config-core.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-core.js
@@ -85,15 +85,16 @@
         { value: 'Round Robin', label: 'Round Robin (Interleave)' },
         { value: 'Random Round Robin', label: 'Random Round Robin (Interleave)' },
         { value: 'Shuffled Round Robin', label: 'Shuffled Round Robin (Interleave)' },
+        { value: 'Least Recently Watched Round Robin', label: 'Least Recently Watched Round Robin (Interleave)' },
         { value: 'Random', label: 'Random' },
         { value: 'NoOrder', label: 'Default' }
     ];
 
     // Sorts that have no Ascending/Descending direction
-    SmartLists.ORDERLESS_SORTS = ['Random', 'Random Round Robin', 'Shuffled Round Robin', 'NoOrder'];
+    SmartLists.ORDERLESS_SORTS = ['Random', 'Random Round Robin', 'Shuffled Round Robin', 'Least Recently Watched Round Robin', 'NoOrder'];
 
     // Round Robin sort variants (all use a GroupBy field)
-    SmartLists.ROUND_ROBIN_SORTS = ['Round Robin', 'Random Round Robin', 'Shuffled Round Robin'];
+    SmartLists.ROUND_ROBIN_SORTS = ['Round Robin', 'Random Round Robin', 'Shuffled Round Robin', 'Least Recently Watched Round Robin'];
 
     SmartLists.isOrderlessSort = function (name) {
         return SmartLists.ORDERLESS_SORTS.indexOf(name) !== -1;

--- a/Jellyfin.Plugin.SmartLists/Core/Orders/LastPlayedOrderBase.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Orders/LastPlayedOrderBase.cs
@@ -126,7 +126,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
         /// <summary>
         /// Gets aggregate LastPlayedDate for container items when their children are already cached.
         /// </summary>
-        private static DateTime? GetAggregateLastPlayedDate(
+        internal static DateTime? GetAggregateLastPlayedDate(
             BaseItem item,
             User user,
             IUserDataManager userDataManager,
@@ -167,7 +167,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
         /// <summary>
         /// Extracts LastPlayedDate from user data, handling both DateTime and Nullable&lt;DateTime&gt;
         /// </summary>
-        private static DateTime GetLastPlayedDateFromUserData(object? userData)
+        internal static DateTime GetLastPlayedDateFromUserData(object? userData)
         {
             if (userData == null) return DateTime.MinValue;
 

--- a/Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.SmartLists.Services.Shared;
+using Jellyfin.Plugin.SmartLists.Utilities;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Entities.TV;
@@ -307,5 +308,80 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
         public override string Name => "Shuffled Round Robin";
 
         protected override bool ShuffleWithinGroups => true;
+    }
+
+    /// <summary>
+    /// Round Robin sort with groups ordered by how recently the user watched anything in them:
+    /// least recently watched first, never-watched groups first of all (alphabetical tie-break).
+    /// The rotation "continues where the user left off" with no persisted state - it is derived
+    /// entirely from per-user LastPlayedDate data, so it is deterministic for a given watch history.
+    /// </summary>
+    public class RoundRobinLeastRecentlyWatchedOrder : RoundRobinBase
+    {
+        public override string Name => "Least Recently Watched Round Robin";
+
+        /// <summary>
+        /// Group key → most recent per-user LastPlayedDate, computed from the UNFILTERED media
+        /// pool (rules like "Playback Status is Unwatched" remove watched items from the results,
+        /// so recency derived from filtered items would see every group as never watched).
+        /// Set by SmartList before <see cref="RoundRobinBase.PreComputePositions"/>.
+        /// Groups absent from the map are treated as never watched and sort first.
+        /// </summary>
+        public Dictionary<string, DateTime> GroupRecency { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+        protected override List<string> OrderGroupKeys(IEnumerable<string> keys)
+        {
+            return keys
+                .OrderBy(k => GroupRecency.TryGetValue(k, out var d) ? d : DateTime.MinValue)
+                .ThenBy(k => k, OrderUtilities.SharedNaturalComparer)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Builds the group key → most recent LastPlayedDate map for one user across the given items.
+        /// Container items (Series/Season/MusicAlbum) use the aggregate-over-children date when the
+        /// refresh cache has their children, mirroring LastPlayedOrderBase.
+        /// </summary>
+        internal static Dictionary<string, DateTime> BuildGroupRecency(
+            IEnumerable<BaseItem> items,
+            string? groupByField,
+            User user,
+            IUserDataManager? userDataManager,
+            RefreshQueueService.RefreshCache? refreshCache,
+            ILogger? logger)
+        {
+            var recency = new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
+            if (string.IsNullOrEmpty(groupByField) || userDataManager == null || user == null)
+            {
+                logger?.LogWarning("Least Recently Watched Round Robin: missing GroupByField or user context - groups fall back to alphabetical order");
+                return recency;
+            }
+
+            foreach (var item in items)
+            {
+                try
+                {
+                    var key = ExtractGroupKey(item, groupByField);
+
+                    var lastPlayed = LastPlayedOrderBase.GetAggregateLastPlayedDate(item, user, userDataManager, refreshCache)
+                        ?? LastPlayedOrderBase.GetLastPlayedDateFromUserData(
+                            refreshCache != null
+                                ? UserDataCacheHelper.GetCachedUserData(user, item, refreshCache, userDataManager)
+                                : userDataManager.GetUserData(user, item));
+
+                    if (lastPlayed > DateTime.MinValue &&
+                        (!recency.TryGetValue(key, out var existing) || lastPlayed > existing))
+                    {
+                        recency[key] = lastPlayed;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger?.LogWarning(ex, "Error reading last played date for item {ItemName}", item.Name);
+                }
+            }
+
+            return recency;
+        }
     }
 }

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -758,6 +758,16 @@ namespace Jellyfin.Plugin.SmartLists.Core
                     return [];
                 }
 
+                // Least Recently Watched Round Robin needs per-group watch recency computed from the
+                // UNFILTERED pool: rules like "Playback Status is Unwatched" remove watched items from
+                // the results, so recency derived from filtered items would see every group as unwatched.
+                // Same injection pattern as SimilarityOrder.Scores / RuleBlockOrder.GroupMappings.
+                foreach (var lrwOrder in Orders.OfType<RoundRobinLeastRecentlyWatchedOrder>())
+                {
+                    lrwOrder.GroupRecency = RoundRobinLeastRecentlyWatchedOrder.BuildGroupRecency(
+                        itemsArray, lrwOrder.GroupByField, user, userDataManager, refreshCache, logger);
+                }
+
                 // Media type filtering is now handled at the API level in PlaylistService.GetAllUserMedia()
                 // This provides significant performance improvements by filtering at the database level
                 logger?.LogDebug("Processing {ItemCount} items (already filtered by media type at API level)", itemCount);

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -3091,6 +3091,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
             { "Round Robin Descending", () => new RoundRobinOrderDesc() },
             { "Random Round Robin", () => new RoundRobinRandomOrder() },
             { "Shuffled Round Robin", () => new RoundRobinShuffledOrder() },
+            { "Least Recently Watched Round Robin", () => new RoundRobinLeastRecentlyWatchedOrder() },
             { "NoOrder", () => new NoOrder() },
         };
 
@@ -3106,6 +3107,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
             "Random",
             "Random Round Robin",
             "Shuffled Round Robin",
+            "Least Recently Watched Round Robin",
             "NoOrder",
         };
 

--- a/docs/content/examples/common-use-cases.md
+++ b/docs/content/examples/common-use-cases.md
@@ -103,6 +103,16 @@ Like the Shuffled TV Channel above, but the episodes within each show are shuffl
 
 Result: Shuffled Round Robin over shows A, B, C might produce: Show A S02E03, Show C S01E01, Show B S03E02, Show A S01E01, Show C S02E04, Show B S01E05, etc. Both the show rotation and the episode order within each show are random — a new arrangement on every refresh.
 
+### Continue-Where-You-Left-Off TV Channel (Least Recently Watched Round Robin)
+Like the TV Channel playlist above, but the show rotation follows your watch history instead of alphabetical order:
+
+- **Media Types**: Episode
+- **Playback Status** = Unplayed
+- **Sort by**: Least Recently Watched Round Robin (Interleave), **Group By**: Series Name
+- **Auto Refresh**: On All Changes
+
+Result: Shows you have never watched come first, and the show you watched most recently goes to the back of the rotation. Watch an episode of Show A, and on the next refresh Show A moves to the end while the other shows shift forward — the rotation "continues where you left off".
+
 ### TV Channel with Commercials (Bumpers)
 Take any of the TV Channel playlists above and weave "commercial break" clips between the episodes:
 

--- a/docs/content/user-guide/sorting-and-limits.md
+++ b/docs/content/user-guide/sorting-and-limits.md
@@ -241,7 +241,7 @@ Unlike Random Round Robin, the rotation is not shuffled — it is derived entire
 With other auto-refresh modes the rotation still advances, but only at the next refresh (scheduled or on library changes).
 
 !!! note "Per-user rotation"
-    For lists shared with multiple users, each user gets their own rotation based on their own watch history.
+    For playlists shared with multiple users, each user gets their own rotation based on their own watch history. Collections use the [reference user's](user-selection.md#collections-reference-user) watch history, so all users see the same rotation.
 
 ## Random Group Selection
 

--- a/docs/content/user-guide/sorting-and-limits.md
+++ b/docs/content/user-guide/sorting-and-limits.md
@@ -192,6 +192,7 @@ Like Random Round Robin, groups are interleaved in random order — and addition
 - **Round Robin**: Groups in alphabetical order, items within each group in natural order.
 - **Random Round Robin**: Group order randomized each refresh, items within each group in natural order.
 - **Shuffled Round Robin**: Group order randomized each refresh AND items within each group shuffled.
+- **Least Recently Watched Round Robin**: Group order follows your watch history (least recently watched first), items within each group in natural order.
 
 **Example** — Shuffled Round Robin (Group By: Series Name) over shows A, B, C might produce:
 
@@ -212,6 +213,35 @@ Both the show rotation and the episode order within each show are random, and re
 2. Select **Shuffled Round Robin (Interleave)** as your sort
 3. Choose the **Group By** field (e.g., Series Name for TV episodes) — the same Group By fields as Round Robin are supported
 4. No Sort Order is needed — both group order and item order are always randomized
+
+### Least Recently Watched Round Robin (Interleave)
+Rotates through your shows starting with the one you watched **least** recently — shows you have never watched come first, and the show you watched most recently goes to the back of the rotation. Watch an episode of Show A today, and on the next refresh Show A moves to the end of the rotation while the other shows shift forward. Within each group, items stay in natural order (episodes by season/episode number).
+
+Unlike Random Round Robin, the rotation is not shuffled — it is derived entirely from your watch history, so it "continues where you left off" across refreshes, and refreshing without watching anything produces the same order.
+
+**Example** — 3 shows: you have never watched Show C, watched Show A last week, and watched Show B yesterday:
+
+| Position | Item |
+|----------|------|
+| 1 | Show C - S01E01 |
+| 2 | Show A - S01E01 |
+| 3 | Show B - S01E01 |
+| 4 | Show C - S01E02 |
+| 5 | Show A - S01E02 |
+| 6 | Show B - S01E02 |
+
+**Recommended setup for a fair TV rotation**:
+
+1. Add the rule `Playback Status = Unplayed` — watched episodes drop off, and each show's next unwatched episode surfaces automatically
+2. Select **Least Recently Watched Round Robin (Interleave)** as your sort
+3. Choose the **Group By** field (e.g., Series Name for TV episodes)
+4. No Sort Order is needed — group order always follows watch recency (never watched first, most recently watched last, alphabetical tie-break)
+5. Set [Auto Refresh](auto-refresh.md) to **On All Changes** so the rotation advances right after you finish watching something
+
+With other auto-refresh modes the rotation still advances, but only at the next refresh (scheduled or on library changes).
+
+!!! note "Per-user rotation"
+    For lists shared with multiple users, each user gets their own rotation based on their own watch history.
 
 ## Random Group Selection
 

--- a/docs/superpowers/plans/2026-07-11-least-recently-watched-round-robin.md
+++ b/docs/superpowers/plans/2026-07-11-least-recently-watched-round-robin.md
@@ -1,0 +1,401 @@
+# Least Recently Watched Round Robin Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A new round-robin sort variant that orders show rotation by how recently the user watched each show — least recently watched first, never-watched first of all — so the rotation "continues where you left off" with zero persisted state.
+
+**Architecture:** New `RoundRobinLeastRecentlyWatchedOrder` subclass of `RoundRobinBase` whose group ordering reads a `GroupRecency` map (group key → most recent per-user `LastPlayedDate`). SmartList injects that map at the top of `FilterPlaylistItems`, computed from the **unfiltered** media pool — this is load-bearing: the intended companion rule `Playback Status is Unwatched` removes watched episodes from results, so recency derived from filtered items would see every group as never-watched. Auto-refresh needs **no changes** (verified: playback events select playlists by media type + membership, not rules).
+
+**Tech Stack:** C# (.NET, multi-target net9.0/net10.0), Jellyfin plugin API, vanilla JS config pages (no ES6 template literals).
+
+**Spec:** `docs/superpowers/specs/2026-07-10-least-recently-watched-round-robin-design.md`
+
+## Global Constraints
+
+- Build treats all warnings as errors (`AnalysisMode=Recommended`): CA1822 (make static), CA1305 (locale), CA5394 (insecure Random — suppress with pragma like existing round-robin code if needed).
+- Both frameworks must build: `net10.0` and `net9.0`.
+- Sort display name everywhere (backend registry, JS constants, docs): exactly `Least Recently Watched Round Robin`. UI dropdown label: `Least Recently Watched Round Robin (Interleave)`.
+- Config JS: no ES6 template literals, string concatenation only; never `is="emby-input"`; user messages via `showNotification()`.
+- No test suite exists. Verification = build both targets + live checks against local Jellyfin (<http://localhost:8096>) via `cd dev && ./build-local.sh`.
+- Working tree is the worktree at `.claude/worktrees/least-recently-watched-round-robin`, branch `worktree-least-recently-watched-round-robin`, based on main `60ab82f`.
+- Commit messages end with:
+
+  ```text
+  Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_01RBFLcyWKuktDSu9acy68zg
+  ```
+
+---
+
+### Task 1: Order class, helper promotion, backend registry
+
+**Files:**
+
+- Modify: `Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs` (append new class at end, after `RoundRobinShuffledOrder`, ~line 305)
+- Modify: `Jellyfin.Plugin.SmartLists/Core/Orders/LastPlayedOrderBase.cs` (promote two private static helpers to internal, ~lines 129 and 170)
+- Modify: `Jellyfin.Plugin.SmartLists/Core/SmartList.cs` (`OrderMap` ~line 3093, `DirectionlessOrders` ~line 3104)
+
+**Interfaces:**
+
+- Consumes: `RoundRobinBase` (`GroupByField`, `ExtractGroupKey`, `OrderGroupKeys` hook), `OrderUtilities.SharedNaturalComparer`, `UserDataCacheHelper.GetCachedUserData(User, BaseItem, RefreshCache, IUserDataManager)` (returns `UserItemData?`), `LastPlayedOrderBase.GetAggregateLastPlayedDate` / `GetLastPlayedDateFromUserData`.
+- Produces: `RoundRobinLeastRecentlyWatchedOrder` with `public Dictionary<string, DateTime> GroupRecency { get; set; }` and `internal static Dictionary<string, DateTime> BuildGroupRecency(IEnumerable<BaseItem> items, string? groupByField, User user, IUserDataManager? userDataManager, RefreshQueueService.RefreshCache? refreshCache, ILogger? logger)`. Task 2 calls both. Registry name `"Least Recently Watched Round Robin"`.
+
+- [ ] **Step 1: Promote the two `LastPlayedOrderBase` helpers**
+
+In `Jellyfin.Plugin.SmartLists/Core/Orders/LastPlayedOrderBase.cs`, change the access modifier of both existing methods (bodies unchanged):
+
+```csharp
+// line ~129: was "private static DateTime? GetAggregateLastPlayedDate("
+internal static DateTime? GetAggregateLastPlayedDate(
+
+// line ~170: was "private static DateTime GetLastPlayedDateFromUserData(object? userData)"
+internal static DateTime GetLastPlayedDateFromUserData(object? userData)
+```
+
+- [ ] **Step 2: Add the order class**
+
+Append to `Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs`, inside the namespace, after `RoundRobinShuffledOrder`:
+
+```csharp
+    /// <summary>
+    /// Round Robin sort with groups ordered by how recently the user watched anything in them:
+    /// least recently watched first, never-watched groups first of all (alphabetical tie-break).
+    /// The rotation "continues where the user left off" with no persisted state - it is derived
+    /// entirely from per-user LastPlayedDate data, so it is deterministic for a given watch history.
+    /// </summary>
+    public class RoundRobinLeastRecentlyWatchedOrder : RoundRobinBase
+    {
+        public override string Name => "Least Recently Watched Round Robin";
+
+        /// <summary>
+        /// Group key → most recent per-user LastPlayedDate, computed from the UNFILTERED media
+        /// pool (rules like "Playback Status is Unwatched" remove watched items from the results,
+        /// so recency derived from filtered items would see every group as never watched).
+        /// Set by SmartList before <see cref="RoundRobinBase.PreComputePositions"/>.
+        /// Groups absent from the map are treated as never watched and sort first.
+        /// </summary>
+        public Dictionary<string, DateTime> GroupRecency { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+        protected override List<string> OrderGroupKeys(IEnumerable<string> keys)
+        {
+            return keys
+                .OrderBy(k => GroupRecency.TryGetValue(k, out var d) ? d : DateTime.MinValue)
+                .ThenBy(k => k, OrderUtilities.SharedNaturalComparer)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Builds the group key → most recent LastPlayedDate map for one user across the given items.
+        /// Container items (Series/Season/MusicAlbum) use the aggregate-over-children date when the
+        /// refresh cache has their children, mirroring LastPlayedOrderBase.
+        /// </summary>
+        internal static Dictionary<string, DateTime> BuildGroupRecency(
+            IEnumerable<BaseItem> items,
+            string? groupByField,
+            User user,
+            IUserDataManager? userDataManager,
+            RefreshQueueService.RefreshCache? refreshCache,
+            ILogger? logger)
+        {
+            var recency = new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
+            if (string.IsNullOrEmpty(groupByField) || userDataManager == null || user == null)
+            {
+                logger?.LogWarning("Least Recently Watched Round Robin: missing GroupByField or user context - groups fall back to alphabetical order");
+                return recency;
+            }
+
+            foreach (var item in items)
+            {
+                try
+                {
+                    var key = ExtractGroupKey(item, groupByField);
+
+                    var lastPlayed = LastPlayedOrderBase.GetAggregateLastPlayedDate(item, user, userDataManager, refreshCache)
+                        ?? LastPlayedOrderBase.GetLastPlayedDateFromUserData(
+                            refreshCache != null
+                                ? UserDataCacheHelper.GetCachedUserData(user, item, refreshCache, userDataManager)
+                                : userDataManager.GetUserData(user, item));
+
+                    if (lastPlayed > DateTime.MinValue &&
+                        (!recency.TryGetValue(key, out var existing) || lastPlayed > existing))
+                    {
+                        recency[key] = lastPlayed;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger?.LogWarning(ex, "Error reading last played date for item {ItemName}", item.Name);
+                }
+            }
+
+            return recency;
+        }
+    }
+```
+
+Add `using Jellyfin.Plugin.SmartLists.Utilities;` to the file's usings if not already present (needed for `UserDataCacheHelper`; `OrderUtilities` lives in the same namespace as the orders — check existing usings and only add what's missing).
+
+- [ ] **Step 3: Register the order**
+
+In `Jellyfin.Plugin.SmartLists/Core/SmartList.cs`:
+
+`OrderMap` (~line 3093), after the Shuffled Round Robin entry:
+
+```csharp
+            { "Shuffled Round Robin", () => new RoundRobinShuffledOrder() },
+            { "Least Recently Watched Round Robin", () => new RoundRobinLeastRecentlyWatchedOrder() },
+```
+
+`DirectionlessOrders` (~line 3104), after "Shuffled Round Robin":
+
+```csharp
+            "Random",
+            "Random Round Robin",
+            "Shuffled Round Robin",
+            "Least Recently Watched Round Robin",
+            "NoOrder",
+```
+
+No `InitializeFromDto` change: the existing `is RoundRobinBase` branch assigns `GroupByField` generically. No `IsDescendingOrder` change: it is a type list of `*Desc` orders; the new class is not in it, so it correctly reports ascending.
+
+- [ ] **Step 4: Build both targets**
+
+```bash
+dotnet build Jellyfin.Plugin.SmartLists --framework net10.0 --configuration Release
+dotnet build Jellyfin.Plugin.SmartLists --framework net9.0 --configuration Release
+```
+
+Expected: both succeed, zero warnings (warnings are errors).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs Jellyfin.Plugin.SmartLists/Core/Orders/LastPlayedOrderBase.cs Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+git commit -m "Add Least Recently Watched Round Robin order and registry entries"
+```
+
+---
+
+### Task 2: SmartList recency injection
+
+**Files:**
+
+- Modify: `Jellyfin.Plugin.SmartLists/Core/SmartList.cs` (top of `FilterPlaylistItems`, ~line 715-722)
+
+**Interfaces:**
+
+- Consumes: `RoundRobinLeastRecentlyWatchedOrder.GroupRecency` (property) and `RoundRobinLeastRecentlyWatchedOrder.BuildGroupRecency(...)` from Task 1.
+- Produces: every `RoundRobinLeastRecentlyWatchedOrder` in `Orders` has `GroupRecency` populated before any of the three `PrepareRoundRobinPositions` call sites (lines ~894, ~1106, ~1364) runs. No signature changes anywhere.
+
+- [ ] **Step 1: Inject the recency map at the top of `FilterPlaylistItems`**
+
+Current code at ~line 715:
+
+```csharp
+        public IEnumerable<Guid> FilterPlaylistItems(IEnumerable<BaseItem> items, ILibraryManager libraryManager,
+            User user, RefreshQueueService.RefreshCache refreshCache, IUserDataManager? userDataManager = null, ILogger? logger = null, Action<int, int>? progressCallback = null)
+        {
+            var stopwatch = Stopwatch.StartNew();
+
+            // Clear similarity scores from any previous runs
+            _similarityScores.Clear();
+```
+
+Insert directly after the `_similarityScores.Clear();` line:
+
+```csharp
+            // Least Recently Watched Round Robin needs per-group watch recency computed from the
+            // UNFILTERED pool: rules like "Playback Status is Unwatched" remove watched items from
+            // the results, so recency derived from filtered items would see every group as unwatched.
+            // Same injection pattern as SimilarityOrder.Scores / RuleBlockOrder.GroupMappings.
+            if (Orders != null && Orders.Any(o => o is RoundRobinLeastRecentlyWatchedOrder))
+            {
+                var recencyPool = items as IList<BaseItem> ?? items.ToList();
+                items = recencyPool;
+                foreach (var lrwOrder in Orders.OfType<RoundRobinLeastRecentlyWatchedOrder>())
+                {
+                    lrwOrder.GroupRecency = RoundRobinLeastRecentlyWatchedOrder.BuildGroupRecency(
+                        recencyPool, lrwOrder.GroupByField, user, userDataManager, refreshCache, logger);
+                }
+            }
+```
+
+Notes for the implementer:
+
+- The `items = recencyPool;` reassignment prevents double enumeration of a lazy `IEnumerable` (the pool is enumerated here and again by the filtering pipeline below).
+- This runs before all three `PrepareRoundRobinPositions` call sites, including the per-rule-block path and the include-only early-return path, so no call-site changes are needed.
+- If the file needs a using for `System.Linq`, it already has one (the method uses `.Select` below).
+
+- [ ] **Step 2: Build both targets**
+
+```bash
+dotnet build Jellyfin.Plugin.SmartLists --framework net10.0 --configuration Release
+dotnet build Jellyfin.Plugin.SmartLists --framework net9.0 --configuration Release
+```
+
+Expected: both succeed, zero warnings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+git commit -m "Inject watch-recency map into Least Recently Watched Round Robin before sorting"
+```
+
+---
+
+### Task 3: UI sort constants
+
+**Files:**
+
+- Modify: `Jellyfin.Plugin.SmartLists/Configuration/config-core.js` (~lines 65-96)
+
+**Interfaces:**
+
+- Consumes: nothing from other tasks (value string must match Task 1's registry name exactly).
+- Produces: `'Least Recently Watched Round Robin'` present in `SORT_OPTIONS`, `ORDERLESS_SORTS`, `ROUND_ROBIN_SORTS`. All dropdown visibility (Group By shown, Asc/Desc hidden), save paths, and display formatting flow through the existing `isOrderlessSort`/`isRoundRobinSort` predicates — no other JS files change.
+
+- [ ] **Step 1: Add the three entries in `config-core.js`**
+
+In `SmartLists.SORT_OPTIONS` (~line 87), after the Shuffled Round Robin entry:
+
+```javascript
+        { value: 'Shuffled Round Robin', label: 'Shuffled Round Robin (Interleave)' },
+        { value: 'Least Recently Watched Round Robin', label: 'Least Recently Watched Round Robin (Interleave)' },
+```
+
+Replace the two constant arrays (~lines 93 and 96):
+
+```javascript
+    // Sorts that have no Ascending/Descending direction
+    SmartLists.ORDERLESS_SORTS = ['Random', 'Random Round Robin', 'Shuffled Round Robin', 'Least Recently Watched Round Robin', 'NoOrder'];
+
+    // Round Robin sort variants (all use a GroupBy field)
+    SmartLists.ROUND_ROBIN_SORTS = ['Round Robin', 'Random Round Robin', 'Shuffled Round Robin', 'Least Recently Watched Round Robin'];
+```
+
+- [ ] **Step 2: Verify no hardcoded round-robin chains remain that would miss the new sort**
+
+```bash
+grep -n "Shuffled Round Robin" Jellyfin.Plugin.SmartLists/Configuration/*.js
+```
+
+Expected: hits ONLY in `config-core.js` (the SORT_OPTIONS entry and the two arrays). If any other file hardcodes the round-robin list, add the new name there the same way and note it as a deviation.
+
+- [ ] **Step 3: Syntax-check**
+
+```bash
+node --check Jellyfin.Plugin.SmartLists/Configuration/config-core.js
+```
+
+Expected: no output (success).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Jellyfin.Plugin.SmartLists/Configuration/config-core.js
+git commit -m "Add Least Recently Watched Round Robin to UI sort constants"
+```
+
+---
+
+### Task 4: Docs
+
+**Files:**
+
+- Modify: `docs/content/user-guide/sorting-and-limits.md` (round robin section — locate with `grep -n "Round Robin" docs/content/user-guide/sorting-and-limits.md`)
+
+**Interfaces:** none — prose only. Match the page's existing tone/format for the other round-robin variants (read the section first, follow its structure: if variants are a table, add a row; if subsections, add a subsection).
+
+- [ ] **Step 1: Document the variant**
+
+Content to convey (adapt to the page's existing format, don't paste verbatim if the section is a table):
+
+```markdown
+#### Least Recently Watched Round Robin
+
+Rotates through your shows starting with the one you watched *least* recently — shows you have
+never watched come first, and the show you watched most recently goes to the back of the rotation.
+Watch an episode of Show A today, and on the next refresh Show A moves to the end while the others
+shift forward. Episodes within each show stay in their natural order (season/episode).
+
+Unlike Random Round Robin, the rotation is not shuffled — it is derived from your watch history,
+so it "continues where you left off" across refreshes.
+
+**Recommended setup for a fair TV rotation:**
+
+- **Sort By:** Least Recently Watched Round Robin, **Group By:** Series Name
+- **Rule:** Playback Status → is → Unwatched (watched episodes drop off; each show's next unwatched
+  episode surfaces automatically)
+- **Auto-refresh:** On all changes (the rotation advances right after you finish watching something)
+
+With other auto-refresh modes the rotation still advances, but only at the next refresh
+(scheduled or library change).
+
+!!! note
+    For playlists shared by multiple users, each user gets their own rotation based on their own
+    watch history.
+```
+
+- [ ] **Step 2: Check for other docs mentioning the round-robin family**
+
+```bash
+grep -rn "Random Round Robin" docs/content/ | grep -v sorting-and-limits
+```
+
+If example pages enumerate the variants (e.g. `docs/content/examples/common-use-cases.md`), add the new variant consistently there too.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/content/
+git commit -m "Document Least Recently Watched Round Robin"
+```
+
+---
+
+### Task 5: End-to-end verification against local Jellyfin
+
+**Files:** none modified — verification only. Follow spec section "Verification".
+
+- [ ] **Step 1: Build and deploy to the local container**
+
+```bash
+cd dev && ./build-local.sh
+```
+
+Expected: build succeeds, container restarts.
+
+- [ ] **Step 2: Create a test playlist via the admin API**
+
+Use the pattern from previous sessions: base URL `http://localhost:8096`, admin API key from `dev/` config (check `dev/` scripts or ask the driver). Create a playlist with: MediaTypes `["Episode"]`, sort `SortBy: "Least Recently Watched Round Robin"` + `GroupByField: "SeriesName"` (SortOptions format), rule `Playback Status is Unwatched` for the owner user, `AutoRefresh: OnAllChanges`. POST to the SmartLists controller endpoint (same endpoint used when testing bumpers: `/Plugins/SmartLists/...` — discover exact route via `grep -n "Route" Jellyfin.Plugin.SmartLists/Api/Controllers/SmartListController.cs`).
+
+- [ ] **Step 3: Verify initial rotation**
+
+Refresh the playlist, then fetch its items. Expected: series interleave alphabetically (all never-watched), episodes in season/episode order within each series slot.
+
+- [ ] **Step 4: Watch something and verify rotation advance**
+
+Mark the first episode played via Jellyfin API (`POST /Users/{userId}/PlayedItems/{itemId}` with the API key). Wait for the batched auto-refresh (up to ~30s; watch `docker logs jellyfin 2>&1 | grep -i "Smart"`). Fetch items again. Expected: the watched episode's series now rotates LAST; its slot shows that series' next unwatched episode; other series shifted forward.
+
+- [ ] **Step 5: Verify determinism**
+
+Refresh the playlist twice more without watching anything. Expected: identical order both times (no shuffle).
+
+- [ ] **Step 6: Regression check**
+
+Refresh an existing Round Robin / Random Round Robin / Shuffled Round Robin playlist (create one if none exists). Expected: behavior unchanged; no new warnings in logs.
+
+- [ ] **Step 7: Clean up test playlists, verify logs clean**
+
+Delete test playlists via API. `docker logs jellyfin 2>&1 | grep -iE "smart.*(error|warn)" | tail -20` — expected: no new errors from this feature.
+
+- [ ] **Step 8: Commit any fixes found; otherwise nothing to commit**
+
+---
+
+## Self-review notes
+
+- Spec coverage: order class + recency semantics (Task 1), unfiltered-pool injection (Task 2), UI constants (Task 3), docs incl. companion recipe + multi-user note (Task 4), verification incl. determinism + regression (Task 5). Auto-refresh: spec says verified no-op — no task, docs cover the mode note.
+- Names consistent: `RoundRobinLeastRecentlyWatchedOrder`, `GroupRecency`, `BuildGroupRecency`, registry/JS string `"Least Recently Watched Round Robin"`.
+- `UserDataCacheHelper.GetCachedUserData` returns `UserItemData?`; passing it to `GetLastPlayedDateFromUserData(object?)` is fine (reflection helper handles any shape across both target ABIs).

--- a/docs/superpowers/specs/2026-07-10-least-recently-watched-round-robin-design.md
+++ b/docs/superpowers/specs/2026-07-10-least-recently-watched-round-robin-design.md
@@ -62,11 +62,9 @@ No change to the `OrderGroupKeys` hook signature — the recency map is instance
 
 ### Auto-refresh (`Services/Shared/AutoRefreshService.cs`)
 
-Without this, the rotation only advances on library changes or schedule — watching an episode wouldn't reorder anything until some unrelated refresh. Playlists using this sort must be treated as playback-relevant:
+**Verified during planning: no code change needed.** Playback events already reach every playlist this sort cares about: `IsRelevantUserDataChange` treats a `LastPlayedDate` change as significant, `GetAffectedPlaylistsFromCacheAsync` selects playlists by **media type** (the field-level `_ruleTypeToPlaylistsCache` is not consulted for filtering — "kept for potential future optimizations"), and `IsUserRelevantToPlaylist` is a membership check (AllUsers / UserPlaylists / owner) that the watching user always passes for their own playlists. A playlist with Auto-refresh **On all changes** therefore re-sorts right after a watch with zero changes here.
 
-- In `AddPlaylistToRuleCache`: when any sort option's `SortBy` is "Least Recently Watched Round Robin", register the playlist under the same `"{MediaType}+PlaybackStatus"`-style cache keys as if it had a `PlaybackStatus` rule (for each of the playlist's media types).
-- In the `IsItemRelevantToPlaylist` fallback: also return true for playback-data changes when the playlist uses this sort.
-- Docs note: per-play rotation advance requires Auto-refresh **On all changes** (playback events route through `OnUserDataSaved` → `HandleLibraryChangeAsync`, which filters to OnAllChanges playlists).
+- Docs note only: per-play rotation advance requires Auto-refresh **On all changes**; other modes advance the rotation at their next refresh.
 
 ### UI (`Configuration/config-core.js`, `config-sorts.js`)
 
@@ -106,7 +104,7 @@ Document as an example on the sorting docs page (and cross-link from the round-r
 
 | Area | Files |
 | --- | --- |
-| Backend | `Core/Orders/RoundRobinOrder.cs`, `Core/SmartList.cs`, `Services/Shared/AutoRefreshService.cs` |
+| Backend | `Core/Orders/RoundRobinOrder.cs`, `Core/Orders/LastPlayedOrderBase.cs` (promote two private helpers), `Core/SmartList.cs` |
 | UI | `Configuration/config-core.js` (constants), `config-sorts.js`/`config-formatters.js` (verify predicates only) |
 | Docs | `/docs/content/` sorting page + example |
 
@@ -119,4 +117,4 @@ No test suite; verify against local Jellyfin (`cd dev && ./build-local.sh`, both
 3. Mark an episode of Show A watched (via UI or API) → playlist auto-refreshes → rotation now B, C, A; Show A's watched episode gone (unwatched rule), its next episode appears in Show A's slots.
 4. Watch Show B → rotation C, A, B.
 5. Remove the unwatched rule, refresh: watched episodes reappear in natural order within their groups; rotation still least-recently-watched first.
-6. Regression: Round Robin Ascending/Descending/Random/Shuffled playlists refresh unchanged; a playlist without this sort does not start refreshing on playback events (cache keys scoped to LRW playlists only).
+6. Regression: Round Robin Ascending/Descending/Random/Shuffled playlists refresh unchanged (auto-refresh behavior is untouched — no AutoRefreshService changes in this feature).

--- a/docs/superpowers/specs/2026-07-10-least-recently-watched-round-robin-design.md
+++ b/docs/superpowers/specs/2026-07-10-least-recently-watched-round-robin-design.md
@@ -1,0 +1,122 @@
+# Design: Least Recently Watched Round Robin
+
+**Date:** 2026-07-10
+**Status:** Draft — awaiting user review
+**Origin:** User feedback on Round Robin — "if I watch 2 episodes today, they are Show A and B. Tomorrow ... it will be Shows A and B again and C and D will never get watched. If I open my list and see Show A, B, C, D, and I watch 2 episodes, I would like to open my list tomorrow and see Show C, D, A, B."
+
+## Behavior
+
+A new sort option, **"Least Recently Watched Round Robin"**, extends the round-robin family. Groups (shows) are ordered by how recently the user watched anything in them — least recently watched first, never-watched first of all — then interleaved round-robin with natural episode order within each group.
+
+Watch an episode of Show A today → on the next refresh Show A's slot moves to the back of the rotation. The rotation "continues where you left off" without any persisted rotation state: it is derived entirely from Jellyfin's per-user `LastPlayedDate` data.
+
+| Variant | Group order | Within-group order |
+| --- | --- | --- |
+| Round Robin Ascending | A→Z | Natural (season/episode, disc/track, name) |
+| Round Robin Descending | Z→A | Natural |
+| Random Round Robin | Shuffled | Natural |
+| Shuffled Round Robin | Shuffled | Shuffled |
+| **Least Recently Watched Round Robin (new)** | **Oldest watch date → newest; never-watched first** | **Natural** |
+
+Directionless (no Asc/Desc variants — "most recently watched first" has no use case). Deterministic: same watch history → same order.
+
+### Group recency definition
+
+For each group (e.g. each series), recency = the **maximum per-user `LastPlayedDate` across all of the group's items in the playlist's full media pool** — *before* rule filtering. This is load-bearing: the intended companion rule is `Playback Status is Unwatched`, which removes watched episodes from the result list. If recency were computed from the filtered results, every group would look never-watched and the feature would degrade to alphabetical. Computing from the unfiltered pool means the watched-yesterday episode still stamps its show as recently watched even though it no longer appears in the playlist.
+
+- Never-watched group → `DateTime.MinValue` → sorts first. Ties (including all-never-watched) break alphabetically by group key (natural comparer) — degrades gracefully to Round Robin Ascending.
+- Partially watched episodes count: Jellyfin sets `LastPlayedDate` on playback, so starting an episode moves its show back. Desired ("I watched some of A today").
+- Works for any Group By field (Series Name, Album, Artist, Genres, Studios): recency is per group key, aggregated over pool items, not series-specific.
+- Container items (Series/Season/MusicAlbum media types): recency from the item's own user data, upgraded to the aggregate-over-children value when the refresh cache has children (same mechanism as `LastPlayedOrderBase.GetAggregateLastPlayedDate` — reuse it, promote from `private` if needed).
+
+## Implementation
+
+### Order class (`Core/Orders/RoundRobinOrder.cs`)
+
+```csharp
+public class RoundRobinLeastRecentlyWatchedOrder : RoundRobinBase
+{
+    public override string Name => "Least Recently Watched Round Robin";
+
+    /// <summary>Group key → most recent LastPlayedDate. Set by SmartList before PreComputePositions.</summary>
+    public Dictionary<string, DateTime> GroupRecency { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+    protected override List<string> OrderGroupKeys(IEnumerable<string> keys)
+    {
+        return keys
+            .OrderBy(k => GroupRecency.TryGetValue(k, out var d) ? d : DateTime.MinValue)
+            .ThenBy(k => k, OrderUtilities.SharedNaturalComparer)
+            .ToList();
+    }
+}
+```
+
+No change to the `OrderGroupKeys` hook signature — the recency map is instance state, mirroring how `GroupByField` is already injected by SmartList. `ItemPositions`/`GetSortKey` mechanics unchanged, so multi-sort cascades, early-return paths, per-group limits, and MaxItems compose exactly as for the other round-robin variants.
+
+### SmartList (`Core/SmartList.cs`)
+
+1. **Recency map construction.** `PrepareRoundRobinPositions` gains the context to build the map: the full unfiltered per-user pool, `User`, `IUserDataManager?`, and `RefreshQueueService.RefreshCache?`. For each `RoundRobinLeastRecentlyWatchedOrder` in `Orders`: one pass over the pool, `ExtractGroupKey(item, GroupByField)` → track max `LastPlayedDate` (via `UserDataCacheHelper.GetCachedUserData` when a refresh cache is present, falling back to `userDataManager.GetUserData`), assign the resulting map to `GroupRecency`, then `PreComputePositions` as today. When `userDataManager` or `user` is null, log a warning and leave the map empty (alphabetical fallback) — same convention as `LastPlayedOrderBase`.
+2. **All three call sites** of `PrepareRoundRobinPositions` (main results, expanded results, per-rule-block group items) pass the full pool available in their scope plus the user context already flowing through `FilterPlaylistItems`. Verify at implementation time that the per-rule-block path has the pre-filter pool in scope; if only the block-filtered subset is available there, pass the widest set the scope has and note it (per-block lists are an edge case for this sort).
+3. **Registry**: add `{ "Least Recently Watched Round Robin", () => new RoundRobinLeastRecentlyWatchedOrder() }` to the order map, add the name to `DirectionlessOrders`. The existing generic `is RoundRobinBase` branch in `InitializeFromDto` already assigns `GroupByField` — no special-casing.
+4. `IsDescendingOrder`: not descending (no change needed if the default is false — verify).
+
+### Auto-refresh (`Services/Shared/AutoRefreshService.cs`)
+
+Without this, the rotation only advances on library changes or schedule — watching an episode wouldn't reorder anything until some unrelated refresh. Playlists using this sort must be treated as playback-relevant:
+
+- In `AddPlaylistToRuleCache`: when any sort option's `SortBy` is "Least Recently Watched Round Robin", register the playlist under the same `"{MediaType}+PlaybackStatus"`-style cache keys as if it had a `PlaybackStatus` rule (for each of the playlist's media types).
+- In the `IsItemRelevantToPlaylist` fallback: also return true for playback-data changes when the playlist uses this sort.
+- Docs note: per-play rotation advance requires Auto-refresh **On all changes** (playback events route through `OnUserDataSaved` → `HandleLibraryChangeAsync`, which filters to OnAllChanges playlists).
+
+### UI (`Configuration/config-core.js`, `config-sorts.js`)
+
+- Add `'Least Recently Watched Round Robin'` to `SORT_OPTIONS` (next to the other round-robin entries), `ROUND_ROBIN_SORTS` (Group By dropdown visibility + GroupByField save path), and `ORDERLESS_SORTS` (hide the Asc/Desc dropdown). The centralized predicates from the review-fixes pass (`isRoundRobinSort`/`isOrderlessSort`) mean no per-site condition chains need touching.
+- `config-formatters.js` display formatting flows through the same predicates — verify the name renders in the properties panel sort row.
+- Both HTML pages: nothing — sort options are JS-driven.
+
+### Validation / DTO
+
+None. The sort is selected by name like every other sort; no new DTO fields, no InputValidator changes.
+
+## Recommended companion setup (docs)
+
+The sort answers "which show comes first"; pairing it with these makes the full "continue watching my rotation" experience:
+
+- Rule: `Playback Status` → `is` → `Unwatched` (watched episodes drop off; natural within-group order then surfaces each show's next unwatched episode).
+- Auto-refresh: **On all changes** (rotation advances right after watching).
+- Group By: `Series Name` for TV.
+
+Document as an example on the sorting docs page (and cross-link from the round-robin section).
+
+## Edge cases
+
+- **No GroupByField**: existing warning + original order (unchanged base behavior).
+- **All groups never-watched**: alphabetical rotation — identical to Round Robin Ascending until the first watch.
+- **User watches something mid-refresh-cycle without auto-refresh**: rotation stale until next refresh; documented, not defended in code.
+- **AllUsers playlists**: `ProcessPlaylist` runs per user; each user gets their own rotation from their own watch data. Collections use the reference user, consistent with other user-data sorts.
+- **Bumpers**: unrelated — weave runs after sorting; composes with this sort like any other.
+
+## Out of scope
+
+- Persisted rotation state (pointer files, "resume position") — watch-data derivation covers the use case with zero storage.
+- A "Most Recently Watched" descending variant.
+- Changing existing round-robin variants.
+
+## Touched files
+
+| Area | Files |
+| --- | --- |
+| Backend | `Core/Orders/RoundRobinOrder.cs`, `Core/SmartList.cs`, `Services/Shared/AutoRefreshService.cs` |
+| UI | `Configuration/config-core.js` (constants), `config-sorts.js`/`config-formatters.js` (verify predicates only) |
+| Docs | `/docs/content/` sorting page + example |
+
+## Verification
+
+No test suite; verify against local Jellyfin (`cd dev && ./build-local.sh`, both target frameworks build clean):
+
+1. Playlist: Episode media type, 3+ series, sort = Least Recently Watched Round Robin, Group By = Series Name, rule `Playback Status is Unwatched`, auto-refresh On all changes.
+2. Initial refresh: never-watched shows rotate alphabetically (A, B, C, A, B, C, ...).
+3. Mark an episode of Show A watched (via UI or API) → playlist auto-refreshes → rotation now B, C, A; Show A's watched episode gone (unwatched rule), its next episode appears in Show A's slots.
+4. Watch Show B → rotation C, A, B.
+5. Remove the unwatched rule, refresh: watched episodes reappear in natural order within their groups; rotation still least-recently-watched first.
+6. Regression: Round Robin Ascending/Descending/Random/Shuffled playlists refresh unchanged; a playlist without this sort does not start refreshing on playback events (cache keys scoped to LRW playlists only).


### PR DESCRIPTION
## What
Adds a new round-robin sort variant, **Least Recently Watched Round Robin**, that orders the show rotation by how recently the user watched each show — least recently watched first, never-watched shows first of all — so the rotation continues where the user left off.

## Why
User feedback on Round Robin: with an alphabetical rotation the same shows always sit at the top, so shows further down never get watched. This variant derives the rotation from per-user `LastPlayedDate` data — no persisted rotation state — and is deterministic for a given watch history.

## Changes
- **`RoundRobinLeastRecentlyWatchedOrder`** (`Core/Orders/RoundRobinOrder.cs`): orders groups by a `GroupRecency` map (group key → most recent per-user LastPlayedDate), alphabetical tie-break, never-watched groups first. Registered in `OrderMap` and `DirectionlessOrders`.
- **Recency injection** (`Core/SmartList.cs`): `FilterPlaylistItems` builds the recency map from the **unfiltered** media pool before sorting — required so the recommended companion rule `Playback Status = Unplayed` (which removes watched episodes from results) doesn't blind the sort. Same injection pattern as `SimilarityOrder.Scores`.
- **Helper promotion** (`Core/Orders/LastPlayedOrderBase.cs`): `GetAggregateLastPlayedDate` / `GetLastPlayedDateFromUserData` promoted to `internal` for reuse (container items aggregate over cached children).
- **UI** (`Configuration/config-core.js`): new entry in `SORT_OPTIONS`, `ORDERLESS_SORTS`, `ROUND_ROBIN_SORTS` — all dropdown visibility and formatting flows through the existing predicates.
- **Docs**: new variant section + recommended setup in `sorting-and-limits.md`, "Continue-Where-You-Left-Off TV Channel" recipe in `common-use-cases.md`. Collections note: one rotation from the reference user's watch history.
- **Auto-refresh**: no code changes needed (verified: playback events already reach playlists via the media-type cache and user membership check; `LastPlayedDate` changes count as significant). With Auto-refresh "On All Changes" the rotation advances right after watching.
- Spec + implementation plan under `docs/superpowers/`.

## Verification
Live-tested against local Jellyfin 12 (both `net10.0`/`net9.0` build clean, warnings-as-errors):
- Initial rotation matched independently computed recency order (never-watched alphabetical, then oldest→newest watch date)
- Marking an episode played auto-advanced the rotation: that show moved to last
- Deterministic across repeated refreshes
- With `Playback Status = Unplayed`, watched episodes drop off but the rotation still reflects pool recency (the just-watched show stays last, its slot surfaces the next unwatched episode)
- Existing round-robin variants and other playlists refresh unchanged; no plugin errors/warnings in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBFLcyWKuktDSu9acy68zg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Least Recently Watched Round Robin (Interleave)” sorting.
  * Interleaves groups based on each user’s watch history, prioritizing never- or least-recently-watched groups.
  * Added configuration support for the new directionless sorting option.

* **Documentation**
  * Added user guidance, setup recommendations, examples, and multi-user behavior details for the new sorting mode.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->