### PR TITLE
Add Collection group-by and Order Within Group to round-robin sorts

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Configuration/config-core.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-core.js
@@ -112,6 +112,7 @@
     // Fields available for Round Robin grouping, filtered by media type in the UI
     SmartLists.ROUND_ROBIN_GROUP_FIELDS = [
         { value: 'SeriesName', label: 'Series Name', mediaTypes: ['Episode'] },
+        { value: 'Collections', label: 'Collection', mediaTypes: ['Episode', 'Movie'] },
         { value: 'AlbumName', label: 'Album Name', mediaTypes: ['Audio', 'MusicVideo'] },
         { value: 'Artist', label: 'Artist', mediaTypes: ['Audio', 'MusicVideo'] },
         { value: 'Genres', label: 'Genre (first)', mediaTypes: null },

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-sorts.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-sorts.js
@@ -123,7 +123,7 @@
     };
 
     // Helper function to sync Sort Order UI based on Sort By value
-    SmartLists.syncSortOrderUI = function(sortByValue, sortOrderContainer, sortOrderSelect, groupByContainer) {
+    SmartLists.syncSortOrderUI = function(sortByValue, sortOrderContainer, sortOrderSelect, groupByContainer, withinGroupContainer) {
         if (!sortOrderContainer || !sortOrderSelect) return;
         
         // Hide Sort Order for Random, Random Round Robin, and Default (they don't use ordering)
@@ -141,6 +141,12 @@
         // Show/hide GroupBy dropdown for Round Robin and Random Round Robin
         if (groupByContainer) {
             groupByContainer.style.display = SmartLists.isRoundRobinSort(sortByValue) ? '' : 'none';
+        }
+
+        // Show/hide Order Within Group for round robin sorts (not Shuffled - shuffle wins)
+        if (withinGroupContainer) {
+            var showWithinGroup = SmartLists.isRoundRobinSort(sortByValue) && sortByValue !== 'Shuffled Round Robin';
+            withinGroupContainer.style.display = showWithinGroup ? '' : 'none';
         }
     };
     
@@ -339,6 +345,18 @@
         groupByField.container.style.display = SmartLists.isRoundRobinSort(actualSortBy) ? '' : 'none';
         fieldsContainer.appendChild(groupByField.container);
 
+        // Order Within Group field (round robin sorts except Shuffled)
+        const withinGroupField = SmartLists.createSortField('Order Within Group', 'sort-withingroup-' + sortId, 'select');
+        withinGroupField.container.style.minWidth = '200px';
+        withinGroupField.container.style.maxWidth = '200px';
+        var savedWithinGroup = (sortData && sortData.WithinGroupOrder) ? sortData.WithinGroupOrder : 'Natural';
+        SmartLists.populateSelectElement(withinGroupField.input, [
+            { value: 'Natural', label: 'Season/Episode (default)', selected: savedWithinGroup !== 'AirDate' },
+            { value: 'AirDate', label: 'Air Date', selected: savedWithinGroup === 'AirDate' }
+        ]);
+        withinGroupField.container.style.display = (SmartLists.isRoundRobinSort(actualSortBy) && actualSortBy !== 'Shuffled Round Robin') ? '' : 'none';
+        fieldsContainer.appendChild(withinGroupField.container);
+
         box.appendChild(fieldsContainer);
 
         // Remove button (positioned absolutely within box)
@@ -353,7 +371,7 @@
 
         // Add event listener to sync Sort Order UI and checkbox visibility when Sort By changes
         sortByField.input.addEventListener('change', function() {
-            SmartLists.syncSortOrderUI(this.value, sortOrderField.container, sortOrderField.input, groupByField.container);
+            SmartLists.syncSortOrderUI(this.value, sortOrderField.container, sortOrderField.input, groupByField.container, withinGroupField.container);
             // Show/hide ignore articles checkbox based on Sort By value
             const showIgnoreArticles = (this.value === 'Name' || this.value === 'SeriesName');
             ignoreArticlesField.container.style.display = showIgnoreArticles ? '' : 'none';
@@ -364,7 +382,7 @@
         });
 
         // Initialize Sort Order UI based on current Sort By value
-        SmartLists.syncSortOrderUI(actualSortBy, sortOrderField.container, sortOrderField.input, groupByField.container);
+        SmartLists.syncSortOrderUI(actualSortBy, sortOrderField.container, sortOrderField.input, groupByField.container, withinGroupField.container);
 
         return box;
     };
@@ -493,6 +511,10 @@
                 if (groupBySelect && groupBySelect.value) {
                     sortEntry.GroupByField = groupBySelect.value;
                 }
+                var withinGroupSelect = box.querySelector('[id^="sort-withingroup-"]');
+                if (withinGroupSelect && withinGroupSelect.value === 'AirDate' && sortBy !== 'Shuffled Round Robin') {
+                    sortEntry.WithinGroupOrder = 'AirDate';
+                }
             }
 
             sorts.push(sortEntry);
@@ -539,7 +561,9 @@
             // Sync Sort Order UI for the effective value
             var groupByContainer = box.querySelector('[id^="sort-groupby-"]');
             groupByContainer = groupByContainer ? groupByContainer.closest('.sort-field-container') : null;
-            SmartLists.syncSortOrderUI(effectiveSortValue, sortOrderContainer, sortOrderSelect, groupByContainer);
+            var withinGroupContainer = box.querySelector('[id^="sort-withingroup-"]');
+            withinGroupContainer = withinGroupContainer ? withinGroupContainer.closest('.sort-field-container') : null;
+            SmartLists.syncSortOrderUI(effectiveSortValue, sortOrderContainer, sortOrderSelect, groupByContainer, withinGroupContainer);
 
             // Update Round Robin Group By dropdown options
             if (groupByContainer) {

--- a/Jellyfin.Plugin.SmartLists/Core/Models/SortOption.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Models/SortOption.cs
@@ -17,6 +17,15 @@ namespace Jellyfin.Plugin.SmartLists.Core.Models
         /// </summary>
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? GroupByField { get; set; }
+
+        /// <summary>
+        /// How items are ordered inside each Round Robin group.
+        /// "Natural" (default, also when null/unknown): season/episode, disc/track, or name.
+        /// "AirDate": premiere date (day precision), tie-broken by season/episode.
+        /// Ignored by Shuffled Round Robin (shuffle wins).
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? WithinGroupOrder { get; set; }
     }
 }
 

--- a/Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs
@@ -27,6 +27,21 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
         public string? GroupByField { get; set; }
 
         /// <summary>
+        /// Item id → collection name, for GroupByField "Collections". Built by SmartList from the
+        /// unfiltered media pool (episodes resolve membership through their parent series) and set
+        /// before <see cref="PreComputePositions"/>. Items absent from the map fall back to
+        /// series-name/own-name grouping in <see cref="ExtractGroupKey"/>.
+        /// </summary>
+        public Dictionary<Guid, string>? CollectionGroupKeys { get; set; }
+
+        /// <summary>
+        /// When true, items within each group are ordered by air date (premiere date, day precision)
+        /// instead of natural season/episode order. Set from SortOption.WithinGroupOrder.
+        /// Ignored when <see cref="ShuffleWithinGroups"/> is true.
+        /// </summary>
+        public bool OrderWithinGroupsByAirDate { get; set; }
+
+        /// <summary>
         /// When true, items within each group are shuffled instead of sorted in natural order.
         /// </summary>
         protected virtual bool ShuffleWithinGroups => false;
@@ -50,7 +65,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
         /// </summary>
         public void PreComputePositions(IEnumerable<BaseItem> items, ILogger? logger = null)
         {
-            ItemPositions = BuildInterleavedPositions(items, GroupByField, OrderGroupKeys, Name, logger, ShuffleWithinGroups);
+            ItemPositions = BuildInterleavedPositions(items, GroupByField, OrderGroupKeys, Name, logger, ShuffleWithinGroups, CollectionGroupKeys, OrderWithinGroupsByAirDate);
         }
 
         public override IEnumerable<BaseItem> OrderBy(IEnumerable<BaseItem> items)
@@ -96,7 +111,9 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
             Func<IEnumerable<string>, List<string>> orderGroupKeys,
             string logPrefix,
             ILogger? logger,
-            bool shuffleWithinGroups = false)
+            bool shuffleWithinGroups = false,
+            Dictionary<Guid, string>? collectionGroupKeys = null,
+            bool airDateWithinGroups = false)
         {
             var positions = new ConcurrentDictionary<Guid, int>();
 
@@ -114,7 +131,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
             var groups = new Dictionary<string, List<BaseItem>>(StringComparer.OrdinalIgnoreCase);
             foreach (var item in itemsList)
             {
-                var key = ExtractGroupKey(item, groupByField);
+                var key = ExtractGroupKey(item, groupByField, collectionGroupKeys);
                 if (!groups.TryGetValue(key, out var group))
                 {
                     group = new List<BaseItem>();
@@ -132,6 +149,10 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
                 if (shuffleWithinGroups)
                 {
                     Shuffle(kvp.Value, Random.Shared);
+                }
+                else if (airDateWithinGroups)
+                {
+                    kvp.Value.Sort((a, b) => CompareWithinGroupByAirDate(a, b));
                 }
                 else
                 {
@@ -165,7 +186,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
         /// <summary>
         /// Extracts the group key from an item based on the configured GroupByField.
         /// </summary>
-        internal static string ExtractGroupKey(BaseItem item, string? groupByField)
+        internal static string ExtractGroupKey(BaseItem item, string? groupByField, Dictionary<Guid, string>? collectionGroupKeys = null)
         {
             if (string.IsNullOrEmpty(groupByField))
             {
@@ -209,6 +230,20 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
 
                     return string.Empty;
 
+                case "Collections":
+                    if (collectionGroupKeys != null && collectionGroupKeys.TryGetValue(item.Id, out var collectionName))
+                    {
+                        return collectionName;
+                    }
+
+                    // Not in any collection: fall back to per-show grouping
+                    if (item is Episode collectionEpisode)
+                    {
+                        return collectionEpisode.SeriesName ?? string.Empty;
+                    }
+
+                    return item.Name ?? string.Empty;
+
                 default:
                     return item.Name ?? string.Empty;
             }
@@ -237,6 +272,29 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
             return OrderUtilities.SharedNaturalComparer.Compare(
                 a.SortName ?? a.Name ?? string.Empty,
                 b.SortName ?? b.Name ?? string.Empty);
+        }
+
+        /// <summary>
+        /// Compares two items within the same group by air date (premiere date, day precision).
+        /// Missing dates are DateTime.MinValue and sort first (Release Date sort convention).
+        /// Same-day ties put episodes before non-episodes, then fall back to natural order,
+        /// so multi-part crossovers airing the same day keep their episode order.
+        /// </summary>
+        internal static int CompareWithinGroupByAirDate(BaseItem a, BaseItem b)
+        {
+            var dateCompare = OrderUtilities.GetReleaseDate(a).Date.CompareTo(OrderUtilities.GetReleaseDate(b).Date);
+            if (dateCompare != 0)
+            {
+                return dateCompare;
+            }
+
+            var episodeCompare = OrderUtilities.IsEpisode(b).CompareTo(OrderUtilities.IsEpisode(a));
+            if (episodeCompare != 0)
+            {
+                return episodeCompare;
+            }
+
+            return CompareWithinGroup(a, b);
         }
 
         /// <summary>
@@ -348,7 +406,8 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
             User user,
             IUserDataManager? userDataManager,
             RefreshQueueService.RefreshCache? refreshCache,
-            ILogger? logger)
+            ILogger? logger,
+            Dictionary<Guid, string>? collectionGroupKeys = null)
         {
             var recency = new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
             if (string.IsNullOrEmpty(groupByField) || userDataManager == null || user == null)
@@ -361,7 +420,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
             {
                 try
                 {
-                    var key = ExtractGroupKey(item, groupByField);
+                    var key = ExtractGroupKey(item, groupByField, collectionGroupKeys);
 
                     var lastPlayed = LastPlayedOrderBase.GetAggregateLastPlayedDate(item, user, userDataManager, refreshCache)
                         ?? LastPlayedOrderBase.GetLastPlayedDateFromUserData(

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -126,6 +126,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                         if (order is RoundRobinBase rr)
                         {
                             rr.GroupByField = so.GroupByField;
+                            rr.OrderWithinGroupsByAirDate = string.Equals(so.WithinGroupOrder, "AirDate", StringComparison.OrdinalIgnoreCase);
                         }
 
                         return order;

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -759,14 +759,30 @@ namespace Jellyfin.Plugin.SmartLists.Core
                     return [];
                 }
 
-                // Least Recently Watched Round Robin needs per-group watch recency computed from the
-                // UNFILTERED pool: rules like "Playback Status is Unwatched" remove watched items from
-                // the results, so recency derived from filtered items would see every group as unwatched.
-                // Same injection pattern as SimilarityOrder.Scores / RuleBlockOrder.GroupMappings.
+                // Round Robin sorts may need maps computed from the UNFILTERED pool before filtering
+                // (same injection pattern as SimilarityOrder.Scores / RuleBlockOrder.GroupMappings):
+                // - "Collections" grouping: item id -> collection name (episodes resolve via their series).
+                // - Least Recently Watched: per-group watch recency. Rules like "Playback Status is
+                //   Unwatched" remove watched items from the results, so recency derived from filtered
+                //   items would see every group as unwatched.
+                Dictionary<Guid, string>? collectionGroupKeys = null;
+                if (Orders.OfType<RoundRobinBase>().Any(o => o.GroupByField == "Collections"))
+                {
+                    collectionGroupKeys = BuildCollectionGroupKeyMap(itemsArray, user, libraryManager, refreshCache, logger);
+                    foreach (var rrOrder in Orders.OfType<RoundRobinBase>())
+                    {
+                        if (rrOrder.GroupByField == "Collections")
+                        {
+                            rrOrder.CollectionGroupKeys = collectionGroupKeys;
+                        }
+                    }
+                }
+
                 foreach (var lrwOrder in Orders.OfType<RoundRobinLeastRecentlyWatchedOrder>())
                 {
                     lrwOrder.GroupRecency = RoundRobinLeastRecentlyWatchedOrder.BuildGroupRecency(
-                        itemsArray, lrwOrder.GroupByField, user, userDataManager, refreshCache, logger);
+                        itemsArray, lrwOrder.GroupByField, user, userDataManager, refreshCache, logger,
+                        lrwOrder.GroupByField == "Collections" ? collectionGroupKeys : null);
                 }
 
                 // Media type filtering is now handled at the API level in PlaylistService.GetAllUserMedia()
@@ -1649,6 +1665,92 @@ namespace Jellyfin.Plugin.SmartLists.Core
             }
 
             return [];
+        }
+
+        /// <summary>
+        /// Builds an item id → collection name map for Round Robin "Collections" grouping.
+        /// TV collections contain Series items, so episodes resolve membership through their
+        /// parent series; movies (and any direct members) resolve by their own id.
+        /// When an item belongs to multiple collections, the alphabetically-first collection
+        /// name wins (consistent with the Genres/Studios "first value" convention).
+        /// Direct members only — nested collections are not flattened.
+        /// </summary>
+        private static Dictionary<Guid, string> BuildCollectionGroupKeyMap(
+            IReadOnlyList<BaseItem> pool,
+            User user,
+            ILibraryManager libraryManager,
+            RefreshQueueService.RefreshCache? refreshCache,
+            ILogger? logger)
+        {
+            var map = new Dictionary<Guid, string>();
+
+            try
+            {
+                BaseItem[] allCollections;
+                if (refreshCache?.AllCollections != null)
+                {
+                    allCollections = refreshCache.AllCollections;
+                }
+                else
+                {
+                    var query = new InternalItemsQuery(user)
+                    {
+                        IncludeItemTypes = [BaseItemKind.BoxSet],
+                        Recursive = true,
+                    };
+                    allCollections = [.. libraryManager.GetItemsResult(query).Items];
+                    if (refreshCache != null)
+                    {
+                        refreshCache.AllCollections = allCollections;
+                    }
+                }
+
+                // memberId -> collection name; alphabetically-first collection wins
+                var memberToCollection = new Dictionary<Guid, string>();
+                foreach (var collection in allCollections.OrderBy(c => c.Name ?? string.Empty, OrderUtilities.SharedNaturalComparer))
+                {
+                    BaseItem[] children;
+                    if (refreshCache != null && refreshCache.CollectionDirectChildren.TryGetValue(collection.Id, out var cachedChildren))
+                    {
+                        children = cachedChildren;
+                    }
+                    else
+                    {
+                        children = GetCollectionChildren(collection, user, logger);
+                        refreshCache?.CollectionDirectChildren.TryAdd(collection.Id, children);
+                    }
+
+                    foreach (var child in children)
+                    {
+                        if (!memberToCollection.ContainsKey(child.Id))
+                        {
+                            memberToCollection[child.Id] = collection.Name ?? string.Empty;
+                        }
+                    }
+                }
+
+                foreach (var item in pool)
+                {
+                    if (memberToCollection.TryGetValue(item.Id, out var directName))
+                    {
+                        map[item.Id] = directName;
+                    }
+                    else if (item is Episode episode && episode.SeriesId != Guid.Empty &&
+                             memberToCollection.TryGetValue(episode.SeriesId, out var seriesCollectionName))
+                    {
+                        map[item.Id] = seriesCollectionName;
+                    }
+                }
+
+                logger?.LogDebug("Collection group map: {MappedCount} of {PoolCount} items belong to a collection ({CollectionCount} collections checked)",
+                    map.Count, pool.Count, allCollections.Length);
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex, "Error building collection group map - items will fall back to series/name grouping");
+            }
+
+            return map;
         }
 
         /// <summary>

--- a/docs/content/examples/common-use-cases.md
+++ b/docs/content/examples/common-use-cases.md
@@ -113,6 +113,16 @@ Like the TV Channel playlist above, but the show rotation follows your watch his
 
 Result: Shows you have never watched come first, and the show you watched most recently goes to the back of the rotation. Watch an episode of Show A, and on the next refresh Show A moves to the end while the other shows shift forward — the rotation "continues where you left off".
 
+### Franchise TV Channel (crossovers in air-date order)
+Have franchise collections like NCIS or One Chicago where crossover episodes span several shows? Group the rotation by collection and play each franchise in airing order:
+
+- **Media Types**: Episode
+- **Playback Status** = Unplayed
+- **Sort by**: Least Recently Watched Round Robin (Interleave), **Group By**: Collection, **Order Within Group**: Air Date
+- **Auto Refresh**: On All Changes
+
+Result: Each collection becomes one slot in the rotation and plays chronologically across its shows — crossovers stay in order, and a spinoff only starts appearing once the timeline reaches its premiere. Shows not in any collection rotate as themselves. Watch anything in a franchise and the whole franchise moves to the back of the rotation.
+
 ### TV Channel with Commercials (Bumpers)
 Take any of the TV Channel playlists above and weave "commercial break" clips between the episodes:
 

--- a/docs/content/user-guide/sorting-and-limits.md
+++ b/docs/content/user-guide/sorting-and-limits.md
@@ -230,7 +230,7 @@ Both the show rotation and the episode order within each show are random, and re
 4. No Sort Order is needed — both group order and item order are always randomized
 
 ### Least Recently Watched Round Robin (Interleave)
-Rotates through your shows starting with the one you watched **least** recently — shows you have never watched come first, and the show you watched most recently goes to the back of the rotation. Watch an episode of Show A today, and on the next refresh Show A moves to the end of the rotation while the other shows shift forward. Within each group, items stay in natural order (episodes by season/episode number).
+Rotates through your shows starting with the one you watched **least** recently — shows you have never watched come first, and the show you watched most recently goes to the back of the rotation. Watch an episode of Show A today, and on the next refresh Show A moves to the end of the rotation while the other shows shift forward. Within each group, items stay in natural order (episodes by season/episode number), or air-date order if you set **Order Within Group** to Air Date.
 
 Unlike Random Round Robin, the rotation is not shuffled — it is derived entirely from your watch history, so it "continues where you left off" across refreshes, and refreshing without watching anything produces the same order.
 

--- a/docs/content/user-guide/sorting-and-limits.md
+++ b/docs/content/user-guide/sorting-and-limits.md
@@ -128,6 +128,7 @@ Interleaves items across groups defined by a field you choose (e.g., Series Name
 | Field | Available when |
 |-------|---------------|
 | Series Name | Episode media type |
+| Collection | Episode or Movie media type |
 | Album Name | Audio or Music Video media type |
 | Artist | Audio or Music Video media type |
 | Genre (first) | All media types |
@@ -138,6 +139,18 @@ Interleaves items across groups defined by a field you choose (e.g., Series Name
 
 !!! note "Multi-value fields"
     For Genre and Studio, items are grouped by their **first** value. For example, a movie tagged "Action, Comedy" would be placed in the "Action" group.
+
+!!! note "Grouping by Collection"
+    Collections are Jellyfin's regular collections — manually created ones, auto-created movie collections, and SmartLists smart collections all work. Episodes belong to a collection through their **series** (TV collections contain series). If an item is in several collections, it's grouped under the alphabetically-first one. Items that aren't in any collection fall back to grouping by Series Name (episodes) or their own name. Only direct collection members count — nested collections are not flattened.
+
+**Order Within Group**:
+
+All round robin variants except Shuffled Round Robin (where shuffling always wins) let you choose how items are ordered inside each group:
+
+- **Season/Episode (default)**: Natural order — episodes by season/episode number, audio by disc/track number, other items by name.
+- **Air Date**: Premiere date order (day precision). Items airing on the same day keep their episode order, and items with no date come first.
+
+Air Date is made for franchise viewing: combine **Group By: Collection** with **Order Within Group: Air Date** and crossover episodes that span multiple shows play in airing order, while a spinoff only enters the rotation once the timeline reaches its premiere.
 
 !!! warning "NextUnwatched vs Playback Status"
     If you want to interleave **all** unwatched episodes, use `Playback Status = Unplayed`. The `Next Unwatched = Yes` filter only returns 1 episode per series (the very next one to watch), which limits Round Robin to at most one item per show.
@@ -150,7 +163,7 @@ Works exactly like Round Robin, but **shuffles the group order randomly** on eac
 - **Round Robin**: Groups are always in alphabetical order (A→Z or Z→A). Show A always comes first.
 - **Random Round Robin**: Group order is randomized each refresh. One time Show C might come first, the next time Show B.
 
-Within each group, items always stay in natural order (episodes by season/episode number).
+Within each group, items stay in natural order (episodes by season/episode number), or air-date order if you set **Order Within Group** to Air Date.
 
 **Example** — Same 3 shows, different refreshes:
 
@@ -241,6 +254,8 @@ Unlike Random Round Robin, the rotation is not shuffled — it is derived entire
 5. Set [Auto Refresh](auto-refresh.md) to **On All Changes** so the rotation advances right after you finish watching something
 
 With other auto-refresh modes the rotation still advances, but only at the next refresh (scheduled or on library changes).
+
+With **Group By: Collection**, the whole franchise carries one recency — watching any member sends the entire collection group to the back of the rotation.
 
 !!! note "Per-user rotation"
     For playlists shared with multiple users, each user gets their own rotation based on their own watch history. Collections use the [reference user's](user-selection.md#collections-reference-user) watch history, so all users see the same rotation.

--- a/docs/superpowers/plans/2026-07-12-collection-group-by-round-robin.md
+++ b/docs/superpowers/plans/2026-07-12-collection-group-by-round-robin.md
@@ -1,0 +1,554 @@
+# Collection Group By + Within-Group Order Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Round-robin sorts can group by Jellyfin collection (franchise = one rotation slot; episodes resolve membership via their series) and order items within each group by air date instead of season/episode.
+
+**Architecture:** New `"Collections"` Group By value backed by an itemId→collection-name map that SmartList builds once per refresh from the unfiltered pool and injects into the round-robin orders — the exact pattern `GroupRecency` (LRW) already uses. A new nullable `WithinGroupOrder` DTO field selects a `CompareWithinGroupByAirDate` comparator inside `BuildInterleavedPositions`. LRW recency reuses the same map so a franchise carries one recency.
+
+**Tech Stack:** C# (.NET multi-target net9.0/net10.0), Jellyfin plugin API, vanilla JS config pages.
+
+**Spec:** `docs/superpowers/specs/2026-07-12-collection-group-by-round-robin-design.md`
+
+## Global Constraints
+
+- Build treats all warnings as errors (`AnalysisMode=Recommended`); both frameworks must build: `net10.0` and `net9.0`.
+- Group By field value everywhere (backend + JS): exactly `Collections`. UI label: `Collection`. DTO property: `WithinGroupOrder`, values `Natural` (default, may be omitted/null) and `AirDate`.
+- Config JS: no ES6 template literals; never `is="emby-input"`; user messages via `showNotification()`. NOTE: config-sorts.js uses `const`/arrow functions already — match the file's existing style.
+- No test suite. Verification = build both targets + live checks against local Jellyfin (<http://localhost:8096>).
+- Working tree: worktree at `.claude/worktrees/collection-group-by-round-robin`, branch `worktree-collection-group-by-round-robin`, based on main `0337526`.
+- Line numbers below are anchors on that commit — locate by quoted code, not absolute number.
+- Commit messages end with (blank line before):
+
+  ```text
+  Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_01RBFLcyWKuktDSu9acy68zg
+  ```
+
+---
+
+### Task 1: DTO field + order-class mechanics (map consumption, air-date comparator)
+
+**Files:**
+
+- Modify: `Jellyfin.Plugin.SmartLists/Core/Models/SortOption.cs`
+- Modify: `Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs`
+- Modify: `Jellyfin.Plugin.SmartLists/Core/SmartList.cs` (only the `InitializeFromDto` round-robin branch, ~line 126)
+
+**Interfaces:**
+
+- Consumes: `OrderUtilities.GetReleaseDate/IsEpisode/GetSeasonNumber/GetEpisodeNumber/SharedNaturalComparer` (static class in SmartList.cs ~3318).
+- Produces (Task 2 relies on these exact members): `RoundRobinBase.CollectionGroupKeys` (`Dictionary<Guid, string>?`), `RoundRobinBase.OrderWithinGroupsByAirDate` (`bool`), `ExtractGroupKey(BaseItem item, string? groupByField, Dictionary<Guid, string>? collectionGroupKeys = null)`, `BuildGroupRecency(..., Dictionary<Guid, string>? collectionGroupKeys = null)` (appended optional param), `SortOption.WithinGroupOrder` (`string?`).
+
+- [ ] **Step 1: Add `WithinGroupOrder` to SortOption**
+
+In `Core/Models/SortOption.cs`, after the `GroupByField` property (keep its `[JsonIgnore]` style):
+
+```csharp
+        /// <summary>
+        /// How items are ordered inside each Round Robin group.
+        /// "Natural" (default, also when null/unknown): season/episode, disc/track, or name.
+        /// "AirDate": premiere date (day precision), tie-broken by season/episode.
+        /// Ignored by Shuffled Round Robin (shuffle wins).
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? WithinGroupOrder { get; set; }
+```
+
+- [ ] **Step 2: RoundRobinBase — new state + threaded parameters**
+
+In `Core/Orders/RoundRobinOrder.cs`:
+
+(a) After the `GroupByField` property (~line 27), add:
+
+```csharp
+        /// <summary>
+        /// Item id → collection name, for GroupByField "Collections". Built by SmartList from the
+        /// unfiltered media pool (episodes resolve membership through their parent series) and set
+        /// before <see cref="PreComputePositions"/>. Items absent from the map fall back to
+        /// series-name/own-name grouping in <see cref="ExtractGroupKey"/>.
+        /// </summary>
+        public Dictionary<Guid, string>? CollectionGroupKeys { get; set; }
+
+        /// <summary>
+        /// When true, items within each group are ordered by air date (premiere date, day precision)
+        /// instead of natural season/episode order. Set from SortOption.WithinGroupOrder.
+        /// Ignored when <see cref="ShuffleWithinGroups"/> is true.
+        /// </summary>
+        public bool OrderWithinGroupsByAirDate { get; set; }
+```
+
+(b) `PreComputePositions` (~51-54) passes the new state:
+
+```csharp
+        public void PreComputePositions(IEnumerable<BaseItem> items, ILogger? logger = null)
+        {
+            ItemPositions = BuildInterleavedPositions(items, GroupByField, OrderGroupKeys, Name, logger, ShuffleWithinGroups, CollectionGroupKeys, OrderWithinGroupsByAirDate);
+        }
+```
+
+(c) `BuildInterleavedPositions` (~93-99) gains two trailing optional parameters:
+
+```csharp
+        internal static ConcurrentDictionary<Guid, int> BuildInterleavedPositions(
+            IEnumerable<BaseItem> items,
+            string? groupByField,
+            Func<IEnumerable<string>, List<string>> orderGroupKeys,
+            string logPrefix,
+            ILogger? logger,
+            bool shuffleWithinGroups = false,
+            Dictionary<Guid, string>? collectionGroupKeys = null,
+            bool airDateWithinGroups = false)
+```
+
+Inside it, the grouping loop (~117) becomes `var key = ExtractGroupKey(item, groupByField, collectionGroupKeys);` and the within-group ordering block (~130-140) becomes:
+
+```csharp
+            foreach (var kvp in groups)
+            {
+                if (shuffleWithinGroups)
+                {
+                    Shuffle(kvp.Value, Random.Shared);
+                }
+                else if (airDateWithinGroups)
+                {
+                    kvp.Value.Sort((a, b) => CompareWithinGroupByAirDate(a, b));
+                }
+                else
+                {
+                    kvp.Value.Sort((a, b) => CompareWithinGroup(a, b));
+                }
+            }
+```
+
+(d) `ExtractGroupKey` (~168) gains the map parameter and a `"Collections"` case (insert before the `default:` case; fallback mirrors the `"SeriesName"` case):
+
+```csharp
+        internal static string ExtractGroupKey(BaseItem item, string? groupByField, Dictionary<Guid, string>? collectionGroupKeys = null)
+```
+
+```csharp
+                case "Collections":
+                    if (collectionGroupKeys != null && collectionGroupKeys.TryGetValue(item.Id, out var collectionName))
+                    {
+                        return collectionName;
+                    }
+
+                    // Not in any collection: fall back to per-show grouping
+                    if (item is Episode collectionEpisode)
+                    {
+                        return collectionEpisode.SeriesName ?? string.Empty;
+                    }
+
+                    return item.Name ?? string.Empty;
+```
+
+(e) New comparator, placed directly after `CompareWithinGroup` (~240) — same semantics as `ReleaseDateOrder` (day precision, episodes first on ties, then season/episode via the existing comparator):
+
+```csharp
+        /// <summary>
+        /// Compares two items within the same group by air date (premiere date, day precision).
+        /// Missing dates are DateTime.MinValue and sort first (Release Date sort convention).
+        /// Same-day ties put episodes before non-episodes, then fall back to natural order,
+        /// so multi-part crossovers airing the same day keep their episode order.
+        /// </summary>
+        internal static int CompareWithinGroupByAirDate(BaseItem a, BaseItem b)
+        {
+            var dateCompare = OrderUtilities.GetReleaseDate(a).Date.CompareTo(OrderUtilities.GetReleaseDate(b).Date);
+            if (dateCompare != 0)
+            {
+                return dateCompare;
+            }
+
+            var episodeCompare = OrderUtilities.IsEpisode(b).CompareTo(OrderUtilities.IsEpisode(a));
+            if (episodeCompare != 0)
+            {
+                return episodeCompare;
+            }
+
+            return CompareWithinGroup(a, b);
+        }
+```
+
+(f) `RoundRobinLeastRecentlyWatchedOrder.BuildGroupRecency` (~345-351) gains a trailing optional parameter `Dictionary<Guid, string>? collectionGroupKeys = null`, and its key line (~364) becomes `var key = ExtractGroupKey(item, groupByField, collectionGroupKeys);`.
+
+- [ ] **Step 3: InitializeFromDto assigns the flag**
+
+In `Core/SmartList.cs` `InitializeFromDto`, the existing branch (~126-129):
+
+```csharp
+                        if (order is RoundRobinBase rr)
+                        {
+                            rr.GroupByField = so.GroupByField;
+                            rr.OrderWithinGroupsByAirDate = string.Equals(so.WithinGroupOrder, "AirDate", StringComparison.OrdinalIgnoreCase);
+                        }
+```
+
+- [ ] **Step 4: Build both targets**
+
+```bash
+dotnet build Jellyfin.Plugin.SmartLists --framework net10.0 --configuration Release
+dotnet build Jellyfin.Plugin.SmartLists --framework net9.0 --configuration Release
+```
+
+Expected: both succeed, zero warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Jellyfin.Plugin.SmartLists/Core/Models/SortOption.cs Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+git commit -m "Add WithinGroupOrder and Collections group-key mechanics to round robin"
+```
+
+---
+
+### Task 2: SmartList — collection map builder + injection
+
+**Files:**
+
+- Modify: `Jellyfin.Plugin.SmartLists/Core/SmartList.cs` (injection block ~760-769; new private helper near `GetCollectionChildren` ~1619)
+
+**Interfaces:**
+
+- Consumes (from Task 1): `RoundRobinBase.CollectionGroupKeys`, `BuildGroupRecency(..., collectionGroupKeys)`. Also existing: `GetCollectionChildren(BaseItem, User, ILogger?)` (private static, SmartList.cs ~1619), `refreshCache.AllCollections` (`BaseItem[]?`), `refreshCache.CollectionDirectChildren` (`ConcurrentDictionary<Guid, BaseItem[]>`), `InternalItemsQuery`/`BaseItemKind` (already used at ~1499-1505 in `GetMatchingCollections` — copy that query shape exactly).
+- Produces: `BuildCollectionGroupKeyMap(IReadOnlyList<BaseItem> pool, User user, ILibraryManager libraryManager, RefreshQueueService.RefreshCache? refreshCache, ILogger? logger)` returning `Dictionary<Guid, string>`.
+
+- [ ] **Step 1: Add the map builder**
+
+Insert after `GetCollectionChildren` (~1651):
+
+```csharp
+        /// <summary>
+        /// Builds an item id → collection name map for Round Robin "Collections" grouping.
+        /// TV collections contain Series items, so episodes resolve membership through their
+        /// parent series; movies (and any direct members) resolve by their own id.
+        /// When an item belongs to multiple collections, the alphabetically-first collection
+        /// name wins (consistent with the Genres/Studios "first value" convention).
+        /// Direct members only — nested collections are not flattened.
+        /// </summary>
+        private static Dictionary<Guid, string> BuildCollectionGroupKeyMap(
+            IReadOnlyList<BaseItem> pool,
+            User user,
+            ILibraryManager libraryManager,
+            RefreshQueueService.RefreshCache? refreshCache,
+            ILogger? logger)
+        {
+            var map = new Dictionary<Guid, string>();
+
+            try
+            {
+                BaseItem[] allCollections;
+                if (refreshCache?.AllCollections != null)
+                {
+                    allCollections = refreshCache.AllCollections;
+                }
+                else
+                {
+                    var query = new InternalItemsQuery(user)
+                    {
+                        IncludeItemTypes = [BaseItemKind.BoxSet],
+                        Recursive = true,
+                    };
+                    allCollections = [.. libraryManager.GetItemsResult(query).Items];
+                    if (refreshCache != null)
+                    {
+                        refreshCache.AllCollections = allCollections;
+                    }
+                }
+
+                // memberId -> collection name; alphabetically-first collection wins
+                var memberToCollection = new Dictionary<Guid, string>();
+                foreach (var collection in allCollections.OrderBy(c => c.Name ?? string.Empty, OrderUtilities.SharedNaturalComparer))
+                {
+                    BaseItem[] children;
+                    if (refreshCache != null && refreshCache.CollectionDirectChildren.TryGetValue(collection.Id, out var cachedChildren))
+                    {
+                        children = cachedChildren;
+                    }
+                    else
+                    {
+                        children = GetCollectionChildren(collection, user, logger);
+                        refreshCache?.CollectionDirectChildren.TryAdd(collection.Id, children);
+                    }
+
+                    foreach (var child in children)
+                    {
+                        if (!memberToCollection.ContainsKey(child.Id))
+                        {
+                            memberToCollection[child.Id] = collection.Name ?? string.Empty;
+                        }
+                    }
+                }
+
+                foreach (var item in pool)
+                {
+                    if (memberToCollection.TryGetValue(item.Id, out var directName))
+                    {
+                        map[item.Id] = directName;
+                    }
+                    else if (item is Episode episode && episode.SeriesId != Guid.Empty &&
+                             memberToCollection.TryGetValue(episode.SeriesId, out var seriesCollectionName))
+                    {
+                        map[item.Id] = seriesCollectionName;
+                    }
+                }
+
+                logger?.LogDebug("Collection group map: {MappedCount} of {PoolCount} items belong to a collection ({CollectionCount} collections checked)",
+                    map.Count, pool.Count, allCollections.Length);
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex, "Error building collection group map - items will fall back to series/name grouping");
+            }
+
+            return map;
+        }
+```
+
+Adaptation notes for the implementer: if `refreshCache.AllCollections`/`CollectionDirectChildren` member names or types differ, check `RefreshQueueService.cs` ~725-772 (`AllCollections` is `BaseItem[]?` at ~732, `CollectionDirectChildren` is `ConcurrentDictionary<Guid, BaseItem[]>` at ~762) and adapt; if `GetItemsResult(query).Items` needs a different materialization, copy the exact shape used by `GetMatchingCollections` (~1499-1505). `Episode` (`MediaBrowser.Controller.Entities.TV`) is already imported by SmartList.cs.
+
+- [ ] **Step 2: Extend the injection block**
+
+Replace the existing block at ~760-769 (currently the LRW-only injection starting with the comment `// Least Recently Watched Round Robin needs per-group watch recency...`) with:
+
+```csharp
+                // Round Robin sorts may need maps computed from the UNFILTERED pool before filtering
+                // (same injection pattern as SimilarityOrder.Scores / RuleBlockOrder.GroupMappings):
+                // - "Collections" grouping: item id -> collection name (episodes resolve via their series).
+                // - Least Recently Watched: per-group watch recency. Rules like "Playback Status is
+                //   Unwatched" remove watched items from the results, so recency derived from filtered
+                //   items would see every group as unwatched.
+                Dictionary<Guid, string>? collectionGroupKeys = null;
+                if (Orders.OfType<RoundRobinBase>().Any(o => o.GroupByField == "Collections"))
+                {
+                    collectionGroupKeys = BuildCollectionGroupKeyMap(itemsArray, user, libraryManager, refreshCache, logger);
+                    foreach (var rrOrder in Orders.OfType<RoundRobinBase>())
+                    {
+                        if (rrOrder.GroupByField == "Collections")
+                        {
+                            rrOrder.CollectionGroupKeys = collectionGroupKeys;
+                        }
+                    }
+                }
+
+                foreach (var lrwOrder in Orders.OfType<RoundRobinLeastRecentlyWatchedOrder>())
+                {
+                    lrwOrder.GroupRecency = RoundRobinLeastRecentlyWatchedOrder.BuildGroupRecency(
+                        itemsArray, lrwOrder.GroupByField, user, userDataManager, refreshCache, logger,
+                        lrwOrder.GroupByField == "Collections" ? collectionGroupKeys : null);
+                }
+```
+
+(`itemsArray` and `libraryManager` are already in scope — `itemsArray` is materialized at ~748, `libraryManager` is a method parameter.)
+
+- [ ] **Step 3: Build both targets**
+
+```bash
+dotnet build Jellyfin.Plugin.SmartLists --framework net10.0 --configuration Release
+dotnet build Jellyfin.Plugin.SmartLists --framework net9.0 --configuration Release
+```
+
+Expected: both succeed, zero warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+git commit -m "Build and inject collection group-key map for Round Robin Collections grouping"
+```
+
+---
+
+### Task 3: UI — Group By entry + Order Within Group dropdown
+
+**Files:**
+
+- Modify: `Jellyfin.Plugin.SmartLists/Configuration/config-core.js` (~113-119)
+- Modify: `Jellyfin.Plugin.SmartLists/Configuration/config-sorts.js` (syncSortOrderUI ~126-145; createSortBox ~329-367; collectSortsFromForm ~485-496; updateAllSortOptionsVisibility ~540-555)
+
+**Interfaces:**
+
+- Consumes: Task 1's DTO contract — save `WithinGroupOrder: 'AirDate'` (omit for Natural), Group By value `'Collections'`.
+- Produces: nothing downstream.
+
+- [ ] **Step 1: config-core.js — Group By entry**
+
+In `SmartLists.ROUND_ROBIN_GROUP_FIELDS` (~113-119), add after the `SeriesName` entry:
+
+```javascript
+        { value: 'Collections', label: 'Collection', mediaTypes: ['Episode', 'Movie'] },
+```
+
+- [ ] **Step 2: config-sorts.js — syncSortOrderUI gains the new container**
+
+Replace the function (~126-145) with (new 5th parameter + visibility rule):
+
+```javascript
+    // Helper function to sync Sort Order UI based on Sort By value
+    SmartLists.syncSortOrderUI = function(sortByValue, sortOrderContainer, sortOrderSelect, groupByContainer, withinGroupContainer) {
+        if (!sortOrderContainer || !sortOrderSelect) return;
+        
+        // Hide Sort Order for Random, Random Round Robin, and Default (they don't use ordering)
+        if (SmartLists.isOrderlessSort(sortByValue)) {
+            sortOrderContainer.style.display = 'none';
+        } else {
+            sortOrderContainer.style.display = '';
+            
+            // Auto-set to Descending when Similarity is selected (most similar first)
+            if (sortByValue === 'Similarity') {
+                sortOrderSelect.value = 'Descending';
+            }
+        }
+
+        // Show/hide GroupBy dropdown for Round Robin and Random Round Robin
+        if (groupByContainer) {
+            groupByContainer.style.display = SmartLists.isRoundRobinSort(sortByValue) ? '' : 'none';
+        }
+
+        // Show/hide Order Within Group for round robin sorts (not Shuffled - shuffle wins)
+        if (withinGroupContainer) {
+            var showWithinGroup = SmartLists.isRoundRobinSort(sortByValue) && sortByValue !== 'Shuffled Round Robin';
+            withinGroupContainer.style.display = showWithinGroup ? '' : 'none';
+        }
+    };
+```
+
+- [ ] **Step 3: config-sorts.js — createSortBox: new field + wired calls**
+
+(a) After the Group By field block (ends `fieldsContainer.appendChild(groupByField.container);` ~340), add:
+
+```javascript
+        // Order Within Group field (round robin sorts except Shuffled)
+        const withinGroupField = SmartLists.createSortField('Order Within Group', 'sort-withingroup-' + sortId, 'select');
+        withinGroupField.container.style.minWidth = '200px';
+        withinGroupField.container.style.maxWidth = '200px';
+        var savedWithinGroup = (sortData && sortData.WithinGroupOrder) ? sortData.WithinGroupOrder : 'Natural';
+        SmartLists.populateSelectElement(withinGroupField.input, [
+            { value: 'Natural', label: 'Season/Episode (default)', selected: savedWithinGroup !== 'AirDate' },
+            { value: 'AirDate', label: 'Air Date', selected: savedWithinGroup === 'AirDate' }
+        ]);
+        withinGroupField.container.style.display = (SmartLists.isRoundRobinSort(actualSortBy) && actualSortBy !== 'Shuffled Round Robin') ? '' : 'none';
+        fieldsContainer.appendChild(withinGroupField.container);
+```
+
+(b) The change listener (~356) and the init call (~367) pass the new container:
+
+```javascript
+            SmartLists.syncSortOrderUI(this.value, sortOrderField.container, sortOrderField.input, groupByField.container, withinGroupField.container);
+```
+
+```javascript
+        SmartLists.syncSortOrderUI(actualSortBy, sortOrderField.container, sortOrderField.input, groupByField.container, withinGroupField.container);
+```
+
+- [ ] **Step 4: config-sorts.js — save path**
+
+In `collectSortsFromForm`, inside the existing `if (SmartLists.isRoundRobinSort(sortBy))` block (~491-496), after the GroupByField lines add:
+
+```javascript
+                var withinGroupSelect = box.querySelector('[id^="sort-withingroup-"]');
+                if (withinGroupSelect && withinGroupSelect.value === 'AirDate' && sortBy !== 'Shuffled Round Robin') {
+                    sortEntry.WithinGroupOrder = 'AirDate';
+                }
+```
+
+(Natural is deliberately omitted from the JSON — old configs stay byte-identical.)
+
+- [ ] **Step 5: config-sorts.js — updateAllSortOptionsVisibility**
+
+At ~540-542, the sync call gains the new container (resolve it the same way as groupByContainer):
+
+```javascript
+            var groupByContainer = box.querySelector('[id^="sort-groupby-"]');
+            groupByContainer = groupByContainer ? groupByContainer.closest('.sort-field-container') : null;
+            var withinGroupContainer = box.querySelector('[id^="sort-withingroup-"]');
+            withinGroupContainer = withinGroupContainer ? withinGroupContainer.closest('.sort-field-container') : null;
+            SmartLists.syncSortOrderUI(effectiveSortValue, sortOrderContainer, sortOrderSelect, groupByContainer, withinGroupContainer);
+```
+
+Note: verify the container-resolution idiom matches what the file actually uses at ~540 (`closest('.sort-field-container')`) — if `createSortField` uses a different wrapper class, mirror whatever the Group By resolution uses.
+
+(No repopulation-on-media-type-change needed for the new select — its options are static. The Group By select's existing repopulation at ~544-555 automatically picks up the Collections entry via `getFilteredRoundRobinFields`.)
+
+- [ ] **Step 6: Syntax check**
+
+```bash
+node --check Jellyfin.Plugin.SmartLists/Configuration/config-core.js
+node --check Jellyfin.Plugin.SmartLists/Configuration/config-sorts.js
+```
+
+Expected: no output.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Jellyfin.Plugin.SmartLists/Configuration/config-core.js Jellyfin.Plugin.SmartLists/Configuration/config-sorts.js
+git commit -m "Add Collection group-by option and Order Within Group dropdown to sort UI"
+```
+
+---
+
+### Task 4: Docs
+
+**Files:**
+
+- Modify: `docs/content/user-guide/sorting-and-limits.md` (Group By table ~126-134; Round Robin section; variant notes)
+- Modify: `docs/content/examples/common-use-cases.md` (round-robin recipes ~76-135)
+
+**Interfaces:** none — prose. Match the existing docs style exactly (read the sections first; the Group By table lives in the "Round Robin (Interleave)" section and other variants cross-reference it).
+
+- [ ] **Step 1: sorting-and-limits.md**
+
+Content to convey (adapt to existing format):
+
+1. Add a row to the "Available Group By fields" table: `Collection` | `Episode or Movie media type`.
+2. Below the table, extend the multi-value note: episodes belong to a collection through their **series** (TV collections contain series); an item in several collections groups under the alphabetically-first one; items in no collection group by Series Name (episodes) or their own name; direct collection members only (nested collections are not flattened). Collections are Jellyfin's regular collections — manual, auto-created movie collections, or SmartLists smart collections all work.
+3. New subsection **"Order Within Group"** in the Round Robin section: applies to all round-robin variants except Shuffled; `Season/Episode (default)` = current behavior; `Air Date` = premiere date (day precision, same-day ties keep episode order; missing dates first). Highlight the franchise use: Group By Collection + Air Date plays crossovers in airing order, and a spinoff only enters the rotation once the timeline reaches its premiere.
+4. One line in the Least Recently Watched section: with Group By Collection, the whole franchise carries one recency — watching any member sends the collection group to the back.
+
+- [ ] **Step 2: common-use-cases.md — new recipe**
+
+Add after the "Continue-Where-You-Left-Off TV Channel" recipe, matching the established recipe format:
+
+```markdown
+### Franchise TV Channel (crossovers in air-date order)
+
+Have franchise collections like NCIS or One Chicago where crossover episodes span several shows? Group the rotation by collection and play each franchise in airing order:
+
+- **Media Type:** Episode
+- **Rules:** Playback Status = Unplayed
+- **Sort By:** Least Recently Watched Round Robin, **Group By:** Collection, **Order Within Group:** Air Date
+- **Auto Refresh:** On All Changes
+
+Each collection becomes one slot in the rotation and plays chronologically across its shows — crossovers stay in order, and a spinoff only starts appearing once the timeline reaches its premiere. Shows not in any collection rotate as themselves. Watch anything in a franchise and the whole franchise moves to the back of the rotation.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/content/
+git commit -m "Document Collection group-by and Order Within Group"
+```
+
+---
+
+### Task 5: End-to-end verification against local Jellyfin
+
+**Files:** none — verification only, per spec "Verification". Driver (main session) runs this; steps recorded here for completeness.
+
+- [ ] **Step 1:** Build worktree plugin into the container-mounted output and restart: `dotnet build Jellyfin.Plugin.SmartLists/Jellyfin.Plugin.SmartLists.csproj --framework net10.0 --configuration Release -o /Users/johan.yourstone/Git/jellyfin-smartplaylist-plugin/build_output /p:Version=12.0.0.0 /p:AssemblyVersion=12.0.0.0 && docker restart jellyfin`.
+- [ ] **Step 2:** Create a Jellyfin collection containing two series with interleaved episode air dates (via API: create BoxSet, add Show Alpha + Show Beta series; adjust PremiereDates via metadata if needed).
+- [ ] **Step 3:** Episode playlist, Round Robin Ascending + Group By Collection + Order Within Group Air Date: collection shows occupy ONE slot, episodes across both shows in air-date order; non-collection shows rotate individually.
+- [ ] **Step 4:** Switch Order Within Group to default: same single group, internal order by season/episode across both shows.
+- [ ] **Step 5:** Least Recently Watched Round Robin + Group By Collection: mark a collection episode played → whole collection group moves to the back on refresh.
+- [ ] **Step 6:** Movie playlist + Group By Collection with a movie collection → one group, Air Date = release order.
+- [ ] **Step 7:** Regression: existing round-robin playlists (all variants, all existing Group By values, no WithinGroupOrder in JSON) refresh identically; UI hides Order Within Group for Shuffled and non-round-robin sorts; Collection option hidden for Audio-only playlists; values round-trip through save/edit.
+- [ ] **Step 8:** Logs clean: `docker logs jellyfin 2>&1 | grep -iE "\[ERR\]|\[WRN\]" | grep -i smart` → no new errors/warnings. Delete test playlists/collection.
+
+---
+
+## Self-review notes
+
+- Spec coverage: DTO (T1), order mechanics + comparator + LRW map param (T1), map builder + injection (T2), UI (T3), docs (T4), verification incl. movie + regression (T5). Alphabetical-first: `OrderBy(SharedNaturalComparer)` + first-assignment-wins in T2. Direct-members-only: `GetCollectionChildren`, no recursion. Shuffled exclusion: UI hides (T3) + shuffle branch precedes airDate branch (T1).
+- Type consistency: `CollectionGroupKeys`/`OrderWithinGroupsByAirDate`/`WithinGroupOrder`/`BuildCollectionGroupKeyMap` names match across tasks; `ExtractGroupKey`/`BuildGroupRecency` optional-param signatures consistent between T1 and T2 call sites.
+- `Episode.SeriesId` is a non-nullable `Guid` on Jellyfin's Episode entity; the `!= Guid.Empty` guard covers orphaned episodes.

--- a/docs/superpowers/specs/2026-07-12-collection-group-by-round-robin-design.md
+++ b/docs/superpowers/specs/2026-07-12-collection-group-by-round-robin-design.md
@@ -1,0 +1,130 @@
+# Design: Collection Group By + Within-Group Order for Round Robin
+
+**Date:** 2026-07-12
+**Status:** Approved (design discussion 2026-07-12)
+**Origin:** Follow-up request on Least Recently Watched Round Robin — "If a show/s is part of a collection, can you view those shows as 1 group for that collection, not as the individual shows, and sort by airdate within that group rather than by episode number? This would keep shows' timelines and crossovers in order." (NCIS/CSI/One Chicago-style franchise collections with crossover episodes.)
+
+## Behavior
+
+Two additions to the round-robin sort family:
+
+### 1. Group By: Collection
+
+A new Group By option, **Collection** (field value `"Collections"`), for **Episode and Movie** playlists. Each Jellyfin collection (BoxSet — manual, TMDB-auto-created, or a SmartLists smart collection; they are the same item type) becomes ONE rotation group:
+
+- **Episodes** resolve membership through their parent series: TV collections contain Series items, so an episode belongs to the collection that contains its series (`episode.SeriesId` in the collection's member set).
+- **Movies** resolve membership directly (`movie.Id` in the member set).
+- **Items in no collection** fall back to today's grouping: episodes group by Series Name, everything else by its own name. Standalone shows rotate as themselves alongside franchise groups — mixed lists work naturally.
+- **Multiple collections**: the alphabetically-first collection name wins (deterministic; consistent with the existing "first value" convention for Genres/Studios).
+- **Nested collections**: direct members only (matches the Collections rule's default search depth). Deepening is a later knob if requested.
+
+Works with all four round-robin variants. With **Least Recently Watched Round Robin** the whole franchise carries one recency — watch any NCIS episode and the entire NCIS-verse group moves to the back of the rotation.
+
+### 2. Order Within Group
+
+A new per-sort dropdown, **Order Within Group**, for round-robin sorts (hidden for Shuffled Round Robin, which shuffles within groups):
+
+| Value | Meaning |
+| --- | --- |
+| `Natural` (default) | Current behavior: season/episode for episodes, disc/track for audio, name otherwise. Absent/null in old configs → byte-identical behavior. |
+| `AirDate` | `PremiereDate` truncated to day, tie-broken episodes-first → season → episode (same semantics as the existing Release Date sort). Missing dates sort first. |
+
+`AirDate` within a Collection group plays a franchise in airing order — crossover events spanning multiple shows interleave correctly, and a spinoff's episodes only start appearing once the timeline reaches its premiere (this satisfies the requester's "air-date proximity" idea with no extra logic). Available for every Group By value, not just Collection (e.g. Series Name + AirDate puts specials into the timeline).
+
+## Data model
+
+`Core/Models/SortOption.cs` gains one property (same pattern as `GroupByField`):
+
+```csharp
+/// <summary>
+/// How items are ordered inside each Round Robin group.
+/// "Natural" (default): season/episode, disc/track, or name.
+/// "AirDate": premiere date (day precision), tie-broken by season/episode.
+/// </summary>
+[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+public string? WithinGroupOrder { get; set; }
+```
+
+No validation added — consistent with `SortBy`/`GroupByField`, which are unvalidated and degrade gracefully (unknown values behave as `Natural`).
+
+## Backend
+
+### Order classes (`Core/Orders/RoundRobinOrder.cs`)
+
+- `RoundRobinBase` gains two injected/assigned members:
+  - `public Dictionary<Guid, string>? CollectionGroupKeys { get; set; }` — itemId → collection name, set by SmartList (same injection pattern as `RoundRobinLeastRecentlyWatchedOrder.GroupRecency`). Only populated when `GroupByField == "Collections"`.
+  - `public bool OrderWithinGroupsByAirDate { get; set; }` — set from the DTO in `InitializeFromDto`.
+- `ExtractGroupKey` (currently `ExtractGroupKey(BaseItem, string?)`, RoundRobinOrder.cs ~168) gains a `Dictionary<Guid, string>? collectionGroupKeys` parameter and a `"Collections"` case: map hit → collection name; miss → existing SeriesName fallback logic (episode → `SeriesName`, else `Name`).
+- `BuildInterleavedPositions` (~93) gains the map parameter and an `airDateWithinGroups` flag alongside the existing `shuffleWithinGroups`; group-internal sort picks `CompareWithinGroupByAirDate` when the flag is set (and shuffle still wins for the Shuffled variant).
+- New `internal static int CompareWithinGroupByAirDate(BaseItem a, BaseItem b)`: compare `OrderUtilities.GetReleaseDate(x).Date`, then episodes-before-non-episodes, then `GetSeasonNumber`, then `GetEpisodeNumber` — mirroring `ReleaseDateOrder` so same-day crossover parts keep airing order. Missing dates are `DateTime.MinValue` (sort first), same sentinel as Release Date sort.
+- `PreComputePositions` passes the instance state (`CollectionGroupKeys`, `OrderWithinGroupsByAirDate`) into `BuildInterleavedPositions`.
+- `RoundRobinLeastRecentlyWatchedOrder.BuildGroupRecency` gains the same map parameter so recency keys agree with grouping keys (franchise = one recency).
+
+### SmartList (`Core/SmartList.cs`)
+
+1. **Map construction.** New private static helper `BuildCollectionGroupKeyMap(IReadOnlyList<BaseItem> pool, User user, ILibraryManager libraryManager, RefreshQueueService.RefreshCache? refreshCache, ILogger? logger)`:
+   - Enumerate user-visible BoxSets (`InternalItemsQuery(user) { IncludeItemTypes = [BaseItemKind.BoxSet], Recursive = true }`), reusing `refreshCache.AllCollections` when populated (same cache the Collections rule extraction fills).
+   - For each BoxSet, get direct members via the existing child-enumeration mechanism (`GetCollectionChildren` already in SmartList.cs ~1619; reuse rather than duplicate a fourth copy of the reflection pattern), reusing `refreshCache.CollectionDirectChildren` when present.
+   - Build member-id → collection-name with **alphabetically-first-wins** (process collections in name order via the natural comparer; first assignment wins).
+   - Map pool items: movie/other → own Id lookup; episode → `SeriesId` lookup. Only items that resolve to a collection enter the map (misses fall back inside `ExtractGroupKey`).
+2. **Injection block** (extend the existing GroupRecency injection at ~760-769, which already runs on the unfiltered pool before filtering):
+   - If any order is `RoundRobinBase` with `GroupByField == "Collections"`: build the map once, assign to those orders' `CollectionGroupKeys`.
+   - Build the map **before** the LRW recency loop and pass it to `BuildGroupRecency` so recency is keyed by collection where applicable.
+3. **`InitializeFromDto`** (~126-129, the existing `is RoundRobinBase rr` branch): additionally `rr.OrderWithinGroupsByAirDate = string.Equals(so.WithinGroupOrder, "AirDate", StringComparison.OrdinalIgnoreCase);`.
+4. No changes to `PrepareRoundRobinPositions` or its three call sites — the map and flag are instance state, set once per `FilterPlaylistItems` run before any call site executes.
+
+### Per-user and caching notes
+
+- The map is built per `FilterPlaylistItems` run (per user for AllUsers playlists), user-scoped through `InternalItemsQuery(user)`/`GetChildren(user, true)` — same owner-visibility semantics as the Collections rule field.
+- `refreshCache.CollectionDirectChildren` is not user-keyed (pre-existing single-owner assumption shared with the rule engine); this feature reuses it as-is and inherits that behavior.
+- Collection membership changes (adding a series to a BoxSet) trigger refreshes through existing library-change handling; no AutoRefreshService changes.
+
+## UI (`Configuration/config-core.js`, `config-sorts.js`)
+
+- `ROUND_ROBIN_GROUP_FIELDS` (config-core.js ~113-119): add `{ value: 'Collections', label: 'Collection', mediaTypes: ['Episode', 'Movie'] }` — `getFilteredRoundRobinFields` handles media-type visibility automatically.
+- New **Order Within Group** select in the sort box (config-sorts.js `createSortBox`, next to the Group By select): options `Natural` ("Season/Episode (default)") and `AirDate` ("Air Date"); visible when `isRoundRobinSort(sortBy) && sortBy !== 'Shuffled Round Robin'`; plain `populateSelectElement` like Group By (not searchable).
+- Save path (`collectSortsFromForm` ~463-502): when round-robin and value is `AirDate`, set `sortEntry.WithinGroupOrder = 'AirDate'` (omit for Natural — keeps JSON clean and old-config-compatible). Load path: `sortData.WithinGroupOrder` → select value, mirroring `GroupByField` handling.
+- Visibility sync in `syncSortOrderUI` (~126-145) alongside the Group By container toggle; re-filter on media-type change is not needed (options are static).
+- Both HTML pages: no changes (sort boxes are fully JS-built in `#sorts-container`).
+- `formatSortDisplay` shows neither `GroupByField` nor `WithinGroupOrder` today — unchanged (pre-existing display gap, out of scope).
+
+## Docs
+
+- `sorting-and-limits.md`: add `Collection` row to the "Available Group By fields" table (~126-134) — "Episode or Movie media type"; document multi-collection alphabetical-first and the series-based membership for episodes; add an "Order Within Group" subsection to the Round Robin section (applies to all variants except Shuffled); note the LRW composition (franchise recency).
+- `common-use-cases.md`: new recipe **"Franchise TV Channel (crossovers in air-date order)"** — Group By Collection + Order Within Group Air Date + Playback Status = Unplayed + Least Recently Watched Round Robin + Auto Refresh On All Changes; mention the requester's NCIS/One Chicago scenario shape.
+
+## Edge cases
+
+- **Item in no collection** → falls back to Series Name / own name grouping (single-show groups rotate as themselves).
+- **Missing PremiereDate with AirDate order** → sorts first within the group (Release Date sort convention).
+- **Empty collections / collections with no pool items** → produce no groups (map only covers pool items).
+- **Group By Collection on unsupported media types** (saved via API): map resolves by item Id; non-members fall back by name — graceful, undocumented.
+- **`WithinGroupOrder` on Shuffled Round Robin** (via API): shuffle wins (flag ignored), matching the UI hiding the knob.
+- **Collections rule + Collection grouping together**: independent — rules filter, grouping groups; no interaction.
+
+## Out of scope
+
+- Air-date **proximity gating** between shows (requester's second idea) — satisfied structurally by AirDate ordering within a collection group; no separate mechanism.
+- Nested-collection depth knob for grouping (direct members only).
+- Showing GroupByField/WithinGroupOrder in the list-properties sort display (pre-existing gap for GroupByField).
+- Validation of the new DTO value (consistent with existing sort fields).
+
+## Touched files
+
+| Area | Files |
+| --- | --- |
+| Backend | `Core/Orders/RoundRobinOrder.cs`, `Core/SmartList.cs`, `Core/Models/SortOption.cs` |
+| UI | `Configuration/config-core.js`, `Configuration/config-sorts.js` |
+| Docs | `docs/content/user-guide/sorting-and-limits.md`, `docs/content/examples/common-use-cases.md` |
+
+## Verification
+
+No test suite; against local Jellyfin (build both targets, warnings are errors):
+
+1. In the dev library, create a Jellyfin collection containing two series whose episode air dates interleave (e.g. Show Alpha + Show Beta; set PremiereDates via metadata edit if needed).
+2. Playlist: Episode media type, Round Robin Ascending, Group By = Collection, Order Within Group = Air Date. Expect: the two collection shows occupy ONE rotation slot with episodes in air-date order across both shows; non-collection shows rotate as individual groups alphabetically.
+3. Switch Order Within Group back to default (Natural): the collection still forms ONE group, but episodes inside it sort by season/episode number across both shows (Alpha S1E1 and Beta S1E1 adjacent) — verify grouping is unchanged and only the internal order differs.
+4. Switch sort to Least Recently Watched Round Robin: watch/mark an episode of Show Alpha → whole collection group moves to the back on refresh; standalone shows unaffected.
+5. Movie playlist: Group By = Collection with a TMDB-style movie collection → franchise movies form one group, Air Date = release order.
+6. Regression: existing round-robin playlists (all four variants, Series Name/Album/Artist/Genres/Studios groupings) refresh byte-identical; playlist without WithinGroupOrder in JSON behaves exactly as before.
+7. UI: Group By shows "Collection" only for Episode/Movie media types; Order Within Group hidden for Shuffled Round Robin and non-round-robin sorts; values round-trip through save/edit.


### PR DESCRIPTION
## What
Round-robin sorts can now group by **Jellyfin collection** (a whole franchise becomes one rotation slot) and order items **within each group by air date** instead of season/episode — so franchise timelines and crossover episodes play in airing order.

## Why
Follow-up to the Least Recently Watched Round Robin feature request: users with franchise collections (NCIS-verse, One Chicago, CSI) want the shows in a collection treated as a single rotation group, played chronologically so crossovers stay in order and a spinoff only enters the rotation once its premiere date is reached. Grouping by collection + air-date ordering satisfies both asks structurally — no separate "air-date proximity" logic needed.

## Changes
- **`SortOption.WithinGroupOrder`** (new nullable DTO field): `"Natural"` (default, absent in JSON — old configs byte-identical) or `"AirDate"`.
- **`RoundRobinBase`** (`Core/Orders/RoundRobinOrder.cs`): new `CollectionGroupKeys` map + `OrderWithinGroupsByAirDate` flag threaded through `PreComputePositions`/`BuildInterleavedPositions`; `ExtractGroupKey` gains a `"Collections"` case (map hit → collection name; miss → series-name/own-name fallback); new `CompareWithinGroupByAirDate` comparator (premiere date, day precision, same-day ties keep episode order — mirrors Release Date sort). Shuffled Round Robin's shuffle takes precedence over air-date ordering.
- **`SmartList.cs`**: new `BuildCollectionGroupKeyMap` — enumerates user-visible BoxSets (reusing the per-refresh `AllCollections`/`CollectionDirectChildren` caches), resolves episodes via their parent series and movies directly, alphabetically-first collection wins for multi-membership, direct members only. Injected into round-robin orders from the unfiltered pool (same pattern as the LRW recency map) and passed into `BuildGroupRecency` so a franchise carries one watch-recency with Least Recently Watched.
- **UI** (`config-core.js`, `config-sorts.js`): `Collection` entry in the Group By dropdown (Episode/Movie media types); new "Order Within Group" select (Season/Episode default / Air Date), hidden for Shuffled Round Robin and non-round-robin sorts; save path omits the default value.
- **Docs**: Group By table row + "Grouping by Collection" note + "Order Within Group" subsection in `sorting-and-limits.md`; new "Franchise TV Channel (crossovers in air-date order)" recipe in `common-use-cases.md`.

## Verification
Live-tested against local Jellyfin 12 (both `net10.0`/`net9.0` build clean, warnings-as-errors):
- Two-series collection formed ONE rotation slot with exact air-date interleave across shows (A1→B1→A2→B2→A3→B3), other shows rotating individually alphabetically
- Direct-episode membership and series-in-smart-collection both resolve; alphabetical-first picked the right collection for an item in three collections
- Natural mode: same grouping, season/episode internal order
- Least Recently Watched + Collection grouping: watching one episode moved the whole franchise group to the back
- Movie collection: one group, release order (2009 before 2025)
- Regression: existing playlists refresh identically; configs without `WithinGroupOrder` unchanged; no plugin errors/warnings in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBFLcyWKuktDSu9acy68zg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Round Robin lists can now group episodes and movies by **Collection**.
  - Added **Order Within Group** for eligible Round Robin modes (Natural or **Air Date**).
  - Collection grouping also applies to **Least Recently Watched** behavior for whole franchise/collection groups.
  - Titles without collection membership continue using existing fallback grouping.

- **Documentation**
  - Updated Round Robin “Sorting and Limits” docs for **Collection** grouping and **Order Within Group**.
  - Added a new franchise crossover example covering Collection-based air-date ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->