### PR TITLE
Added "More options" collapsable section when creating/editing lists.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,3 +131,10 @@ Every tag builds **both** ABIs (`TARGETS` in release.yml: 10.11.0/net9.0 and 12.
 - Update the mkdocs `/docs/content/` when adding user-facing features. Put any examples in the example sections.
 - **UI changes must update both HTML files**: `config.html` (admin) and `user-playlists.html` (user) - the JS modules are shared
 - Form fields need updates in: HTML (both pages), JS (create/edit/display), and backend DTOs
+- **Create-form fields and the Advanced options fold**: required inputs must never
+  be placed inside `#advanced-options-body` (collapsed `display:none` hides native
+  validation). New advanced fields go under the matching sub-heading inside the fold
+  (Limits / Bumpers / Automation / Sharing / Presentation); new core fields go above
+  it. If a new advanced field has an unambiguous non-default state, add a signal for
+  it in `syncAdvancedSection` (config-lists.js) so edit mode surfaces it as a chip
+  and auto-expands.

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
@@ -1307,6 +1307,16 @@
                     SmartLists.createPlaylist(page);
                 }
             }, SmartLists.getEventListenerOptions(pageSignal));
+
+            // If native validation flags a control hidden inside the collapsed
+            // Advanced fold, expand the fold so the browser can focus it.
+            // ('invalid' doesn't bubble — use capture.)
+            playlistForm.addEventListener('invalid', function (e) {
+                const body = page.querySelector('#advanced-options-body');
+                if (body && body.style.display === 'none' && body.contains(e.target)) {
+                    SmartLists.toggleAdvancedOptions(page, true);
+                }
+            }, { capture: true, signal: pageSignal });
         }
 
         const randomGroupSelectionEnabled = page.querySelector('#randomGroupSelectionEnabled');
@@ -2556,6 +2566,11 @@
             // Re-apply list type visibility after cleanup
             if (page._pageInitialized) {
                 SmartLists.handleListTypeChange(page);
+                // bfcache can restore the fold body/icon out of sync
+                const advBody = page.querySelector('#advanced-options-body');
+                if (advBody && SmartLists.toggleAdvancedOptions) {
+                    SmartLists.toggleAdvancedOptions(page, advBody.style.display !== 'none');
+                }
                 // Reload backup list when navigating back to the page (admin pages only)
                 if (!SmartLists.IS_USER_PAGE && SmartLists.loadBackupList) {
                     SmartLists.loadBackupList();

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
@@ -459,6 +459,10 @@
             }
             SmartLists.setCurrentUserAsDefault(page);
         }
+
+        if (SmartLists.renderAdvancedSummaryFromForm) {
+            SmartLists.renderAdvancedSummaryFromForm(page);
+        }
     };
 
     // Fallback defaults when config fails to load
@@ -489,6 +493,10 @@
         const sortsContainer = page.querySelector('#sorts-container');
         if (sortsContainer && sortsContainer.querySelectorAll('.sort-box').length === 0) {
             SmartLists.safeAddSortBox(page, { SortBy: 'NoOrder', SortOrder: 'Ascending' });
+        }
+
+        if (SmartLists.renderAdvancedSummaryFromForm) {
+            SmartLists.renderAdvancedSummaryFromForm(page);
         }
     };
 

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
@@ -1250,6 +1250,13 @@
                 SmartLists.closeAllKebabMenus(page);
             }
 
+            if (target.closest('#advanced-options-header')) {
+                if (SmartLists.toggleAdvancedOptions) {
+                    SmartLists.toggleAdvancedOptions(page);
+                }
+                return;
+            }
+
             if (target.closest('.playlist-header')) {
                 const playlistCard = target.closest('.playlist-card');
                 if (playlistCard && SmartLists.togglePlaylistCard) {

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -678,16 +678,9 @@
         }
     };
 
-    SmartLists.renderAdvancedSummaryFromForm = function (page) {
-        // Edit mode owns the summary via syncAdvancedSection; don't let
-        // late-arriving async defaults overwrite its chips.
-        if (page._editMode) {
-            return;
-        }
-        const summaryEl = page.querySelector('#advanced-summary');
-        if (!summaryEl) {
-            return;
-        }
+    // Value chips (Max Items, auto-refresh) read from the populated form.
+    // Shared by the create-mode default summary and the edit/clone summary.
+    SmartLists.getAdvancedValueChips = function (page) {
         const parts = [];
         const maxItems = parseInt(SmartLists.getElementValue(page, '#playlistMaxItems', '0'), 10);
         if (!isNaN(maxItems)) {
@@ -702,7 +695,20 @@
         if (refreshValue) {
             parts.push(refreshLabels[refreshValue] || refreshValue);
         }
-        summaryEl.textContent = parts.join(' · ');
+        return parts;
+    };
+
+    SmartLists.renderAdvancedSummaryFromForm = function (page) {
+        // Edit mode owns the summary via syncAdvancedSection; don't let
+        // late-arriving async defaults overwrite its chips.
+        if (page._editMode) {
+            return;
+        }
+        const summaryEl = page.querySelector('#advanced-summary');
+        if (!summaryEl) {
+            return;
+        }
+        summaryEl.textContent = SmartLists.getAdvancedValueChips(page).join(' · ');
     };
 
     SmartLists.syncAdvancedSection = function (page, playlist) {
@@ -736,7 +742,12 @@
         if (imageRows > 0) {
             chips.push(imageRows === 1 ? '1 image' : imageRows + ' images');
         }
-        summaryEl.textContent = chips.join(' · ');
+        // Feature signals first, then the always-present value chips (Max Items,
+        // auto-refresh) read from the populated form, so applied configuration
+        // stays visible on the collapsed header in edit/clone mode too.
+        summaryEl.textContent = chips.concat(SmartLists.getAdvancedValueChips(page)).join(' · ');
+        // Auto-expand only on unambiguous feature signals — value fields have
+        // async-loaded defaults, so "non-default" can't be determined reliably.
         if (chips.length > 0) {
             SmartLists.toggleAdvancedOptions(page, true);
         }

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -678,6 +678,33 @@
         }
     };
 
+    SmartLists.renderAdvancedSummaryFromForm = function (page) {
+        // Edit mode owns the summary via syncAdvancedSection; don't let
+        // late-arriving async defaults overwrite its chips.
+        if (page._editMode) {
+            return;
+        }
+        const summaryEl = page.querySelector('#advanced-summary');
+        if (!summaryEl) {
+            return;
+        }
+        const parts = [];
+        const maxItems = parseInt(SmartLists.getElementValue(page, '#playlistMaxItems', '0'), 10);
+        if (!isNaN(maxItems)) {
+            parts.push(maxItems > 0 ? maxItems + ' items max' : 'unlimited items');
+        }
+        const refreshLabels = {
+            'Never': 'no auto-refresh',
+            'OnLibraryChanges': 'refresh on library changes',
+            'OnAllChanges': 'refresh on all changes'
+        };
+        const refreshValue = SmartLists.getElementValue(page, '#autoRefreshMode', '');
+        if (refreshValue) {
+            parts.push(refreshLabels[refreshValue] || refreshValue);
+        }
+        summaryEl.textContent = parts.join(' · ');
+    };
+
     SmartLists.clearForm = function (page) {
         // Only handle form clearing - edit mode management should be done by caller
 

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -705,6 +705,43 @@
         summaryEl.textContent = parts.join(' · ');
     };
 
+    SmartLists.syncAdvancedSection = function (page, playlist) {
+        const summaryEl = page.querySelector('#advanced-summary');
+        if (!summaryEl || !playlist) {
+            return;
+        }
+        const chips = [];
+        if (playlist.Bumpers && playlist.Bumpers.MediaTypes && playlist.Bumpers.MediaTypes.length > 0) {
+            chips.push('Bumpers');
+        }
+        const scheduleCount = (playlist.Schedules || []).length + (playlist.VisibilitySchedules || []).length;
+        if (scheduleCount > 0) {
+            chips.push(scheduleCount + (scheduleCount === 1 ? ' schedule' : ' schedules'));
+        }
+        if (playlist.RandomGroupSelection && playlist.RandomGroupSelection.Enabled) {
+            chips.push('Random groups');
+        }
+        if (playlist.MaxPlayTimeMinutes > 0) {
+            chips.push('Playtime limit');
+        }
+        if (playlist.Enabled === false) {
+            chips.push('Disabled');
+        }
+        if (playlist.SortTitle || playlist.Overview || playlist.Favorite === true || playlist.Favorite === false ||
+            (playlist.Tags && playlist.Tags.length > 0)) {
+            chips.push('Metadata');
+        }
+        // Images arrive via a separate async endpoint; count what's in the DOM.
+        const imageRows = page.querySelectorAll('#custom-images-container [id^="image-row-"]').length;
+        if (imageRows > 0) {
+            chips.push(imageRows === 1 ? '1 image' : imageRows + ' images');
+        }
+        summaryEl.textContent = chips.join(' · ');
+        if (chips.length > 0) {
+            SmartLists.toggleAdvancedOptions(page, true);
+        }
+    };
+
     SmartLists.clearForm = function (page) {
         // Only handle form clearing - edit mode management should be done by caller
 
@@ -774,6 +811,11 @@
         // Clear custom images container
         if (SmartLists.initCustomImagesContainer) {
             SmartLists.initCustomImagesContainer(page);
+        }
+
+        // Reset the Advanced options fold to collapsed
+        if (SmartLists.toggleAdvancedOptions) {
+            SmartLists.toggleAdvancedOptions(page, false);
         }
     };
 
@@ -1007,10 +1049,16 @@
                     SmartLists.initMetadataTagsInput(page, playlist.Tags || []);
                 }
 
-                // Load existing images for this playlist
+                // Load existing images for this playlist, then re-sync the
+                // Advanced fold so an images-only list still expands.
                 if (SmartLists.loadExistingImages) {
-                    SmartLists.loadExistingImages(page, playlistId);
+                    SmartLists.loadExistingImages(page, playlistId).then(function () {
+                        SmartLists.syncAdvancedSection(page, playlist);
+                    });
                 }
+
+                // Chips + auto-expand from the loaded list (images re-sync above)
+                SmartLists.syncAdvancedSection(page, playlist);
 
             } catch (formError) {
                 console.error('Error populating form for edit:', formError);
@@ -1234,6 +1282,9 @@
                 if (SmartLists.initMetadataTagsInput) {
                     SmartLists.initMetadataTagsInput(page, playlist.Tags || []);
                 }
+
+                // Chips + auto-expand for cloned advanced config
+                SmartLists.syncAdvancedSection(page, playlist);
 
                 // Show success message
                 SmartLists.showNotification('List "' + playlistName + '" cloned successfully! You can now modify and create the new list.', 'success');

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -661,6 +661,23 @@
         }
     };
 
+    SmartLists.toggleAdvancedOptions = function (page, force) {
+        const body = page.querySelector('#advanced-options-body');
+        if (!body) {
+            return;
+        }
+        const expand = force !== undefined ? force : body.style.display === 'none';
+        body.style.display = expand ? 'block' : 'none';
+        const icon = page.querySelector('#advanced-expand-icon');
+        if (icon) {
+            icon.textContent = expand ? '▼' : '▶';
+        }
+        const header = page.querySelector('#advanced-options-header');
+        if (header) {
+            header.setAttribute('aria-expanded', expand ? 'true' : 'false');
+        }
+    };
+
     SmartLists.clearForm = function (page) {
         // Only handle form clearing - edit mode management should be done by caller
 

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-user-select.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-user-select.js
@@ -164,16 +164,25 @@
         const userIds = SmartLists.getSelectedUserIds(page);
         const allUsers = SmartLists.isAllUsersSelected(page);
         const publicCheckboxContainer = page.querySelector('#publicCheckboxContainer');
+        // The "Sharing" sub-heading in the Advanced fold has no content besides
+        // the public checkbox, so it must follow the same visibility.
+        const sharingTitle = page.querySelector('#sharingSectionTitle');
 
         if (publicCheckboxContainer) {
             if (allUsers || userIds.length > 1) {
                 // Hide public checkbox for all-user and multi-user playlists (using inline style)
                 // Note: We use removeProperty() when showing to avoid style persistence across navigations
                 publicCheckboxContainer.style.display = 'none';
+                if (sharingTitle) {
+                    sharingTitle.style.display = 'none';
+                }
             } else {
                 // Show public checkbox for single-user playlists
                 // Remove inline style to prevent persistence across page navigations
                 publicCheckboxContainer.style.removeProperty('display');
+                if (sharingTitle) {
+                    sharingTitle.style.removeProperty('display');
+                }
             }
         }
     };

--- a/Jellyfin.Plugin.SmartLists/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config.html
@@ -149,80 +149,6 @@
                             <div id="sorts-container"></div>
                         </div>
 
-                        <div id="bumper-section" class="inputContainer" style="margin-bottom: 1em;">
-                            <label class="inputLabel">Bumpers (optional)</label>
-                            <div class="fieldDescription" style="margin-bottom: 0.5em;">
-                                Insert short "bumper" items (commercials, interstitials, idents) between playlist
-                                items. Bumpers are selected by their own rules, repeat if fewer than needed, and do
-                                not count toward Max Items.</div>
-                            <div style="display: flex; gap: 1em; flex-wrap: wrap; margin-bottom: 0.5em;">
-                                <div class="selectContainer" style="min-width: 180px;">
-                                    <label class="selectLabel" for="bumperMediaType">Bumper media type</label>
-                                    <select is="emby-select" id="bumperMediaType"
-                                        class="emby-select-withcolor emby-select">
-                                        <option value="">None (disabled)</option>
-                                    </select>
-                                </div>
-                                <div class="selectContainer bumper-detail" style="min-width: 160px; display: none;">
-                                    <label class="selectLabel" for="bumperOrder">Bumper order</label>
-                                    <select is="emby-select" id="bumperOrder"
-                                        class="emby-select-withcolor emby-select">
-                                        <option value="Random">Random</option>
-                                        <option value="Name">Name</option>
-                                        <option value="ReleaseDate">Release Date</option>
-                                    </select>
-                                </div>
-                                <div class="inputContainer bumper-detail" style="min-width: 120px; display: none;">
-                                    <label class="inputLabel" for="bumperInterval">Every N items</label>
-                                    <input type="number" class="emby-input" id="bumperInterval" min="1" max="10000" value="1" />
-                                </div>
-                            </div>
-                            <div id="bumper-rules-container" class="bumper-detail" style="display: none;"></div>
-                            <button type="button" id="add-bumper-rule-group" class="raised emby-button bumper-detail"
-                                style="margin-top: 0.5em; display: none;">
-                                <span>Add Bumper Rule Group</span>
-                            </button>
-                        </div>
-
-                        <div class="checkboxList paperList"
-                            style="padding: 0.5em 1em; margin-bottom: 1em; margin-top: 1em;">
-                            <label class="emby-checkbox-label">
-                                <input type="checkbox" is="emby-checkbox" id="randomGroupSelectionEnabled"
-                                    data-embycheckbox="true" class="emby-checkbox">
-                                <span class="checkboxLabel">
-                                    Random Group Selection
-                                    <a href="https://jellyfin-smartlists-plugin.dinsten.se/user-guide/sorting-and-limits/#random-group-selection"
-                                        target="_blank" rel="noopener noreferrer" title="Documentation"
-                                        style="margin-left: 0.5em; text-decoration: none; color: inherit; display: inline-flex; align-items: center;">
-                                        <span class="material-icons" aria-hidden="true"
-                                            style="font-size: 1.1em; line-height: 0;">info_outline</span>
-                                    </a>
-                                </span>
-                                <span class="checkboxOutline">
-                                    <span class="material-icons checkboxIcon checkboxIcon-checked check"
-                                        aria-hidden="true"></span>
-                                    <span class="material-icons checkboxIcon checkboxIcon-unchecked"
-                                        aria-hidden="true"></span>
-                                </span>
-                            </label>
-                            <div class="fieldDescription">Randomly choose one group from the filtered item pool before
-                                sorting and limits are applied.</div>
-                            <div id="randomGroupSelectionFields" style="display: none; margin-top: 0.75em;">
-                                <div class="selectContainer" style="margin-bottom: 0.75em;">
-                                    <label class="selectLabel" for="randomGroupSelectionGroupBy">Group By</label>
-                                    <select id="randomGroupSelectionGroupBy" is="emby-select"
-                                        class="emby-select-withcolor emby-select"></select>
-                                </div>
-                                <div class="inputContainer" style="margin-bottom: 0;">
-                                    <label class="inputLabel" for="randomGroupSelectionMinimumItems">Minimum Items in Group</label>
-                                    <input type="number" id="randomGroupSelectionMinimumItems" class="emby-input"
-                                        min="0" step="1">
-                                    <div class="fieldDescription">Only consider groups with at least this many items. Leave blank or set to 0 to include all groups.</div>
-                                </div>
-                            </div>
-                        </div>
-
-
                         <div class="inputContainer" style="margin-bottom: 1em;">
                             <label class="inputLabel" for="playlistUser" style="display: flex; align-items: center;">
                                 <span class="playlist-only-label">Playlist Users</span>
@@ -278,7 +204,15 @@
                             </div>
                         </div>
 
-
+                        <button type="button" id="advanced-options-header" class="emby-button"
+                            aria-expanded="false" aria-controls="advanced-options-body"
+                            style="width: 100%; display: flex; align-items: center; gap: 0.5em; text-align: left; padding: 0.75em 1em; margin-bottom: 1em; background: rgba(128, 128, 128, 0.1); border-radius: 4px;">
+                            <span id="advanced-expand-icon" aria-hidden="true">&#9654;</span>
+                            <span style="font-weight: 500;">Advanced options</span>
+                            <span id="advanced-summary" class="fieldDescription" style="margin-left: auto; margin-top: 0; text-align: right;"></span>
+                        </button>
+                        <div id="advanced-options-body" style="display: none;">
+                            <h3 class="sectionTitle" style="margin-top: 0.5em;">Limits</h3>
                         <div class="inputContainer" style="margin-bottom: 1em; margin-top: 1em;">
                             <label class="inputLabel" for="playlistMaxItems"
                                 style="display: flex; align-items: center;">
@@ -311,12 +245,20 @@
                                 limit.</div>
                         </div>
 
-                        <div id="publicCheckboxContainer" class="checkboxList paperList playlist-only-field"
+                        <div class="checkboxList paperList"
                             style="padding: 0.5em 1em; margin-bottom: 1em; margin-top: 1em;">
                             <label class="emby-checkbox-label">
-                                <input type="checkbox" is="emby-checkbox" id="playlistIsPublic" data-embycheckbox="true"
-                                    class="emby-checkbox">
-                                <span class="checkboxLabel">Make playlist public</span>
+                                <input type="checkbox" is="emby-checkbox" id="randomGroupSelectionEnabled"
+                                    data-embycheckbox="true" class="emby-checkbox">
+                                <span class="checkboxLabel">
+                                    Random Group Selection
+                                    <a href="https://jellyfin-smartlists-plugin.dinsten.se/user-guide/sorting-and-limits/#random-group-selection"
+                                        target="_blank" rel="noopener noreferrer" title="Documentation"
+                                        style="margin-left: 0.5em; text-decoration: none; color: inherit; display: inline-flex; align-items: center;">
+                                        <span class="material-icons" aria-hidden="true"
+                                            style="font-size: 1.1em; line-height: 0;">info_outline</span>
+                                    </a>
+                                </span>
                                 <span class="checkboxOutline">
                                     <span class="material-icons checkboxIcon checkboxIcon-checked check"
                                         aria-hidden="true"></span>
@@ -324,9 +266,59 @@
                                         aria-hidden="true"></span>
                                 </span>
                             </label>
-                            <div class="fieldDescription">Allow this playlist to be viewed by any logged in user.</div>
+                            <div class="fieldDescription">Randomly choose one group from the filtered item pool before
+                                sorting and limits are applied.</div>
+                            <div id="randomGroupSelectionFields" style="display: none; margin-top: 0.75em;">
+                                <div class="selectContainer" style="margin-bottom: 0.75em;">
+                                    <label class="selectLabel" for="randomGroupSelectionGroupBy">Group By</label>
+                                    <select id="randomGroupSelectionGroupBy" is="emby-select"
+                                        class="emby-select-withcolor emby-select"></select>
+                                </div>
+                                <div class="inputContainer" style="margin-bottom: 0;">
+                                    <label class="inputLabel" for="randomGroupSelectionMinimumItems">Minimum Items in Group</label>
+                                    <input type="number" id="randomGroupSelectionMinimumItems" class="emby-input"
+                                        min="0" step="1">
+                                    <div class="fieldDescription">Only consider groups with at least this many items. Leave blank or set to 0 to include all groups.</div>
+                                </div>
+                            </div>
                         </div>
 
+                        <div id="bumper-section" class="inputContainer" style="margin-bottom: 1em;">
+                            <h3 class="sectionTitle" style="margin-top: 1.5em;">Bumpers</h3>
+                            <div class="fieldDescription" style="margin-bottom: 0.5em;">
+                                Insert short "bumper" items (commercials, interstitials, idents) between playlist
+                                items. Bumpers are selected by their own rules, repeat if fewer than needed, and do
+                                not count toward Max Items.</div>
+                            <div style="display: flex; gap: 1em; flex-wrap: wrap; margin-bottom: 0.5em;">
+                                <div class="selectContainer" style="min-width: 180px;">
+                                    <label class="selectLabel" for="bumperMediaType">Bumper media type</label>
+                                    <select is="emby-select" id="bumperMediaType"
+                                        class="emby-select-withcolor emby-select">
+                                        <option value="">None (disabled)</option>
+                                    </select>
+                                </div>
+                                <div class="selectContainer bumper-detail" style="min-width: 160px; display: none;">
+                                    <label class="selectLabel" for="bumperOrder">Bumper order</label>
+                                    <select is="emby-select" id="bumperOrder"
+                                        class="emby-select-withcolor emby-select">
+                                        <option value="Random">Random</option>
+                                        <option value="Name">Name</option>
+                                        <option value="ReleaseDate">Release Date</option>
+                                    </select>
+                                </div>
+                                <div class="inputContainer bumper-detail" style="min-width: 120px; display: none;">
+                                    <label class="inputLabel" for="bumperInterval">Every N items</label>
+                                    <input type="number" class="emby-input" id="bumperInterval" min="1" max="10000" value="1" />
+                                </div>
+                            </div>
+                            <div id="bumper-rules-container" class="bumper-detail" style="display: none;"></div>
+                            <button type="button" id="add-bumper-rule-group" class="raised emby-button bumper-detail"
+                                style="margin-top: 0.5em; display: none;">
+                                <span>Add Bumper Rule Group</span>
+                            </button>
+                        </div>
+
+                            <h3 class="sectionTitle" style="margin-top: 1.5em;">Automation</h3>
                         <div class="checkboxList paperList"
                             style="padding: 0.5em 1em; margin-bottom: 1em; margin-top: 1em;">
                             <label class="emby-checkbox-label">
@@ -399,6 +391,24 @@
                             <div class="fieldDescription">Control when this list appears in Jellyfin. Use Enable/Disable actions to automatically show or hide the list on specific dates (e.g., show Christmas movies only in December).</div>
                         </div>
 
+                            <h3 class="sectionTitle playlist-only-field" style="margin-top: 1.5em;">Sharing</h3>
+                        <div id="publicCheckboxContainer" class="checkboxList paperList playlist-only-field"
+                            style="padding: 0.5em 1em; margin-bottom: 1em; margin-top: 1em;">
+                            <label class="emby-checkbox-label">
+                                <input type="checkbox" is="emby-checkbox" id="playlistIsPublic" data-embycheckbox="true"
+                                    class="emby-checkbox">
+                                <span class="checkboxLabel">Make playlist public</span>
+                                <span class="checkboxOutline">
+                                    <span class="material-icons checkboxIcon checkboxIcon-checked check"
+                                        aria-hidden="true"></span>
+                                    <span class="material-icons checkboxIcon checkboxIcon-unchecked"
+                                        aria-hidden="true"></span>
+                                </span>
+                            </label>
+                            <div class="fieldDescription">Allow this playlist to be viewed by any logged in user.</div>
+                        </div>
+
+                            <h3 class="sectionTitle" style="margin-top: 1.5em;">Presentation</h3>
                         <div class="inputContainer" style="margin-bottom: 1em;">
                             <label class="inputLabel" style="display: flex; align-items: center;">
                                 Custom Images
@@ -418,7 +428,7 @@
                         </div>
 
                         <div class="inputContainer" style="margin-bottom: 1em;">
-                            <h3 class="sectionTitle" style="margin-top: 1em; display: flex; align-items: center;">
+                            <label class="inputLabel" style="display: flex; align-items: center;">
                                 Metadata
                                 <a href="https://jellyfin-smartlists-plugin.dinsten.se/user-guide/configuration/#metadata"
                                     target="_blank" rel="noopener noreferrer" title="Documentation"
@@ -426,7 +436,7 @@
                                     <span class="material-icons" aria-hidden="true"
                                         style="font-size: 1.1em; line-height: 0;">info_outline</span>
                                 </a>
-                            </h3>
+                            </label>
                             <div style="margin-top: 0.5em;">
                                 <label class="inputLabel" for="metadataSortTitle">Sort Title</label>
                                 <input type="text" id="metadataSortTitle" class="emby-input"
@@ -454,6 +464,7 @@
                                 </select>
                                 <div class="fieldDescription">For playlists, applies to the selected playlist user(s). For collections, applies to the selected collection user.</div>
                             </div>
+                        </div>
                         </div>
 
                         <div style="margin-top: 2em;">

--- a/Jellyfin.Plugin.SmartLists/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config.html
@@ -391,7 +391,7 @@
                             <div class="fieldDescription">Control when this list appears in Jellyfin. Use Enable/Disable actions to automatically show or hide the list on specific dates (e.g., show Christmas movies only in December).</div>
                         </div>
 
-                            <h3 class="sectionTitle playlist-only-field" style="margin-top: 1.5em;">Sharing</h3>
+                            <h3 id="sharingSectionTitle" class="sectionTitle playlist-only-field" style="margin-top: 1.5em;">Sharing</h3>
                         <div id="publicCheckboxContainer" class="checkboxList paperList playlist-only-field"
                             style="padding: 0.5em 1em; margin-bottom: 1em; margin-top: 1em;">
                             <label class="emby-checkbox-label">

--- a/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
@@ -135,39 +135,48 @@
                             <div id="sorts-container"></div>
                         </div>
 
-                        <div id="bumper-section" class="inputContainer" style="margin-bottom: 1em;">
-                            <label class="inputLabel">Bumpers (optional)</label>
-                            <div class="fieldDescription" style="margin-bottom: 0.5em;">
-                                Insert short "bumper" items (commercials, interstitials, idents) between playlist
-                                items. Bumpers are selected by their own rules, repeat if fewer than needed, and do
-                                not count toward Max Items.</div>
-                            <div style="display: flex; gap: 1em; flex-wrap: wrap; margin-bottom: 0.5em;">
-                                <div class="selectContainer" style="min-width: 180px;">
-                                    <label class="selectLabel" for="bumperMediaType">Bumper media type</label>
-                                    <select is="emby-select" id="bumperMediaType"
-                                        class="emby-select-withcolor emby-select">
-                                        <option value="">None (disabled)</option>
-                                    </select>
-                                </div>
-                                <div class="selectContainer bumper-detail" style="min-width: 160px; display: none;">
-                                    <label class="selectLabel" for="bumperOrder">Bumper order</label>
-                                    <select is="emby-select" id="bumperOrder"
-                                        class="emby-select-withcolor emby-select">
-                                        <option value="Random">Random</option>
-                                        <option value="Name">Name</option>
-                                        <option value="ReleaseDate">Release Date</option>
-                                    </select>
-                                </div>
-                                <div class="inputContainer bumper-detail" style="min-width: 120px; display: none;">
-                                    <label class="inputLabel" for="bumperInterval">Every N items</label>
-                                    <input type="number" class="emby-input" id="bumperInterval" min="1" max="10000" value="1" />
-                                </div>
+                        <!-- User selection hidden for user pages - user is always themselves -->
+                        <input type="hidden" id="playlistUser" value="">
+
+                        <button type="button" id="advanced-options-header" class="emby-button"
+                            aria-expanded="false" aria-controls="advanced-options-body"
+                            style="width: 100%; display: flex; align-items: center; gap: 0.5em; text-align: left; padding: 0.75em 1em; margin-bottom: 1em; background: rgba(128, 128, 128, 0.1); border-radius: 4px;">
+                            <span id="advanced-expand-icon" aria-hidden="true">&#9654;</span>
+                            <span style="font-weight: 500;">Advanced options</span>
+                            <span id="advanced-summary" class="fieldDescription" style="margin-left: auto; margin-top: 0; text-align: right;"></span>
+                        </button>
+                        <div id="advanced-options-body" style="display: none;">
+                            <h3 class="sectionTitle" style="margin-top: 0.5em;">Limits</h3>
+                        <div class="inputContainer" style="margin-bottom: 1em; margin-top: 1em;">
+                            <label class="inputLabel" for="playlistMaxItems"
+                                style="display: flex; align-items: center;">
+                                Max Items
+                                <a href="https://jellyfin-smartlists-plugin.dinsten.se/user-guide/sorting-and-limits/#max-items"
+                                    target="_blank" rel="noopener noreferrer" title="Documentation"
+                                    style="margin-left: 0.5em; text-decoration: none; color: inherit; display: inline-flex; align-items: center;">
+                                    <span class="material-icons" aria-hidden="true"
+                                        style="font-size: 1.1em; line-height: 0;">info_outline</span>
+                                </a>
+                            </label>
+                            <input type="number" id="playlistMaxItems" class="emby-input" min="0" step="1">
+                            <div class="fieldDescription">Maximum number of items in this list. Set to 0 for no limit.
                             </div>
-                            <div id="bumper-rules-container" class="bumper-detail" style="display: none;"></div>
-                            <button type="button" id="add-bumper-rule-group" class="raised emby-button bumper-detail"
-                                style="margin-top: 0.5em; display: none;">
-                                <span>Add Bumper Rule Group</span>
-                            </button>
+                        </div>
+
+                        <div class="inputContainer playlist-only-field" style="margin-bottom: 1em; margin-top: 1em;">
+                            <label class="inputLabel" for="playlistMaxPlayTimeMinutes"
+                                style="display: flex; align-items: center;">
+                                Max Playtime (Minutes)
+                                <a href="https://jellyfin-smartlists-plugin.dinsten.se/user-guide/sorting-and-limits/#max-playtime"
+                                    target="_blank" rel="noopener noreferrer" title="Documentation"
+                                    style="margin-left: 0.5em; text-decoration: none; color: inherit; display: inline-flex; align-items: center;">
+                                    <span class="material-icons" aria-hidden="true"
+                                        style="font-size: 1.1em; line-height: 0;">info_outline</span>
+                                </a>
+                            </label>
+                            <input type="number" id="playlistMaxPlayTimeMinutes" class="emby-input" min="0" step="1">
+                            <div class="fieldDescription">Maximum playtime in minutes for this list. Set to 0 for no
+                                limit.</div>
                         </div>
 
                         <div class="checkboxList paperList"
@@ -208,58 +217,42 @@
                             </div>
                         </div>
 
-
-                        <!-- User selection hidden for user pages - user is always themselves -->
-                        <input type="hidden" id="playlistUser" value="">
-
-                        <div class="inputContainer" style="margin-bottom: 1em; margin-top: 1em;">
-                            <label class="inputLabel" for="playlistMaxItems"
-                                style="display: flex; align-items: center;">
-                                Max Items
-                                <a href="https://jellyfin-smartlists-plugin.dinsten.se/user-guide/sorting-and-limits/#max-items"
-                                    target="_blank" rel="noopener noreferrer" title="Documentation"
-                                    style="margin-left: 0.5em; text-decoration: none; color: inherit; display: inline-flex; align-items: center;">
-                                    <span class="material-icons" aria-hidden="true"
-                                        style="font-size: 1.1em; line-height: 0;">info_outline</span>
-                                </a>
-                            </label>
-                            <input type="number" id="playlistMaxItems" class="emby-input" min="0" step="1">
-                            <div class="fieldDescription">Maximum number of items in this list. Set to 0 for no limit.
+                        <div id="bumper-section" class="inputContainer" style="margin-bottom: 1em;">
+                            <h3 class="sectionTitle" style="margin-top: 1.5em;">Bumpers</h3>
+                            <div class="fieldDescription" style="margin-bottom: 0.5em;">
+                                Insert short "bumper" items (commercials, interstitials, idents) between playlist
+                                items. Bumpers are selected by their own rules, repeat if fewer than needed, and do
+                                not count toward Max Items.</div>
+                            <div style="display: flex; gap: 1em; flex-wrap: wrap; margin-bottom: 0.5em;">
+                                <div class="selectContainer" style="min-width: 180px;">
+                                    <label class="selectLabel" for="bumperMediaType">Bumper media type</label>
+                                    <select is="emby-select" id="bumperMediaType"
+                                        class="emby-select-withcolor emby-select">
+                                        <option value="">None (disabled)</option>
+                                    </select>
+                                </div>
+                                <div class="selectContainer bumper-detail" style="min-width: 160px; display: none;">
+                                    <label class="selectLabel" for="bumperOrder">Bumper order</label>
+                                    <select is="emby-select" id="bumperOrder"
+                                        class="emby-select-withcolor emby-select">
+                                        <option value="Random">Random</option>
+                                        <option value="Name">Name</option>
+                                        <option value="ReleaseDate">Release Date</option>
+                                    </select>
+                                </div>
+                                <div class="inputContainer bumper-detail" style="min-width: 120px; display: none;">
+                                    <label class="inputLabel" for="bumperInterval">Every N items</label>
+                                    <input type="number" class="emby-input" id="bumperInterval" min="1" max="10000" value="1" />
+                                </div>
                             </div>
+                            <div id="bumper-rules-container" class="bumper-detail" style="display: none;"></div>
+                            <button type="button" id="add-bumper-rule-group" class="raised emby-button bumper-detail"
+                                style="margin-top: 0.5em; display: none;">
+                                <span>Add Bumper Rule Group</span>
+                            </button>
                         </div>
 
-                        <div class="inputContainer playlist-only-field" style="margin-bottom: 1em; margin-top: 1em;">
-                            <label class="inputLabel" for="playlistMaxPlayTimeMinutes"
-                                style="display: flex; align-items: center;">
-                                Max Playtime (Minutes)
-                                <a href="https://jellyfin-smartlists-plugin.dinsten.se/user-guide/sorting-and-limits/#max-playtime"
-                                    target="_blank" rel="noopener noreferrer" title="Documentation"
-                                    style="margin-left: 0.5em; text-decoration: none; color: inherit; display: inline-flex; align-items: center;">
-                                    <span class="material-icons" aria-hidden="true"
-                                        style="font-size: 1.1em; line-height: 0;">info_outline</span>
-                                </a>
-                            </label>
-                            <input type="number" id="playlistMaxPlayTimeMinutes" class="emby-input" min="0" step="1">
-                            <div class="fieldDescription">Maximum playtime in minutes for this list. Set to 0 for no
-                                limit.</div>
-                        </div>
-
-                        <div id="publicCheckboxContainer" class="checkboxList paperList playlist-only-field"
-                            style="padding: 0.5em 1em; margin-bottom: 1em; margin-top: 1em;">
-                            <label class="emby-checkbox-label">
-                                <input type="checkbox" is="emby-checkbox" id="playlistIsPublic" data-embycheckbox="true"
-                                    class="emby-checkbox">
-                                <span class="checkboxLabel">Make playlist public</span>
-                                <span class="checkboxOutline">
-                                    <span class="material-icons checkboxIcon checkboxIcon-checked check"
-                                        aria-hidden="true"></span>
-                                    <span class="material-icons checkboxIcon checkboxIcon-unchecked"
-                                        aria-hidden="true"></span>
-                                </span>
-                            </label>
-                            <div class="fieldDescription">Allow this playlist to be viewed by any logged in user.</div>
-                        </div>
-
+                            <h3 class="sectionTitle" style="margin-top: 1.5em;">Automation</h3>
                         <div class="checkboxList paperList"
                             style="padding: 0.5em 1em; margin-bottom: 1em; margin-top: 1em;">
                             <label class="emby-checkbox-label">
@@ -332,6 +325,24 @@
                             <div class="fieldDescription">Control when this list appears in Jellyfin. Use Enable/Disable actions to automatically show or hide the list on specific dates (e.g., show Christmas movies only in December).</div>
                         </div>
 
+                            <h3 class="sectionTitle playlist-only-field" style="margin-top: 1.5em;">Sharing</h3>
+                        <div id="publicCheckboxContainer" class="checkboxList paperList playlist-only-field"
+                            style="padding: 0.5em 1em; margin-bottom: 1em; margin-top: 1em;">
+                            <label class="emby-checkbox-label">
+                                <input type="checkbox" is="emby-checkbox" id="playlistIsPublic" data-embycheckbox="true"
+                                    class="emby-checkbox">
+                                <span class="checkboxLabel">Make playlist public</span>
+                                <span class="checkboxOutline">
+                                    <span class="material-icons checkboxIcon checkboxIcon-checked check"
+                                        aria-hidden="true"></span>
+                                    <span class="material-icons checkboxIcon checkboxIcon-unchecked"
+                                        aria-hidden="true"></span>
+                                </span>
+                            </label>
+                            <div class="fieldDescription">Allow this playlist to be viewed by any logged in user.</div>
+                        </div>
+
+                            <h3 class="sectionTitle" style="margin-top: 1.5em;">Presentation</h3>
                         <div class="inputContainer" style="margin-bottom: 1em;">
                             <label class="inputLabel" style="display: flex; align-items: center;">
                                 Custom Images
@@ -351,7 +362,7 @@
                         </div>
 
                         <div class="inputContainer" style="margin-bottom: 1em;">
-                            <h3 class="sectionTitle" style="margin-top: 1em; display: flex; align-items: center;">
+                            <label class="inputLabel" style="display: flex; align-items: center;">
                                 Metadata
                                 <a href="https://jellyfin-smartlists-plugin.dinsten.se/user-guide/configuration/#metadata"
                                     target="_blank" rel="noopener noreferrer" title="Documentation"
@@ -359,7 +370,7 @@
                                     <span class="material-icons" aria-hidden="true"
                                         style="font-size: 1.1em; line-height: 0;">info_outline</span>
                                 </a>
-                            </h3>
+                            </label>
                             <div style="margin-top: 0.5em;">
                                 <label class="inputLabel" for="metadataSortTitle">Sort Title</label>
                                 <input type="text" id="metadataSortTitle" class="emby-input"
@@ -387,6 +398,7 @@
                                 </select>
                                 <div class="fieldDescription">Set whether the created list is favorited for your user.</div>
                             </div>
+                        </div>
                         </div>
 
                         <div style="margin-top: 2em;">

--- a/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
@@ -325,7 +325,7 @@
                             <div class="fieldDescription">Control when this list appears in Jellyfin. Use Enable/Disable actions to automatically show or hide the list on specific dates (e.g., show Christmas movies only in December).</div>
                         </div>
 
-                            <h3 class="sectionTitle playlist-only-field" style="margin-top: 1.5em;">Sharing</h3>
+                            <h3 id="sharingSectionTitle" class="sectionTitle playlist-only-field" style="margin-top: 1.5em;">Sharing</h3>
                         <div id="publicCheckboxContainer" class="checkboxList paperList playlist-only-field"
                             style="padding: 0.5em 1em; margin-bottom: 1em; margin-top: 1em;">
                             <label class="emby-checkbox-label">

--- a/docs/content/user-guide/configuration.md
+++ b/docs/content/user-guide/configuration.md
@@ -97,7 +97,7 @@ SmartLists allows you to upload custom images for your playlists and collections
 
 **How to Use:**
 
-1. When creating or editing a smart list, scroll to the **Custom Images** section
+1. When creating or editing a smart list, expand **Advanced options** and scroll to the **Custom Images** section
 2. Click **Add Image** to add a new image
 3. Select the image type from the dropdown (each type can only be used once)
 4. Choose an image file from your computer
@@ -143,19 +143,37 @@ The web interface is organized into tabs. The available tabs and features depend
 
 This is where you build new playlists and collections:
 
+!!! note "Advanced options"
+    Fields beyond List Type, Name, Media Types, Rules, Sort Options, and Users live
+    in a collapsed **Advanced options** section on the create/edit form. The collapsed
+    header always shows a summary of what applies (e.g. `500 items max · refresh on
+    library changes`, or `Bumpers · 2 schedules` when editing a configured list), and
+    the section expands automatically when you edit a list that uses advanced features.
+
 - Choose whether to create a Playlist or Collection
 - Define the rules for including items
 - Choose the sort order
 - Select which user(s) should be associated with the list:
   - **For Playlists**: You can select one or more users. Each selected user will get their own personalized Jellyfin playlist based on their playback data. This allows the same smart playlist to show different content for each user (e.g., "My Favorites" showing each user's actual favorites).
   - **For Collections**: Select a single reference user whose context will be used for rule evaluation and library access permissions
-- Set the maximum number of items
-- Set the maximum playtime for the list (playlists only)
-- Decide if the list should be public or private (playlists only - collections are always server-wide)
 - Include extras (behind the scenes, deleted scenes, featurettes, trailers) in the item pool — this option is only visible when the Video media type is selected
-- Choose whether or not to enable the list
-- Configure auto-refresh behavior (Never, On Library Changes, On All Changes)
-- Set custom refresh schedule (Daily, Weekly, Monthly, Yearly, Interval or No schedule)
+
+The remaining fields live inside the collapsed **Advanced options** section, grouped as:
+
+- **Limits**
+  - Set the maximum number of items
+  - Set the maximum playtime for the list (playlists only)
+  - Configure random group selection (see [Random Group Selection](sorting-and-limits.md#random-group-selection))
+- **Bumpers** — weave short interstitial items between the playlist's main items (playlists only, see [Bumpers](bumpers.md))
+- **Automation**
+  - Choose whether or not to enable the list
+  - Configure auto-refresh behavior (Never, On Library Changes, On All Changes)
+  - Set custom refresh schedule (Daily, Weekly, Monthly, Yearly, Interval or No schedule)
+  - Set visibility schedules (see [Visibility Scheduling](auto-refresh.md#visibility-scheduling))
+- **Sharing**
+  - Decide if the list should be public or private (playlists only - collections are always server-wide)
+- **Presentation**
+  - Upload custom images and set metadata such as sort title, overview, tags and favorite (see [Custom Images](#custom-images) and [Metadata](#metadata) above)
 
 !!! info "User Page Differences"
     On the **User Page**, you can only select yourself for playlists and must use your own account as the reference user for collections. Admins can select any user(s) from the dropdown.

--- a/docs/content/user-guide/configuration.md
+++ b/docs/content/user-guide/configuration.md
@@ -144,8 +144,8 @@ The web interface is organized into tabs. The available tabs and features depend
 This is where you build new playlists and collections:
 
 !!! note "Advanced options"
-    Fields beyond List Type, Name, Media Types, Rules, Sort Options, and Users live
-    in a collapsed **Advanced options** section on the create/edit form. The collapsed
+    Fields beyond List Type, Name, Media Types (with its Include Extras option), Rules,
+    Sort Options, and Users live in a collapsed **Advanced options** section on the create/edit form. The collapsed
     header always shows a summary of what applies (e.g. `500 items max · refresh on
     library changes`, or `Bumpers · 2 schedules` when editing a configured list), and
     the section expands automatically when you edit a list that uses advanced features.

--- a/docs/superpowers/plans/2026-07-10-create-form-advanced-fold.md
+++ b/docs/superpowers/plans/2026-07-10-create-form-advanced-fold.md
@@ -175,7 +175,7 @@ git commit -m "Add collapsed Advanced options fold to admin create form"
 - Consumes: nothing (pure HTML; JS from Task 1 is shared and picks up the new ids automatically).
 - Produces: identical fold markup/ids on the user page.
 
-- [ ] **Step 1: Apply the same restructure**
+- [x] **Step 1: Apply the same restructure**
 
 Same three operations as Task 1 Step 1, with these user-page differences:
 - There is no visible Users block. The hidden `<input type="hidden" id="playlistUser" value="">` (line 213) must stay OUTSIDE the fold — leave it directly after the Sort Options container (line 135 area).
@@ -192,7 +192,7 @@ Manual checks on the user config page (link "Open User Config Page" at top of ad
 2. Create a simple playlist as a non-admin user without opening the fold → saves.
 3. List Type switch gating works inside the fold (user page still has both list types).
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html

--- a/docs/superpowers/plans/2026-07-10-create-form-advanced-fold.md
+++ b/docs/superpowers/plans/2026-07-10-create-form-advanced-fold.md
@@ -1,0 +1,509 @@
+# Create/Edit Form "Advanced options" Fold — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Collapse the 11 advanced field groups of the create/edit list form into a single "Advanced options" fold with sub-headings and summary chips, so simple lists are created without scrolling past advanced options.
+
+**Architecture:** Static HTML wrapper (header `<button>` + display-toggled body div) cloned from the Manage-tab collapse pattern, in BOTH `config.html` and `user-playlists.html`. New JS functions live in existing modules (`config-lists.js`, `config-init.js`) — no new JS files. No DOM nodes move at runtime; all existing IDs/classes/conditional-visibility machinery untouched. Spec: `docs/superpowers/specs/2026-07-10-create-form-advanced-fold-design.md`.
+
+**Tech Stack:** Jellyfin plugin config pages (embedded HTML/JS resources), vanilla JS (ES5-style, Jellyfin dashboard environment), .NET build via `dev/build-local.sh`.
+
+## Global Constraints
+
+- **No ES6 template literals** in any `config-*.js` — string concatenation only.
+- **Never** `is="emby-input"`; **never** `is="emby-collapse"` (not registered on plugin config pages — verified against jellyfin-web source and shipped 12.x bundle).
+- Every create-form HTML change applies to **both** `Jellyfin.Plugin.SmartLists/Configuration/config.html` and `Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html`.
+- **No new JS files** (avoids `.csproj` + `Plugin.cs` double registration).
+- Use only main-bundle-safe classes: `emby-button`, `sectionTitle`, `inputContainer`, `selectContainer`, `checkboxList`, `paperList`, `fieldDescription`, `inputLabel`, `material-icons`. Colors inherited, no hardcoded palette values.
+- Expand icons are plain text characters `▶` / `▼` (same as Manage tab, see `config-bulk-actions.js:893-918`).
+- There is no test suite. Every task verifies via `cd dev && ./build-local.sh` (must succeed — warnings are errors) plus manual checks against http://localhost:8096. Admin page: Dashboard → Plugins → SmartLists. User page: requires "File Transformation" + "Plugin Pages" plugins (link at top of admin page).
+- Line numbers below are as of commit `f6724ee`. Re-locate by the quoted anchors if drifted.
+
+---
+
+### Task 1: config.html restructure + minimal toggle JS
+
+**Files:**
+- Modify: `Jellyfin.Plugin.SmartLists/Configuration/config.html:150-462` (create-tab form)
+- Modify: `Jellyfin.Plugin.SmartLists/Configuration/config-lists.js` (add `toggleAdvancedOptions` near `clearForm`, line ~660)
+- Modify: `Jellyfin.Plugin.SmartLists/Configuration/config-init.js:1253` (click delegation)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: DOM ids `#advanced-options-header`, `#advanced-expand-icon`, `#advanced-summary`, `#advanced-options-body`; function `SmartLists.toggleAdvancedOptions(page, force)` — `force` optional boolean (true=expand, false=collapse, undefined=toggle). Tasks 2–5 rely on these exact names.
+
+- [ ] **Step 1: Reorder and wrap the advanced blocks in config.html**
+
+Work only inside `<form id="playlistForm">` (lines 47–463). Three operations, all static cut/paste of existing blocks (do NOT edit the blocks' inner content except where shown):
+
+**(a) Move the Users block up.** Cut the whole Users `inputContainer` — starts line 226 (`<label class="inputLabel" for="playlistUser"` inside) and ends line 279 with its closing `</div>` — and paste it directly after the Sort Options `inputContainer` closes (line 150, the `</div>` after `<div id="sorts-container"></div>`).
+
+**(b) Insert the fold header + body wrapper.** Directly after the moved Users block, insert:
+
+```html
+                        <button type="button" id="advanced-options-header" class="emby-button"
+                            aria-expanded="false" aria-controls="advanced-options-body"
+                            style="width: 100%; display: flex; align-items: center; gap: 0.5em; text-align: left; padding: 0.75em 1em; margin-bottom: 1em; background: rgba(128, 128, 128, 0.1); border-radius: 4px;">
+                            <span id="advanced-expand-icon" aria-hidden="true">&#9654;</span>
+                            <span style="font-weight: 500;">Advanced options</span>
+                            <span id="advanced-summary" class="fieldDescription" style="margin-left: auto; margin-top: 0; text-align: right;"></span>
+                        </button>
+                        <div id="advanced-options-body" style="display: none;">
+```
+
+and close the wrapper with `</div>` immediately BEFORE the submit-button block (`<div style="margin-top: 2em;">` containing `#submitBtn`, line 459).
+
+**(c) Reorder blocks inside the wrapper and add sub-headings.** Final order inside `#advanced-options-body` (all blocks are existing HTML moved verbatim unless noted):
+
+```html
+<!-- inside #advanced-options-body -->
+<h3 class="sectionTitle" style="margin-top: 0.5em;">Limits</h3>
+[Max Items inputContainer            — currently lines 282-296]
+[Max Playtime inputContainer         — currently lines 298-312, keeps class playlist-only-field]
+[Random Group Selection checkboxList — currently lines 187-223]
+
+[#bumper-section                     — currently lines 152-185, ONE inner edit, see below]
+
+<h3 class="sectionTitle" style="margin-top: 1.5em;">Automation</h3>
+[Enable list checkboxList            — currently lines 330-353]
+[Auto-refresh selectContainer        — currently lines 355-371]
+[Refresh Schedules inputContainer    — currently lines 373-386]
+[Visibility Schedules inputContainer — currently lines 388-400]
+
+<h3 class="sectionTitle playlist-only-field" style="margin-top: 1.5em;">Sharing</h3>
+[#publicCheckboxContainer            — currently lines 314-328]
+
+<h3 class="sectionTitle" style="margin-top: 1.5em;">Presentation</h3>
+[Custom Images inputContainer        — currently lines 402-418]
+[Metadata inputContainer             — currently lines 420-457, ONE inner edit, see below]
+```
+
+Inner edit 1 — inside `#bumper-section`, replace its label line
+
+```html
+                            <label class="inputLabel">Bumpers (optional)</label>
+```
+
+with a sub-heading matching the others (the h3 lives INSIDE `#bumper-section` so the existing id-targeted collection-mode hiding covers it):
+
+```html
+                            <h3 class="sectionTitle" style="margin-top: 1.5em;">Bumpers</h3>
+```
+
+Inner edit 2 — inside the Metadata block, demote the existing `<h3 class="sectionTitle" ...>Metadata ...</h3>` (lines 421-429) to a label so it doesn't compete with the new sub-headings (keep the doc link span exactly as is):
+
+```html
+                            <label class="inputLabel" style="display: flex; align-items: center;">
+                                Metadata
+                                <a href="https://jellyfin-smartlists-plugin.dinsten.se/user-guide/configuration/#metadata"
+                                    target="_blank" rel="noopener noreferrer" title="Documentation"
+                                    style="margin-left: 0.5em; text-decoration: none; color: inherit; display: inline-flex; align-items: center;">
+                                    <span class="material-icons" aria-hidden="true"
+                                        style="font-size: 1.1em; line-height: 0;">info_outline</span>
+                                </a>
+                            </label>
+```
+
+Notes:
+- The `Sharing` h3 carries `playlist-only-field` so `handleListTypeChange` hides it together with the public checkbox in Collection mode (and the `pageshow` cleanup already whitelists that class).
+- Do NOT add a class to the Bumpers h3 — it is inside `#bumper-section`, which `updateBumperSectionVisibility` already hides for Collections.
+- All ids, classes, `style` attributes, labels, descriptions, and doc links inside moved blocks stay byte-identical (except the two inner edits above).
+
+- [ ] **Step 2: Add `SmartLists.toggleAdvancedOptions` to config-lists.js**
+
+Insert directly ABOVE `SmartLists.clearForm = function (page) {` (line 664):
+
+```javascript
+    SmartLists.toggleAdvancedOptions = function (page, force) {
+        const body = page.querySelector('#advanced-options-body');
+        if (!body) {
+            return;
+        }
+        const expand = force !== undefined ? force : body.style.display === 'none';
+        body.style.display = expand ? 'block' : 'none';
+        const icon = page.querySelector('#advanced-expand-icon');
+        if (icon) {
+            icon.textContent = expand ? '▼' : '▶';
+        }
+        const header = page.querySelector('#advanced-options-header');
+        if (header) {
+            header.setAttribute('aria-expanded', expand ? 'true' : 'false');
+        }
+    };
+```
+
+- [ ] **Step 3: Wire the header click via the existing page-level delegation**
+
+In `config-init.js`, inside the big click listener, directly BEFORE the `.playlist-header` block (line 1253, anchor: `if (target.closest('.playlist-header')) {`), insert:
+
+```javascript
+            if (target.closest('#advanced-options-header')) {
+                if (SmartLists.toggleAdvancedOptions) {
+                    SmartLists.toggleAdvancedOptions(page);
+                }
+                return;
+            }
+```
+
+- [ ] **Step 4: Build and verify on the admin page**
+
+Run: `cd /Users/johan.yourstone/Git/jellyfin-smartplaylist-plugin/dev && ./build-local.sh`
+Expected: build succeeds, Jellyfin container restarts.
+
+Manual checks at http://localhost:8096 → Dashboard → Plugins → SmartLists (hard-refresh; embedded resources cache aggressively — use devtools "Disable cache" or bump-refresh):
+1. Create tab shows: List Type, Name, Media Types, Rules, Sort Options, Users, collapsed "▶ Advanced options" bar, Create/Clear buttons. Nothing else.
+2. Click the bar → expands, icon flips to ▼; sub-headings read Limits / Bumpers / Automation / Sharing / Presentation; all advanced fields present.
+3. Switch List Type to Collection with fold open → Bumpers section, Sharing h3 + public checkbox, Max Playtime disappear; switch back → they return.
+4. Keyboard: Tab reaches the bar, Enter toggles it.
+5. Create a simple playlist (name + media type + one rule) without touching the fold → saves successfully.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Jellyfin.Plugin.SmartLists/Configuration/config.html Jellyfin.Plugin.SmartLists/Configuration/config-lists.js Jellyfin.Plugin.SmartLists/Configuration/config-init.js
+git commit -m "Add collapsed Advanced options fold to admin create form"
+```
+
+---
+
+### Task 2: Mirror the restructure in user-playlists.html
+
+**Files:**
+- Modify: `Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html:135-396` (create form)
+
+**Interfaces:**
+- Consumes: nothing (pure HTML; JS from Task 1 is shared and picks up the new ids automatically).
+- Produces: identical fold markup/ids on the user page.
+
+- [ ] **Step 1: Apply the same restructure**
+
+Same three operations as Task 1 Step 1, with these user-page differences:
+- There is no visible Users block. The hidden `<input type="hidden" id="playlistUser" value="">` (line 213) must stay OUTSIDE the fold — leave it directly after the Sort Options container (line 135 area).
+- Anchors on this page: `#bumper-section` line 138, Random Group checkbox line ~173, Max Items label line 216, `#publicCheckboxContainer` line 247, Enable list line ~261, Auto-refresh line ~285, `#schedules-container` line 316, `#visibility-schedules-container` line 331, `#custom-images-container` line 345, Metadata h3 line ~353, submit block lines 393-396.
+- Fold header/body markup byte-identical to Task 1 Step 1(b). Sub-heading order and the two inner edits (Bumpers label → h3, Metadata h3 → label) byte-identical to Task 1 Step 1(c).
+
+- [ ] **Step 2: Build and verify on the user page**
+
+Run: `cd /Users/johan.yourstone/Git/jellyfin-smartplaylist-plugin/dev && ./build-local.sh`
+Expected: build succeeds.
+
+Manual checks on the user config page (link "Open User Config Page" at top of admin page):
+1. Same collapsed-by-default fold; toggle works (shared delegation listener).
+2. Create a simple playlist as a non-admin user without opening the fold → saves.
+3. List Type switch gating works inside the fold (user page still has both list types).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
+git commit -m "Mirror Advanced options fold on user config page"
+```
+
+---
+
+### Task 3: Create-mode summary chips (effective defaults)
+
+**Files:**
+- Modify: `Jellyfin.Plugin.SmartLists/Configuration/config-lists.js` (add `renderAdvancedSummaryFromForm` next to `toggleAdvancedOptions`)
+- Modify: `Jellyfin.Plugin.SmartLists/Configuration/config-init.js:462,493` (tail of `applyFormDefaults` and `applyFallbackDefaults`)
+
+**Interfaces:**
+- Consumes: `#advanced-summary` (Task 1), `SmartLists.getElementValue` (existing helper).
+- Produces: `SmartLists.renderAdvancedSummaryFromForm(page)` — reads current form values, writes the summary line; no-ops in edit mode (`page._editMode`). Task 4 relies on the `page._editMode` guard so edit chips are not overwritten by late-arriving defaults.
+
+- [ ] **Step 1: Add `renderAdvancedSummaryFromForm` to config-lists.js**
+
+Insert directly AFTER the `toggleAdvancedOptions` function from Task 1:
+
+```javascript
+    SmartLists.renderAdvancedSummaryFromForm = function (page) {
+        // Edit mode owns the summary via syncAdvancedSection; don't let
+        // late-arriving async defaults overwrite its chips.
+        if (page._editMode) {
+            return;
+        }
+        const summaryEl = page.querySelector('#advanced-summary');
+        if (!summaryEl) {
+            return;
+        }
+        const parts = [];
+        const maxItems = parseInt(SmartLists.getElementValue(page, '#playlistMaxItems', '0'), 10);
+        if (!isNaN(maxItems)) {
+            parts.push(maxItems > 0 ? maxItems + ' items max' : 'unlimited items');
+        }
+        const refreshLabels = {
+            'Never': 'no auto-refresh',
+            'OnLibraryChanges': 'refresh on library changes',
+            'OnAllChanges': 'refresh on all changes'
+        };
+        const refreshValue = SmartLists.getElementValue(page, '#autoRefreshMode', '');
+        if (refreshValue) {
+            parts.push(refreshLabels[refreshValue] || refreshValue);
+        }
+        summaryEl.textContent = parts.join(' · ');
+    };
+```
+
+(Verify the option values first: `grep -n "OnLibraryChanges\|OnAllChanges\|'Never'" Jellyfin.Plugin.SmartLists/Configuration/config-init.js` — the map keys must match the values used when `#autoRefreshMode` options are populated. Add any missing value to `refreshLabels`.)
+
+- [ ] **Step 2: Invoke it whenever defaults are applied**
+
+In `config-init.js`, add as the LAST line inside `SmartLists.applyFormDefaults` (before its closing `};` at line 462) and inside `SmartLists.applyFallbackDefaults` (before its closing `};` at line 493):
+
+```javascript
+        if (SmartLists.renderAdvancedSummaryFromForm) {
+            SmartLists.renderAdvancedSummaryFromForm(page);
+        }
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cd /Users/johan.yourstone/Git/jellyfin-smartplaylist-plugin/dev && ./build-local.sh`
+
+Manual checks:
+1. Admin create tab, fold collapsed: header right side reads e.g. `500 items max · refresh on library changes` (matches Settings-tab defaults).
+2. Change Settings default Max Items → save → back to Create tab (Clear Form) → chip updates.
+3. User page shows the fallback defaults chip (`500 items max · refresh on library changes`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Jellyfin.Plugin.SmartLists/Configuration/config-lists.js Jellyfin.Plugin.SmartLists/Configuration/config-init.js
+git commit -m "Show effective defaults on collapsed Advanced options header"
+```
+
+---
+
+### Task 4: Edit/clone chips + auto-expand + collapse on reset
+
+**Files:**
+- Modify: `Jellyfin.Plugin.SmartLists/Configuration/config-lists.js` (add `syncAdvancedSection`; wire `clearForm:733`, `editPlaylist:966-969`, `clonePlaylist:1191`)
+
+**Interfaces:**
+- Consumes: `toggleAdvancedOptions` (Task 1), `renderAdvancedSummaryFromForm`'s `_editMode` guard (Task 3), `SmartLists.loadExistingImages(page, id)` which returns a Promise (`config-images.js:545`).
+- Produces: `SmartLists.syncAdvancedSection(page, playlist)` — renders edit chips from the DTO + DOM image rows, expands the fold when any chip fires; idempotent, expand-only.
+
+- [ ] **Step 1: Add `syncAdvancedSection` to config-lists.js**
+
+Insert directly AFTER `renderAdvancedSummaryFromForm`:
+
+```javascript
+    SmartLists.syncAdvancedSection = function (page, playlist) {
+        const summaryEl = page.querySelector('#advanced-summary');
+        if (!summaryEl || !playlist) {
+            return;
+        }
+        const chips = [];
+        if (playlist.Bumpers && playlist.Bumpers.MediaTypes && playlist.Bumpers.MediaTypes.length > 0) {
+            chips.push('Bumpers');
+        }
+        const scheduleCount = (playlist.Schedules || []).length + (playlist.VisibilitySchedules || []).length;
+        if (scheduleCount > 0) {
+            chips.push(scheduleCount + (scheduleCount === 1 ? ' schedule' : ' schedules'));
+        }
+        if (playlist.RandomGroupSelection && playlist.RandomGroupSelection.Enabled) {
+            chips.push('Random groups');
+        }
+        if (playlist.MaxPlayTimeMinutes > 0) {
+            chips.push('Playtime limit');
+        }
+        if (playlist.Enabled === false) {
+            chips.push('Disabled');
+        }
+        if (playlist.SortTitle || playlist.Overview || playlist.Favorite === true || playlist.Favorite === false ||
+            (playlist.Tags && playlist.Tags.length > 0)) {
+            chips.push('Metadata');
+        }
+        // Images arrive via a separate async endpoint; count what's in the DOM.
+        const imageRows = page.querySelectorAll('#custom-images-container [id^="image-row-"]').length;
+        if (imageRows > 0) {
+            chips.push(imageRows === 1 ? '1 image' : imageRows + ' images');
+        }
+        summaryEl.textContent = chips.join(' · ');
+        if (chips.length > 0) {
+            SmartLists.toggleAdvancedOptions(page, true);
+        }
+    };
+```
+
+(Signals deliberately exclude async-default fields — MaxItems, AutoRefresh, IsPublic — per the spec: their non-defaultness is ambiguous and they round-trip regardless of fold state.)
+
+- [ ] **Step 2: Collapse the fold on every form reset**
+
+In `SmartLists.clearForm`, directly before the closing `};` (line 733, after the `initCustomImagesContainer` block):
+
+```javascript
+        // Reset the Advanced options fold to collapsed
+        if (SmartLists.toggleAdvancedOptions) {
+            SmartLists.toggleAdvancedOptions(page, false);
+        }
+```
+
+(The default chips re-render via the async `applyFormDefaults`/`applyFallbackDefaults` calls already inside `clearForm`; `cancelEdit` runs `setPageEditState(false)` before `clearForm`, so the `_editMode` guard has already been lifted.)
+
+- [ ] **Step 3: Wire editPlaylist**
+
+In `SmartLists.editPlaylist`, replace the existing images call (lines 966-969):
+
+```javascript
+                // Load existing images for this playlist
+                if (SmartLists.loadExistingImages) {
+                    SmartLists.loadExistingImages(page, playlistId);
+                }
+```
+
+with:
+
+```javascript
+                // Load existing images for this playlist, then re-sync the
+                // Advanced fold so an images-only list still expands.
+                if (SmartLists.loadExistingImages) {
+                    SmartLists.loadExistingImages(page, playlistId).then(function () {
+                        SmartLists.syncAdvancedSection(page, playlist);
+                    });
+                }
+
+                // Chips + auto-expand from the loaded list (images re-sync above)
+                SmartLists.syncAdvancedSection(page, playlist);
+```
+
+- [ ] **Step 4: Wire clonePlaylist**
+
+In `SmartLists.clonePlaylist`, directly after the metadata tags population (line 1191-1192, anchor `SmartLists.initMetadataTagsInput(page, playlist.Tags || []);` and its closing `}`), insert:
+
+```javascript
+                // Chips + auto-expand for cloned advanced config
+                SmartLists.syncAdvancedSection(page, playlist);
+```
+
+(Clone does not copy images, so no promise chaining needed here.)
+
+- [ ] **Step 5: Build and verify**
+
+Run: `cd /Users/johan.yourstone/Git/jellyfin-smartplaylist-plugin/dev && ./build-local.sh`
+
+Manual checks (admin page; create test lists first if needed):
+1. Edit a list with bumpers + a refresh schedule → form opens with fold EXPANDED, header reads `Bumpers · 1 schedule`.
+2. Edit a simple list (defaults only) → fold stays COLLAPSED, header shows default chips.
+3. Edit a list whose only extra is a custom image → fold expands when the image loads, chip `1 image`.
+4. Clone the bumper list → fold expanded, chips shown, submit still says Create.
+5. Cancel Edit → back on Manage tab; return to Create tab → fold collapsed, default chips restored.
+6. Update a configured list successfully → form clears, fold collapsed.
+7. Repeat check 1 on the user page.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+git commit -m "Auto-expand Advanced options with summary chips in edit and clone"
+```
+
+---
+
+### Task 5: Robustness guards — hidden-invalid expand + bfcache icon re-sync
+
+**Files:**
+- Modify: `Jellyfin.Plugin.SmartLists/Configuration/config-init.js:1287-1295` (form listeners), `config-init.js:2539-2548` (pageshow handler)
+
+**Interfaces:**
+- Consumes: `toggleAdvancedOptions` (Task 1), `#advanced-options-body`, `#advanced-expand-icon`.
+- Produces: nothing new — behavior only.
+
+- [ ] **Step 1: Expand the fold when native validation trips inside it**
+
+In `config-init.js`, directly after the existing `playlistForm.addEventListener('submit', ...)` block (lines 1287-1295), still inside the `if (playlistForm) {` guard:
+
+```javascript
+            // If native validation flags a control hidden inside the collapsed
+            // Advanced fold, expand the fold so the browser can focus it.
+            // ('invalid' doesn't bubble — use capture.)
+            playlistForm.addEventListener('invalid', function (e) {
+                const body = page.querySelector('#advanced-options-body');
+                if (body && body.style.display === 'none' && body.contains(e.target)) {
+                    SmartLists.toggleAdvancedOptions(page, true);
+                }
+            }, { capture: true, signal: pageSignal });
+```
+
+(Match the options argument style used elsewhere in this listener block: if the file passes `SmartLists.getEventListenerOptions(pageSignal)`, extend with capture via `{ capture: true, signal: pageSignal }` only if `getEventListenerOptions` returns `{ signal: pageSignal }`; otherwise mirror whatever that helper returns plus `capture: true`. Check `getEventListenerOptions`' definition first: `grep -n "getEventListenerOptions = " Jellyfin.Plugin.SmartLists/Configuration/*.js`.)
+
+- [ ] **Step 2: Re-sync the expand icon on pageshow**
+
+In the `pageshow` handler, inside the `if (page._pageInitialized) {` block (line 2542, next to `SmartLists.handleListTypeChange(page);`), add:
+
+```javascript
+                // bfcache can restore the fold body/icon out of sync
+                const advBody = page.querySelector('#advanced-options-body');
+                if (advBody && SmartLists.toggleAdvancedOptions) {
+                    SmartLists.toggleAdvancedOptions(page, advBody.style.display !== 'none');
+                }
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cd /Users/johan.yourstone/Git/jellyfin-smartplaylist-plugin/dev && ./build-local.sh`
+
+Manual checks:
+1. Temporarily add `required` to `#playlistMaxItems` via devtools, clear its value, fold collapsed, hit Create → fold expands and browser focuses the field (no console error "not focusable"). Remove the attribute after.
+2. Expand fold → navigate to user page → browser Back → icon matches body state.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Jellyfin.Plugin.SmartLists/Configuration/config-init.js
+git commit -m "Guard Advanced fold against hidden invalid controls and bfcache desync"
+```
+
+---
+
+### Task 6: Docs + future-field rules
+
+**Files:**
+- Modify: `docs/content/user-guide/configuration.md` (verify exact path first: `ls docs/content/user-guide/`)
+- Modify: `CLAUDE.md` (repo root, "When Making Changes" section)
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Update user docs**
+
+In the configuration page of the mkdocs docs, where the create-form fields are described, add a short note near the top of the field list (adapt heading level to the page):
+
+```markdown
+!!! note "Advanced options"
+    Fields beyond List Type, Name, Media Types, Rules, Sort Options, and Users live
+    in a collapsed **Advanced options** section on the create/edit form. The collapsed
+    header always shows a summary of what applies (e.g. `500 items max · refresh on
+    library changes`, or `Bumpers · 2 schedules` when editing a configured list), and
+    the section expands automatically when you edit a list that uses advanced features.
+```
+
+Also reorder/regroup the field documentation if it mirrors the old on-screen order (check whether the page lists fields in form order; if it does, note the new grouping: Limits / Bumpers / Automation / Sharing / Presentation).
+
+- [ ] **Step 2: Add future-field rules to CLAUDE.md**
+
+In root `CLAUDE.md`, under "When Making Changes", add:
+
+```markdown
+- **Create-form fields and the Advanced options fold**: required inputs must never
+  be placed inside `#advanced-options-body` (collapsed `display:none` hides native
+  validation). New advanced fields go under the matching sub-heading inside the fold
+  (Limits / Bumpers / Automation / Sharing / Presentation); new core fields go above
+  it. If a new advanced field has an unambiguous non-default state, add a signal for
+  it in `syncAdvancedSection` (config-lists.js) so edit mode surfaces it as a chip
+  and auto-expands.
+```
+
+- [ ] **Step 3: Verify docs build (optional, if mkdocs installed) and commit**
+
+```bash
+git add docs/content CLAUDE.md
+git commit -m "Document Advanced options fold and future-field rules"
+```
+
+---
+
+## Final verification sweep (after all tasks)
+
+1. `cd /Users/johan.yourstone/Git/jellyfin-smartplaylist-plugin/dev && ./build-local.sh` — clean build.
+2. Full spec checklist (spec §Verification), both pages: simple create untouched fold; edit configured list auto-expands with chips; images-only edit expands late; clone matches; cancel/update re-collapse; Playlist↔Collection gating inside open fold; back-nav icon sync; keyboard toggle.
+3. `git log --oneline main..` — 6 commits, one per task.

--- a/docs/superpowers/plans/2026-07-10-create-form-advanced-fold.md
+++ b/docs/superpowers/plans/2026-07-10-create-form-advanced-fold.md
@@ -211,7 +211,7 @@ git commit -m "Mirror Advanced options fold on user config page"
 - Consumes: `#advanced-summary` (Task 1), `SmartLists.getElementValue` (existing helper).
 - Produces: `SmartLists.renderAdvancedSummaryFromForm(page)` — reads current form values, writes the summary line; no-ops in edit mode (`page._editMode`). Task 4 relies on the `page._editMode` guard so edit chips are not overwritten by late-arriving defaults.
 
-- [ ] **Step 1: Add `renderAdvancedSummaryFromForm` to config-lists.js**
+- [x] **Step 1: Add `renderAdvancedSummaryFromForm` to config-lists.js**
 
 Insert directly AFTER the `toggleAdvancedOptions` function from Task 1:
 
@@ -246,7 +246,7 @@ Insert directly AFTER the `toggleAdvancedOptions` function from Task 1:
 
 (Verify the option values first: `grep -n "OnLibraryChanges\|OnAllChanges\|'Never'" Jellyfin.Plugin.SmartLists/Configuration/config-init.js` — the map keys must match the values used when `#autoRefreshMode` options are populated. Add any missing value to `refreshLabels`.)
 
-- [ ] **Step 2: Invoke it whenever defaults are applied**
+- [x] **Step 2: Invoke it whenever defaults are applied**
 
 In `config-init.js`, add as the LAST line inside `SmartLists.applyFormDefaults` (before its closing `};` at line 462) and inside `SmartLists.applyFallbackDefaults` (before its closing `};` at line 493):
 
@@ -265,7 +265,7 @@ Manual checks:
 2. Change Settings default Max Items → save → back to Create tab (Clear Form) → chip updates.
 3. User page shows the fallback defaults chip (`500 items max · refresh on library changes`).
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add Jellyfin.Plugin.SmartLists/Configuration/config-lists.js Jellyfin.Plugin.SmartLists/Configuration/config-init.js

--- a/docs/superpowers/plans/2026-07-10-create-form-advanced-fold.md
+++ b/docs/superpowers/plans/2026-07-10-create-form-advanced-fold.md
@@ -409,7 +409,7 @@ git commit -m "Auto-expand Advanced options with summary chips in edit and clone
 - Consumes: `toggleAdvancedOptions` (Task 1), `#advanced-options-body`, `#advanced-expand-icon`.
 - Produces: nothing new — behavior only.
 
-- [ ] **Step 1: Expand the fold when native validation trips inside it**
+- [x] **Step 1: Expand the fold when native validation trips inside it**
 
 In `config-init.js`, directly after the existing `playlistForm.addEventListener('submit', ...)` block (lines 1287-1295), still inside the `if (playlistForm) {` guard:
 
@@ -427,7 +427,7 @@ In `config-init.js`, directly after the existing `playlistForm.addEventListener(
 
 (Match the options argument style used elsewhere in this listener block: if the file passes `SmartLists.getEventListenerOptions(pageSignal)`, extend with capture via `{ capture: true, signal: pageSignal }` only if `getEventListenerOptions` returns `{ signal: pageSignal }`; otherwise mirror whatever that helper returns plus `capture: true`. Check `getEventListenerOptions`' definition first: `grep -n "getEventListenerOptions = " Jellyfin.Plugin.SmartLists/Configuration/*.js`.)
 
-- [ ] **Step 2: Re-sync the expand icon on pageshow**
+- [x] **Step 2: Re-sync the expand icon on pageshow**
 
 In the `pageshow` handler, inside the `if (page._pageInitialized) {` block (line 2542, next to `SmartLists.handleListTypeChange(page);`), add:
 
@@ -447,7 +447,7 @@ Manual checks:
 1. Temporarily add `required` to `#playlistMaxItems` via devtools, clear its value, fold collapsed, hit Create → fold expands and browser focuses the field (no console error "not focusable"). Remove the attribute after.
 2. Expand fold → navigate to user page → browser Back → icon matches body state.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add Jellyfin.Plugin.SmartLists/Configuration/config-init.js

--- a/docs/superpowers/plans/2026-07-10-create-form-advanced-fold.md
+++ b/docs/superpowers/plans/2026-07-10-create-form-advanced-fold.md
@@ -283,7 +283,7 @@ git commit -m "Show effective defaults on collapsed Advanced options header"
 - Consumes: `toggleAdvancedOptions` (Task 1), `renderAdvancedSummaryFromForm`'s `_editMode` guard (Task 3), `SmartLists.loadExistingImages(page, id)` which returns a Promise (`config-images.js:545`).
 - Produces: `SmartLists.syncAdvancedSection(page, playlist)` — renders edit chips from the DTO + DOM image rows, expands the fold when any chip fires; idempotent, expand-only.
 
-- [ ] **Step 1: Add `syncAdvancedSection` to config-lists.js**
+- [x] **Step 1: Add `syncAdvancedSection` to config-lists.js**
 
 Insert directly AFTER `renderAdvancedSummaryFromForm`:
 
@@ -328,7 +328,7 @@ Insert directly AFTER `renderAdvancedSummaryFromForm`:
 
 (Signals deliberately exclude async-default fields — MaxItems, AutoRefresh, IsPublic — per the spec: their non-defaultness is ambiguous and they round-trip regardless of fold state.)
 
-- [ ] **Step 2: Collapse the fold on every form reset**
+- [x] **Step 2: Collapse the fold on every form reset**
 
 In `SmartLists.clearForm`, directly before the closing `};` (line 733, after the `initCustomImagesContainer` block):
 
@@ -341,7 +341,7 @@ In `SmartLists.clearForm`, directly before the closing `};` (line 733, after the
 
 (The default chips re-render via the async `applyFormDefaults`/`applyFallbackDefaults` calls already inside `clearForm`; `cancelEdit` runs `setPageEditState(false)` before `clearForm`, so the `_editMode` guard has already been lifted.)
 
-- [ ] **Step 3: Wire editPlaylist**
+- [x] **Step 3: Wire editPlaylist**
 
 In `SmartLists.editPlaylist`, replace the existing images call (lines 966-969):
 
@@ -367,7 +367,7 @@ with:
                 SmartLists.syncAdvancedSection(page, playlist);
 ```
 
-- [ ] **Step 4: Wire clonePlaylist**
+- [x] **Step 4: Wire clonePlaylist**
 
 In `SmartLists.clonePlaylist`, directly after the metadata tags population (line 1191-1192, anchor `SmartLists.initMetadataTagsInput(page, playlist.Tags || []);` and its closing `}`), insert:
 
@@ -391,7 +391,7 @@ Manual checks (admin page; create test lists first if needed):
 6. Update a configured list successfully → form clears, fold collapsed.
 7. Repeat check 1 on the user page.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add Jellyfin.Plugin.SmartLists/Configuration/config-lists.js

--- a/docs/superpowers/plans/2026-07-10-create-form-advanced-fold.md
+++ b/docs/superpowers/plans/2026-07-10-create-form-advanced-fold.md
@@ -32,7 +32,7 @@
 - Consumes: nothing new.
 - Produces: DOM ids `#advanced-options-header`, `#advanced-expand-icon`, `#advanced-summary`, `#advanced-options-body`; function `SmartLists.toggleAdvancedOptions(page, force)` — `force` optional boolean (true=expand, false=collapse, undefined=toggle). Tasks 2–5 rely on these exact names.
 
-- [ ] **Step 1: Reorder and wrap the advanced blocks in config.html**
+- [x] **Step 1: Reorder and wrap the advanced blocks in config.html**
 
 Work only inside `<form id="playlistForm">` (lines 47–463). Three operations, all static cut/paste of existing blocks (do NOT edit the blocks' inner content except where shown):
 
@@ -109,7 +109,7 @@ Notes:
 - Do NOT add a class to the Bumpers h3 — it is inside `#bumper-section`, which `updateBumperSectionVisibility` already hides for Collections.
 - All ids, classes, `style` attributes, labels, descriptions, and doc links inside moved blocks stay byte-identical (except the two inner edits above).
 
-- [ ] **Step 2: Add `SmartLists.toggleAdvancedOptions` to config-lists.js**
+- [x] **Step 2: Add `SmartLists.toggleAdvancedOptions` to config-lists.js**
 
 Insert directly ABOVE `SmartLists.clearForm = function (page) {` (line 664):
 
@@ -132,7 +132,7 @@ Insert directly ABOVE `SmartLists.clearForm = function (page) {` (line 664):
     };
 ```
 
-- [ ] **Step 3: Wire the header click via the existing page-level delegation**
+- [x] **Step 3: Wire the header click via the existing page-level delegation**
 
 In `config-init.js`, inside the big click listener, directly BEFORE the `.playlist-header` block (line 1253, anchor: `if (target.closest('.playlist-header')) {`), insert:
 
@@ -157,7 +157,7 @@ Manual checks at http://localhost:8096 → Dashboard → Plugins → SmartLists 
 4. Keyboard: Tab reaches the bar, Enter toggles it.
 5. Create a simple playlist (name + media type + one rule) without touching the fold → saves successfully.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add Jellyfin.Plugin.SmartLists/Configuration/config.html Jellyfin.Plugin.SmartLists/Configuration/config-lists.js Jellyfin.Plugin.SmartLists/Configuration/config-init.js

--- a/docs/superpowers/plans/2026-07-10-create-form-advanced-fold.md
+++ b/docs/superpowers/plans/2026-07-10-create-form-advanced-fold.md
@@ -464,7 +464,7 @@ git commit -m "Guard Advanced fold against hidden invalid controls and bfcache d
 
 **Interfaces:** none.
 
-- [ ] **Step 1: Update user docs**
+- [x] **Step 1: Update user docs**
 
 In the configuration page of the mkdocs docs, where the create-form fields are described, add a short note near the top of the field list (adapt heading level to the page):
 
@@ -479,7 +479,7 @@ In the configuration page of the mkdocs docs, where the create-form fields are d
 
 Also reorder/regroup the field documentation if it mirrors the old on-screen order (check whether the page lists fields in form order; if it does, note the new grouping: Limits / Bumpers / Automation / Sharing / Presentation).
 
-- [ ] **Step 2: Add future-field rules to CLAUDE.md**
+- [x] **Step 2: Add future-field rules to CLAUDE.md**
 
 In root `CLAUDE.md`, under "When Making Changes", add:
 
@@ -493,7 +493,7 @@ In root `CLAUDE.md`, under "When Making Changes", add:
   and auto-expands.
 ```
 
-- [ ] **Step 3: Verify docs build (optional, if mkdocs installed) and commit**
+- [x] **Step 3: Verify docs build (optional, if mkdocs installed) and commit**
 
 ```bash
 git add docs/content CLAUDE.md

--- a/docs/superpowers/plans/2026-07-10-create-form-advanced-fold.md
+++ b/docs/superpowers/plans/2026-07-10-create-form-advanced-fold.md
@@ -147,7 +147,7 @@ In `config-init.js`, inside the big click listener, directly BEFORE the `.playli
 
 - [ ] **Step 4: Build and verify on the admin page**
 
-Run: `cd /Users/johan.yourstone/Git/jellyfin-smartplaylist-plugin/dev && ./build-local.sh`
+Run: `cd dev && ./build-local.sh`
 Expected: build succeeds, Jellyfin container restarts.
 
 Manual checks at http://localhost:8096 → Dashboard → Plugins → SmartLists (hard-refresh; embedded resources cache aggressively — use devtools "Disable cache" or bump-refresh):
@@ -184,7 +184,7 @@ Same three operations as Task 1 Step 1, with these user-page differences:
 
 - [ ] **Step 2: Build and verify on the user page**
 
-Run: `cd /Users/johan.yourstone/Git/jellyfin-smartplaylist-plugin/dev && ./build-local.sh`
+Run: `cd dev && ./build-local.sh`
 Expected: build succeeds.
 
 Manual checks on the user config page (link "Open User Config Page" at top of admin page):
@@ -258,7 +258,7 @@ In `config-init.js`, add as the LAST line inside `SmartLists.applyFormDefaults` 
 
 - [ ] **Step 3: Build and verify**
 
-Run: `cd /Users/johan.yourstone/Git/jellyfin-smartplaylist-plugin/dev && ./build-local.sh`
+Run: `cd dev && ./build-local.sh`
 
 Manual checks:
 1. Admin create tab, fold collapsed: header right side reads e.g. `500 items max · refresh on library changes` (matches Settings-tab defaults).
@@ -380,7 +380,7 @@ In `SmartLists.clonePlaylist`, directly after the metadata tags population (line
 
 - [ ] **Step 5: Build and verify**
 
-Run: `cd /Users/johan.yourstone/Git/jellyfin-smartplaylist-plugin/dev && ./build-local.sh`
+Run: `cd dev && ./build-local.sh`
 
 Manual checks (admin page; create test lists first if needed):
 1. Edit a list with bumpers + a refresh schedule → form opens with fold EXPANDED, header reads `Bumpers · 1 schedule`.
@@ -441,7 +441,7 @@ In the `pageshow` handler, inside the `if (page._pageInitialized) {` block (line
 
 - [ ] **Step 3: Build and verify**
 
-Run: `cd /Users/johan.yourstone/Git/jellyfin-smartplaylist-plugin/dev && ./build-local.sh`
+Run: `cd dev && ./build-local.sh`
 
 Manual checks:
 1. Temporarily add `required` to `#playlistMaxItems` via devtools, clear its value, fold collapsed, hit Create → fold expands and browser focuses the field (no console error "not focusable"). Remove the attribute after.
@@ -504,6 +504,6 @@ git commit -m "Document Advanced options fold and future-field rules"
 
 ## Final verification sweep (after all tasks)
 
-1. `cd /Users/johan.yourstone/Git/jellyfin-smartplaylist-plugin/dev && ./build-local.sh` — clean build.
+1. `cd dev && ./build-local.sh` — clean build.
 2. Full spec checklist (spec §Verification), both pages: simple create untouched fold; edit configured list auto-expands with chips; images-only edit expands late; clone matches; cancel/update re-collapse; Playlist↔Collection gating inside open fold; back-nav icon sync; keyboard toggle.
 3. `git log --oneline main..` — 6 commits, one per task.

--- a/docs/superpowers/specs/2026-07-10-create-form-advanced-fold-design.md
+++ b/docs/superpowers/specs/2026-07-10-create-form-advanced-fold-design.md
@@ -41,7 +41,7 @@ In today's order, with one move (Users block moves up, from after Random Group S
 - **Bumpers** — the whole `#bumper-section` (keeps playlist-only gating and two-stage detail visibility)
 - **Automation** — Enable list, Auto-refresh mode, Refresh Schedules, Visibility Schedules
 - **Sharing** — Make playlist public (keeps `updatePublicCheckboxVisibility` gating)
-- **Presentation** — Custom Images; existing **Metadata** `h3` survives beneath it (Sort Title, Overview, Tags, Favorite)
+- **Presentation** — Custom Images; the existing **Metadata** `h3` is demoted to an `inputLabel` beneath it (Sort Title, Overview, Tags, Favorite) so it doesn't compete with the fold's sub-headings
 
 All three required inputs (`#playlistName`, `#listType`, conditional collection `#playlistUser`) live **outside** the fold — display:none never swallows native validation.
 
@@ -65,16 +65,16 @@ A real `<button class="emby-button">` (main-bundle safe) preserves keyboard/game
 
 ### Summary chips (create AND edit mode)
 
-`#advanced-summary` on the collapsed header always shows a truthful summary, so hidden-but-applied config is never a mystery:
+`#advanced-summary` on the collapsed header always shows the applied value chips (Max Items, auto-refresh — read from the populated form via `getAdvancedValueChips`), so hidden-but-applied configuration stays visible in every mode:
 
-- **Create mode:** effective defaults, e.g. `500 items max · refresh on library changes` (rendered after `applyFormDefaults`/`applyFallbackDefaults` resolves; tolerates defaults arriving a tick after form reset).
-- **Edit mode:** signals from the loaded list, counts over booleans — `Bumpers · 2 schedules · 3 images · Metadata · Disabled · Playtime limit · Random groups`.
+- **Create mode:** value chips only, i.e. the effective defaults, e.g. `500 items max · refresh on library changes` (rendered after `applyFormDefaults`/`applyFallbackDefaults` resolves; tolerates defaults arriving a tick after form reset).
+- **Edit/clone mode:** feature signals first (counts over booleans), then the value chips — `Bumpers · 2 schedules · 3 images · Metadata · Disabled · Playtime limit · Random groups · 100 items max · refresh on library changes`. `IsPublic` is the one applied setting without a chip (its visibility already depends on user selection).
 
 ### Expand/collapse behavior
 
 - Create: always starts collapsed. `clearForm` re-collapses and re-renders default chips.
 - Edit: `SmartLists.syncAdvancedSection(page, playlist)` is appended at the very END of `editPlaylist` (population sequence untouched — it is order-fragile). It renders chips and **auto-expands** the fold if any unambiguous signal fires: bumper media type set, any refresh/visibility schedule, random group enabled, `MaxPlayTimeMinutes > 0`, `Enabled === false`, any metadata field set, any custom image.
-- Fields whose non-defaultness is ambiguous (defaults load async: `AutoRefreshMode`, `MaxItems`, `IsPublic`) never trigger auto-expand; their values round-trip on save regardless of visibility.
+- Fields whose non-defaultness is ambiguous (defaults load async: `AutoRefreshMode`, `MaxItems`, `IsPublic`) never trigger auto-expand — but `AutoRefreshMode` and `MaxItems` remain visible as value chips on the collapsed header, and all values round-trip on save regardless of visibility.
 - Custom images arrive from a separate async endpoint: `loadExistingImages`' success path re-invokes `syncAdvancedSection`, so an images-only list still expands when the response lands.
 - `clonePlaylist` calls the same sync after populating. Update-failure re-invokes `editPlaylist` (sync re-runs). `cancelEdit`/update-success flow through `clearForm` (re-collapse).
 
@@ -103,7 +103,7 @@ Before submit: if `#advanced-options-body` contains an `:invalid` control while 
 
 - Open fold is still a long column (mitigated by sub-headings).
 - Max Items / Make public / Enable list / Auto-refresh land in Advanced — defensible since all have Settings-page defaults; habitual per-list tweakers pay one extra click.
-- Edit of a list whose only non-default value is an async-default field (e.g. MaxItems) opens with the fold closed — value safe and round-trips; visible in create-mode chips as effective value.
+- Edit of a list whose only non-default value is an async-default field (e.g. MaxItems) opens with the fold closed — the value stays visible as a chip on the collapsed header and round-trips on save.
 - Users block moves above Bumpers — small muscle-memory cost for a contiguous fold.
 - No animation, text ▶/▼ icon — consistent with Manage tab.
 

--- a/docs/superpowers/specs/2026-07-10-create-form-advanced-fold-design.md
+++ b/docs/superpowers/specs/2026-07-10-create-form-advanced-fold-design.md
@@ -1,0 +1,121 @@
+# Create/Edit Form: "Advanced options" Fold — Design
+
+**Date:** 2026-07-10
+**Status:** Approved direction (hybrid: minimal-diff fold + sub-headings, create-mode summary chips, pre-submit invalid guard)
+
+## Problem
+
+The Create List form (shared by create and edit, on both `config.html` and `user-playlists.html`) is a single-column wall of ~17 field groups. Creating a simple list (name + media type + a rule) drowns in advanced options: bumpers, random group selection, schedules, custom images, metadata overrides, etc. The form grows with every release.
+
+## Goals
+
+- A simple list is creatable without scrolling past advanced fields.
+- Advanced configuration stays discoverable and is never invisible when it is in effect (especially in edit mode).
+- Near-zero blast radius: no new JS files, no DOM nodes moved at runtime, no backend/DTO changes, reuse the proven Manage-tab collapse pattern.
+
+## Non-goals
+
+- No redesign of the Rules builder.
+- No per-section collapsible IA (deliberate stepping stone: the fold's sub-headings make a later migration to per-section folds mechanical if ever needed).
+- No localStorage persistence of fold state in v1 (cheap follow-up if requested; avoids any race with async `applyFormDefaults`).
+
+## Design
+
+### Visible form (fold collapsed — the default)
+
+In today's order, with one move (Users block moves up, from after Random Group Selection to directly after Sort Options, making the advanced fields contiguous):
+
+1. Edit-mode indicator (edit only)
+2. List Type
+3. List Name
+4. Media Types (+ conditional Include Extras)
+5. Rules builder
+6. Sort Options
+7. Users (admin page: playlist multi-select / collection single select; user page: hidden input)
+8. **▶ Advanced options** — collapsed fold header
+9. Create/Update + Clear Form buttons
+
+### Inside the fold (all existing IDs, labels, descriptions, and conditional-visibility classes unchanged), with static `h3.sectionTitle` sub-headings
+
+- **Limits** — Max Items, Max Playtime (playlist-only), Random Group Selection
+- **Bumpers** — the whole `#bumper-section` (keeps playlist-only gating and two-stage detail visibility)
+- **Automation** — Enable list, Auto-refresh mode, Refresh Schedules, Visibility Schedules
+- **Sharing** — Make playlist public (keeps `updatePublicCheckboxVisibility` gating)
+- **Presentation** — Custom Images; existing **Metadata** `h3` survives beneath it (Sort Title, Overview, Tags, Favorite)
+
+All three required inputs (`#playlistName`, `#listType`, conditional collection `#playlistUser`) live **outside** the fold — display:none never swallows native validation.
+
+### Fold header anatomy
+
+Clones the Manage-tab collapse pattern (display-toggled body, plain-text ▶/▼ icon, no animation — `emby-collapse` is NOT registered on plugin config pages and must not be used):
+
+```html
+<button type="button" id="advanced-options-header" class="emby-button"
+        style="width:100%; display:flex; align-items:center; text-align:left;">
+    <span id="advanced-expand-icon">&#9654;</span>
+    <span>Advanced options</span>
+    <span id="advanced-summary" class="fieldDescription" style="margin-left:auto;"></span>
+</button>
+<div id="advanced-options-body" style="display: none;">
+    <!-- existing advanced field groups, unmoved at runtime -->
+</div>
+```
+
+A real `<button class="emby-button">` (main-bundle safe) preserves keyboard/gamepad focus handling. Only main-bundle-verified classes are used (`emby-button`, `sectionTitle`, `fieldDescription`, `inputContainer`, …); colors inherited, per repo convention.
+
+### Summary chips (create AND edit mode)
+
+`#advanced-summary` on the collapsed header always shows a truthful summary, so hidden-but-applied config is never a mystery:
+
+- **Create mode:** effective defaults, e.g. `500 items max · refresh on library changes` (rendered after `applyFormDefaults`/`applyFallbackDefaults` resolves; tolerates defaults arriving a tick after form reset).
+- **Edit mode:** signals from the loaded list, counts over booleans — `Bumpers · 2 schedules · 3 images · Metadata · Disabled · Playtime limit · Random groups`.
+
+### Expand/collapse behavior
+
+- Create: always starts collapsed. `clearForm` re-collapses and re-renders default chips.
+- Edit: `SmartLists.syncAdvancedSection(page, playlist)` is appended at the very END of `editPlaylist` (population sequence untouched — it is order-fragile). It renders chips and **auto-expands** the fold if any unambiguous signal fires: bumper media type set, any refresh/visibility schedule, random group enabled, `MaxPlayTimeMinutes > 0`, `Enabled === false`, any metadata field set, any custom image.
+- Fields whose non-defaultness is ambiguous (defaults load async: `AutoRefreshMode`, `MaxItems`, `IsPublic`) never trigger auto-expand; their values round-trip on save regardless of visibility.
+- Custom images arrive from a separate async endpoint: `loadExistingImages`' success path re-invokes `syncAdvancedSection`, so an images-only list still expands when the response lands.
+- `clonePlaylist` calls the same sync after populating. Update-failure re-invokes `editPlaylist` (sync re-runs). `cancelEdit`/update-success flow through `clearForm` (re-collapse).
+
+### Pre-submit invalid guard
+
+Before submit: if `#advanced-options-body` contains an `:invalid` control while collapsed, expand the fold first. One-liner; permanently defuses the hidden-required-field validation trap for future fields.
+
+## Implementation notes
+
+- **Both HTML files** (`config.html`, `user-playlists.html`) get the same wrapper + header + sub-headings; user page's Users block is the hidden input (position irrelevant).
+- **JS in existing modules only** (no `.csproj`/`Plugin.cs` registration):
+  - `config-lists.js`: `SmartLists.toggleAdvancedOptions(page, force)` (flip body display, swap ▶/▼; string concatenation, no template literals), `SmartLists.syncAdvancedSection(page, playlist)`; one line in `clearForm`; trailing sync call in `editPlaylist`/`clonePlaylist`.
+  - `config-images.js`: re-invoke sync from `loadExistingImages` success path.
+  - `config-init.js`: add `target.closest('#advanced-options-header')` to the existing page-level click delegation (~line 1254); one line in the `pageshow` handler (~2511) to re-sync ▶/▼ icon from the body's actual display (bfcache back-nav).
+- Wrapper is static HTML; no nodes move at runtime, so module-held references and delegated listeners survive; `handleListTypeChange`, `updateBumperSectionVisibility`, `updatePublicCheckboxVisibility`, and all `initialize*`/`populate*` functions work unchanged.
+- Estimated diff: ~30 lines HTML per page (mostly re-indentation), ~70 lines JS across existing modules.
+- **Docs:** short "Advanced options" note on the configuration page in `docs/content/`.
+
+## Rules for future fields (codify in CLAUDE.md)
+
+1. Required inputs must never live inside the fold.
+2. New advanced fields go under the matching sub-heading inside the fold; new core fields go above it.
+3. Edit-mode chips/auto-expand: add a signal to `syncAdvancedSection` when the new field has an unambiguous non-default state.
+
+## Known trade-offs (accepted)
+
+- Open fold is still a long column (mitigated by sub-headings).
+- Max Items / Make public / Enable list / Auto-refresh land in Advanced — defensible since all have Settings-page defaults; habitual per-list tweakers pay one extra click.
+- Edit of a list whose only non-default value is an async-default field (e.g. MaxItems) opens with the fold closed — value safe and round-trips; visible in create-mode chips as effective value.
+- Users block moves above Bumpers — small muscle-memory cost for a contiguous fold.
+- No animation, text ▶/▼ icon — consistent with Manage tab.
+
+## Verification
+
+No test suite; verify against local Jellyfin (`cd dev && ./build-local.sh`, http://localhost:8096), both admin and user pages:
+
+1. Create simple playlist with fold untouched → saved with defaults (Max Items, auto-refresh) intact.
+2. Edit a list with bumpers + schedules → fold auto-expanded, chips show counts.
+3. Edit a list with only custom images → fold expands when images load.
+4. Clone a configured list → chips/expand state match.
+5. Cancel edit / successful update → fold re-collapses, default chips return.
+6. Switch List Type Playlist↔Collection with fold open → bumpers/playlist-only fields gate correctly inside fold.
+7. Browser back-nav to the page → icon matches body state, no ghost-expanded fold.
+8. Keyboard: header reachable by Tab, toggles on Enter/Space.


### PR DESCRIPTION
## What
Restructures the create/edit list form so simple lists are created without scrolling past advanced options: everything beyond the core fields now lives in a collapsed **Advanced options** section with summary chips and sub-headings.

## Why
The form had grown to ~17 field groups in one column — a wall of bumpers, schedules, images, and metadata options even when creating a trivial list. Research confirmed `is="emby-collapse"` is not registered on plugin config pages (verified in jellyfin-web source and the shipped 12.x bundle), so the fold is a hand-rolled collapse cloned from the existing Manage-tab pattern.

## Changes
- **Visible form** (both pages): List Type, Name, Media Types, Rules, Sort Options, Users (moved up next to Sort), collapsed `▶ Advanced options` bar, submit/clear buttons.
- **Fold contents** under sub-headings Limits / Bumpers / Automation / Sharing / Presentation: Max Items, Max Playtime, Random Group Selection, Bumpers, Enable list, Auto-refresh, Refresh + Visibility Schedules, Make public, Custom Images, Metadata.
- **Summary chips on the collapsed header**: create mode shows effective defaults ("500 items max · refresh on library changes"); edit/clone shows configured features with counts ("Bumpers · 2 schedules · 1 image").
- **Edit/clone auto-expand**: fold opens automatically when the list uses advanced features (expand-only; custom images re-sync when their async load lands). `clearForm`/cancel/update re-collapse it.
- **Guards**: capture-phase `invalid` listener expands the fold if native validation trips inside it; `pageshow` re-syncs the expand icon after bfcache back-navigation; the Sharing sub-heading hides together with the public checkbox for all-users/multi-user playlists.
- New JS lives in existing modules only (`config-lists.js`, `config-init.js`, `config-user-select.js`) — no new embedded resources; no runtime DOM moves, all existing IDs/classes and conditional-visibility machinery untouched.
- Docs: configuration guide regrouped to match the fold; CLAUDE.md gained placement rules for future form fields (required inputs never inside the fold).
- Design spec and implementation plan under `docs/superpowers/`.

Verified with a clean `./build-local.sh` (warnings-as-errors) and mkdocs `--strict`; every task went through an adversarial review pass during implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QS19oSpmtezUt85WorzENR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a collapsible **Advanced options** section to Smart List create and edit forms, with a header summary and summary chips.
  * Advanced settings now auto-expand when relevant options are enabled, including after editing, cloning, and once related images finish loading.
* **Bug Fixes**
  * If a required field inside Advanced options fails browser validation, the section expands so the invalid input is visible.
  * Back/forward navigation now preserves the correct Advanced options expanded/collapsed state.
  * Sharing visibility now stays consistent between the sharing title and public controls.
* **Documentation**
  * Updated the configuration guide to match the new Advanced options workflow (including Custom Images).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->