### PR TITLE
Fix duplicate smart lists via provider-ID tether, recovery and orphan cleanup

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -7,6 +7,14 @@ description: Drive the SmartLists plugin against the local dev Jellyfin containe
 
 ## Build + deploy (from repo root; works from worktrees too)
 
+Before deploying, compile-check BOTH target frameworks (the container only runs net10.0, but the project must also build for net9.0 / Jellyfin 10.11):
+
+```bash
+dotnet build Jellyfin.Plugin.SmartLists/Jellyfin.Plugin.SmartLists.csproj -c Release --no-incremental
+```
+
+Then build + deploy the container framework:
+
 ```bash
 # ALWAYS --no-incremental: incremental deploy builds have served stale DLLs
 dotnet build Jellyfin.Plugin.SmartLists/Jellyfin.Plugin.SmartLists.csproj \
@@ -21,12 +29,13 @@ After a code change, confirm the deployed DLL actually contains it — .NET stri
 
 ```js
 const buf = require('fs').readFileSync('.../build_output/Jellyfin.Plugin.SmartLists.dll');
-buf.toString('utf16le').includes('some new log message')  // check odd offset too: buf.slice(1)
+buf.toString('utf16le').includes('some new log message')
+  || buf.slice(1).toString('utf16le').includes('some new log message')  // odd byte offset
 ```
 
 ## Drive the API
 
-- Wait ready: `until curl -s -o /dev/null -w "%{http_code}" http://localhost:8096/health | grep -q 200; do sleep 2; done`
+- Wait ready (bounded): `timeout 120 bash -c 'until curl -s -o /dev/null -w "%{http_code}" http://localhost:8096/health | grep -q 200; do sleep 2; done'` — on timeout, check `docker logs jellyfin` for startup errors
 - API key: `sqlite3 "file:<MAIN>/dev/jellyfin-data/config/data/jellyfin.db?mode=ro" "SELECT AccessToken FROM ApiKeys"` (dev-only key)
 - Auth header (query-param api_key returns 401): `Authorization: MediaBrowser Token="<key>"`
 - Endpoints: `GET /Plugins/SmartLists` (list), `POST /Plugins/SmartLists/{id}/refresh|enable|disable`

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: verify
+description: Drive the SmartLists plugin against the local dev Jellyfin container to verify a change end-to-end. Use after building any plugin change that has runtime behavior.
+---
+
+# Verifying SmartLists changes against the dev container
+
+## Build + deploy (from repo root; works from worktrees too)
+
+```bash
+# ALWAYS --no-incremental: incremental deploy builds have served stale DLLs
+dotnet build Jellyfin.Plugin.SmartLists/Jellyfin.Plugin.SmartLists.csproj \
+  --framework net10.0 --configuration Release --no-incremental \
+  -o <MAIN_CHECKOUT>/build_output /p:Version=12.0.0.0 /p:AssemblyVersion=12.0.0.0
+docker restart jellyfin
+```
+
+`<MAIN_CHECKOUT>/build_output` is bind-mounted to `/config/plugins/SmartLists` (see dev/docker-compose.yml). Alternatively `cd dev && ./build-local.sh` does the full cycle from the main checkout.
+
+After a code change, confirm the deployed DLL actually contains it — .NET string literals are UTF-16, ASCII `strings` misses them:
+
+```js
+const buf = require('fs').readFileSync('.../build_output/Jellyfin.Plugin.SmartLists.dll');
+buf.toString('utf16le').includes('some new log message')  // check odd offset too: buf.slice(1)
+```
+
+## Drive the API
+
+- Wait ready: `until curl -s -o /dev/null -w "%{http_code}" http://localhost:8096/health | grep -q 200; do sleep 2; done`
+- API key: `sqlite3 "file:<MAIN>/dev/jellyfin-data/config/data/jellyfin.db?mode=ro" "SELECT AccessToken FROM ApiKeys"` (dev-only key)
+- Auth header (query-param api_key returns 401): `Authorization: MediaBrowser Token="<key>"`
+- Endpoints: `GET /Plugins/SmartLists` (list), `POST /Plugins/SmartLists/{id}/refresh|enable|disable`
+- Refresh is queued; wait for `docker logs jellyfin | grep "Completed Refresh operation for list <id>"`
+
+## Observable state
+
+- Plugin DTOs: `<MAIN>/dev/jellyfin-data/config/data/smartlists/{listId}/config.json` (edit only while container stopped — plugin caches DTOs and writes back)
+- Jellyfin playlists on disk: `<MAIN>/dev/jellyfin-data/config/data/playlists/<Name> [Smart]*/playlist.xml`
+- DB (read-only!): `sqlite3 "file:<MAIN>/dev/jellyfin-data/config/data/jellyfin.db?mode=ro"` — tables `BaseItems`, `BaseItemProviders` (provider-ID tether rows: `ProviderId='SmartLists'`)
+- Logs: `docker logs jellyfin 2>&1 | grep -i smart` (debug logging enabled via dev/logging.json)
+
+## Gotchas
+
+- Item IDs are deterministic (type+path hash): deleting and recreating a playlist at the same folder path yields the same item GUID.
+- Simulating a stale `JellyfinPlaylistId`: stop container, edit config.json mapping to a bogus GUID, start, trigger refresh.
+- Jellyfin core appends `1` to the playlist folder name per collision (`GetTargetPath`) — folder names with trailing 1s are normal on multi-user lists.

--- a/Jellyfin.Plugin.SmartLists/Api/Controllers/SmartListController.cs
+++ b/Jellyfin.Plugin.SmartLists/Api/Controllers/SmartListController.cs
@@ -1576,16 +1576,27 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                             logger.LogWarning(ex, "Failed to delete Jellyfin playlists when disabling playlist '{PlaylistName}', continuing", existingPlaylist.Name);
                         }
                         
-                        // Always clear the Jellyfin playlist IDs regardless of deletion success
-                        // This ensures consistency: disabled playlists should not have Jellyfin IDs
-                        playlist.JellyfinPlaylistId = null;
+                        // DeleteAllJellyfinPlaylistsForUsersAsync cleared the IDs of successfully
+                        // deleted playlists on existingPlaylist; failed deletions keep their ID so
+                        // the playlist can be deleted later. Sync the post-delete IDs onto the
+                        // incoming DTO without touching its user membership.
                         if (playlist.UserPlaylists != null)
                         {
-                            foreach (var userMapping in playlist.UserPlaylists)
+                            foreach (var newMapping in playlist.UserPlaylists)
                             {
-                                userMapping.JellyfinPlaylistId = null;
+                                var existingMapping = existingPlaylist.UserPlaylists?.FirstOrDefault(m =>
+                                {
+                                    var normalizedExisting = Guid.TryParse(m.UserId, out var existingGuid)
+                                        ? existingGuid.ToString("N") : m.UserId;
+                                    var normalizedNew = Guid.TryParse(newMapping.UserId, out var newGuid)
+                                        ? newGuid.ToString("N") : newMapping.UserId;
+                                    return string.Equals(normalizedExisting, normalizedNew, StringComparison.OrdinalIgnoreCase);
+                                });
+                                newMapping.JellyfinPlaylistId = existingMapping?.JellyfinPlaylistId;
                             }
                         }
+
+                        playlist.JellyfinPlaylistId = existingPlaylist.JellyfinPlaylistId;
                     }
                 }
 
@@ -1846,9 +1857,9 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                             logger.LogWarning(ex, "Failed to delete Jellyfin collection when disabling collection '{CollectionName}', continuing", existingCollection.Name);
                         }
                         
-                        // Always clear the Jellyfin collection ID regardless of deletion success
-                        // This ensures consistency: disabled collections should not have Jellyfin IDs
-                        collection.JellyfinCollectionId = null;
+                        // DeleteAsync cleared the ID on existingCollection if the Jellyfin collection
+                        // is gone; a failed deletion keeps it so deletion can be retried later
+                        collection.JellyfinCollectionId = existingCollection.JellyfinCollectionId;
                     }
                 }
 
@@ -2283,19 +2294,11 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
 
                     try
                     {
-                        // Remove all Jellyfin playlists FIRST using service method
+                        // Remove all Jellyfin playlists FIRST using service method.
+                        // It clears the IDs of successfully deleted playlists on the DTO;
+                        // failed deletions keep their ID so deletion can be retried later.
                         var playlistService = GetPlaylistService();
                         await playlistService.DeleteAllJellyfinPlaylistsForUsersAsync(playlist);
-
-                        // Clear the Jellyfin playlist IDs since the playlists no longer exist
-                        playlist.JellyfinPlaylistId = null;
-                        if (playlist.UserPlaylists != null)
-                        {
-                            foreach (var userMapping in playlist.UserPlaylists)
-                            {
-                                userMapping.JellyfinPlaylistId = null;
-                            }
-                        }
 
                         // Only save the configuration if the Jellyfin operation succeeds
                         await playlistStore.SaveAsync(playlist);
@@ -2324,10 +2327,11 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
 
                     try
                     {
+                        // DisableAsync (via DeleteAsync) clears the ID if the Jellyfin collection
+                        // is gone; a failed deletion keeps it so deletion can be retried later
                         var collectionService = GetCollectionService();
                         await collectionService.DisableAsync(collection);
 
-                        collection.JellyfinCollectionId = null;
                         await collectionStore.SaveAsync(collection);
                         AutoRefreshService.Instance?.UpdateCollectionInCache(collection);
 

--- a/Jellyfin.Plugin.SmartLists/Api/Controllers/UserSmartListController.cs
+++ b/Jellyfin.Plugin.SmartLists/Api/Controllers/UserSmartListController.cs
@@ -1023,16 +1023,9 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                         try
                         {
                             var playlistService = _playlistService;
+                            // The service clears the IDs of successfully deleted playlists on the
+                            // DTO; failed deletions keep their ID so deletion can be retried later
                             await playlistService.DeleteAllJellyfinPlaylistsForUsersAsync(playlist);
-
-                            playlist.JellyfinPlaylistId = null;
-                            if (playlist.UserPlaylists != null)
-                            {
-                                foreach (var userMapping in playlist.UserPlaylists)
-                                {
-                                    userMapping.JellyfinPlaylistId = null;
-                                }
-                            }
 
                             await playlistStore.SaveAsync(playlist);
                             Services.Shared.AutoRefreshService.Instance?.UpdatePlaylistInCache(playlist);
@@ -1055,10 +1048,11 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
 
                         try
                         {
+                            // DisableAsync (via DeleteAsync) clears the ID if the Jellyfin collection
+                            // is gone; a failed deletion keeps it so deletion can be retried later
                             var collectionService = _collectionService;
                             await collectionService.DisableAsync(collection);
 
-                            collection.JellyfinCollectionId = null;
                             await collectionStore.SaveAsync(collection);
                             Services.Shared.AutoRefreshService.Instance?.UpdateCollectionInCache(collection);
 

--- a/Jellyfin.Plugin.SmartLists/Core/Constants/ProviderKeys.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Constants/ProviderKeys.cs
@@ -1,0 +1,15 @@
+namespace Jellyfin.Plugin.SmartLists.Core.Constants
+{
+    /// <summary>
+    /// Provider ID keys stamped on Jellyfin items by this plugin.
+    /// </summary>
+    public static class ProviderKeys
+    {
+        /// <summary>
+        /// Tethers a Jellyfin playlist/collection to its smart list DTO ID, so the item can be
+        /// recovered when the stored Jellyfin item ID goes stale, and so duplicates provably
+        /// created by this plugin can be cleaned up safely.
+        /// </summary>
+        public const string SmartLists = "SmartLists";
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
@@ -458,9 +458,18 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
 
                 foreach (var orphan in orphans)
                 {
-                    _logger.LogWarning("Deleting orphaned duplicate collection '{CollectionName}' ({CollectionId}) tethered to smart collection {SmartListId}",
-                        orphan.Name, orphan.Id, dto.Id);
-                    _libraryManager.DeleteItem(orphan, new DeleteOptions { DeleteFileLocation = true }, true);
+                    try
+                    {
+                        _logger.LogWarning("Deleting orphaned duplicate collection '{CollectionName}' ({CollectionId}) tethered to smart collection {SmartListId}",
+                            orphan.Name, orphan.Id, dto.Id);
+                        _libraryManager.DeleteItem(orphan, new DeleteOptions { DeleteFileLocation = true }, true);
+                    }
+                    catch (Exception deleteEx)
+                    {
+                        // Per-orphan catch so one failed deletion doesn't strand the rest
+                        _logger.LogWarning(deleteEx, "Failed to delete orphaned duplicate collection '{CollectionName}' ({CollectionId}), continuing with remaining orphans",
+                            orphan.Name, orphan.Id);
+                    }
                 }
             }
             catch (Exception ex)

--- a/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
@@ -327,6 +327,28 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                     }
                 }
 
+                // Recovery: if the stored Jellyfin collection ID is stale (e.g. lost after a DB
+                // migration or restore), re-find the collection via the SmartLists provider ID
+                // stamped on it at creation. Never match by name - duplicate names are legal.
+                if (existingCollectionItem == null && !string.IsNullOrEmpty(dto.Id))
+                {
+                    var tetherQuery = new InternalItemsQuery
+                    {
+                        IncludeItemTypes = [BaseItemKind.BoxSet],
+                        Recursive = true,
+                    };
+
+                    existingCollectionItem = _libraryManager.GetItemsResult(tetherQuery).Items
+                        .FirstOrDefault(b => string.Equals(b.GetProviderId(ProviderKeys.SmartLists), dto.Id, StringComparison.OrdinalIgnoreCase));
+
+                    if (existingCollectionItem != null)
+                    {
+                        _logger.LogInformation("Recovered collection '{CollectionName}' ({CollectionId}) via SmartLists provider ID; stored Jellyfin collection ID was stale",
+                            existingCollectionItem.Name, existingCollectionItem.Id);
+                        dto.JellyfinCollectionId = existingCollectionItem.Id.ToString("N");
+                    }
+                }
+
                 var collectionName = dto.Name;
 
                 if (existingCollectionItem != null && existingCollectionItem.GetBaseItemKind() == BaseItemKind.BoxSet)
@@ -346,8 +368,17 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                         existingCollection.Name = expectedName;
                     }
 
+                    // Retro-stamp the tether on collections created before this mechanism existed
+                    var providerIdChanged = false;
+                    if (!string.IsNullOrEmpty(dto.Id)
+                        && !string.Equals(existingCollection.GetProviderId(ProviderKeys.SmartLists), dto.Id, StringComparison.OrdinalIgnoreCase))
+                    {
+                        providerIdChanged = true;
+                        existingCollection.SetProviderId(ProviderKeys.SmartLists, dto.Id);
+                    }
+
                     // Update the collection if any changes are needed
-                    if (nameChanged)
+                    if (nameChanged || providerIdChanged)
                     {
                         await existingCollection.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken);
                         _logger.LogDebug("Updated existing collection: {CollectionName}", existingCollection.Name);
@@ -362,6 +393,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                     // Update LastRefreshed timestamp for successful refresh
                     dto.LastRefreshed = DateTime.UtcNow;
                     _logger.LogDebug("Updated LastRefreshed timestamp for collection: {CollectionName}", dto.Name);
+
+                    DeleteOrphanedTetheredCollections(dto, existingCollection.Id);
 
                     return (true, $"Updated collection '{existingCollection.Name}' with {newLinkedChildren.Length} items", existingCollection.Id.ToString("N"));
                 }
@@ -382,6 +415,11 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                     // Update the DTO with the new Jellyfin collection ID
                     dto.JellyfinCollectionId = newCollectionId;
 
+                    if (Guid.TryParse(newCollectionId, out var createdCollectionGuid))
+                    {
+                        DeleteOrphanedTetheredCollections(dto, createdCollectionGuid);
+                    }
+
                     // Update LastRefreshed timestamp for successful refresh
                     dto.LastRefreshed = DateTime.UtcNow;
                     _logger.LogDebug("Updated LastRefreshed timestamp for collection: {CollectionName}", dto.Name);
@@ -394,7 +432,46 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
         }
 
         /// <summary>
+        /// Deletes duplicate Jellyfin collections that carry this smart collection's provider-ID
+        /// tether but are not the tracked collection. The tether proves the plugin created them,
+        /// so deletion cannot hit user-created collections.
+        /// </summary>
+        private void DeleteOrphanedTetheredCollections(SmartCollectionDto dto, Guid canonicalCollectionId)
+        {
+            if (string.IsNullOrEmpty(dto.Id))
+            {
+                return;
+            }
+
+            try
+            {
+                var query = new InternalItemsQuery
+                {
+                    IncludeItemTypes = [BaseItemKind.BoxSet],
+                    Recursive = true,
+                };
+
+                var orphans = _libraryManager.GetItemsResult(query).Items
+                    .Where(b => b.Id != canonicalCollectionId
+                        && string.Equals(b.GetProviderId(ProviderKeys.SmartLists), dto.Id, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+
+                foreach (var orphan in orphans)
+                {
+                    _logger.LogWarning("Deleting orphaned duplicate collection '{CollectionName}' ({CollectionId}) tethered to smart collection {SmartListId}",
+                        orphan.Name, orphan.Id, dto.Id);
+                    _libraryManager.DeleteItem(orphan, new DeleteOptions { DeleteFileLocation = true }, true);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to clean up orphaned duplicate collections for '{CollectionName}', continuing", dto.Name);
+            }
+        }
+
+        /// <summary>
         /// Deletes a Jellyfin collection associated with the smart collection.
+        /// Clears the stored Jellyfin collection ID when the collection is deleted or already absent, so callers should persist the DTO afterward.
         /// </summary>
         /// <param name="dto">The smart collection DTO.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
@@ -419,6 +496,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                     else
                     {
                         _logger.LogWarning("No Jellyfin collection found by ID '{JellyfinCollectionId}' for deletion. Collection may have been manually deleted.", dto.JellyfinCollectionId);
+                        dto.JellyfinCollectionId = null;
                     }
                 }
                 else
@@ -432,6 +510,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                         existingCollection.Name, existingCollection.Id);
                     // DeleteFileLocation = true to properly delete the BoxSet entity and its metadata
                     _libraryManager.DeleteItem(existingCollection, new DeleteOptions { DeleteFileLocation = true }, true);
+                    dto.JellyfinCollectionId = null;
                 }
 
                 return Task.CompletedTask;
@@ -486,6 +565,9 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                         // Remove the smart collection naming and keep just the base name
                         existingCollection.Name = dto.Name;
 
+                        // Collection is being handed back to the user - remove the smart list tether
+                        existingCollection.ProviderIds?.Remove(ProviderKeys.SmartLists);
+
                         // Save the changes
                         await existingCollection.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
 
@@ -509,6 +591,9 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                             if (oldName == expectedName)
                             {
                                 existingCollection.Name = baseName;
+
+                                // Collection is being handed back to the user - remove the smart list tether
+                                existingCollection.ProviderIds?.Remove(ProviderKeys.SmartLists);
 
                                 // Save the changes
                                 await existingCollection.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
@@ -893,6 +978,15 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                 if (retrievedItem != null && retrievedItem.GetBaseItemKind() == BaseItemKind.BoxSet)
                 {
                     await FinalizeCollectionMetadataAsync(retrievedItem, formattedName, linkedChildren, dto, ownerUser, cancellationToken).ConfigureAwait(false);
+                }
+
+                // Stamp the tether so the collection can be recovered if the stored ID goes stale.
+                // Done after finalization so no later metadata write can drop it.
+                if (!string.IsNullOrEmpty(dto.Id) && retrievedItem != null
+                    && !string.Equals(retrievedItem.GetProviderId(ProviderKeys.SmartLists), dto.Id, StringComparison.OrdinalIgnoreCase))
+                {
+                    retrievedItem.SetProviderId(ProviderKeys.SmartLists, dto.Id);
+                    await retrievedItem.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
                 }
 
                 return collectionId.ToString("N");

--- a/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
@@ -258,6 +258,33 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
 
                 // Note: Legacy name-based fallback removed - all playlists should now have JellyfinPlaylistId
 
+                // Recovery: if the stored Jellyfin playlist ID is stale (e.g. lost after a DB
+                // migration or restore), re-find the playlist via the SmartLists provider ID
+                // stamped on it at creation. Never match by name - duplicate names are legal.
+                var recoveredViaProviderId = false;
+                if (existingPlaylist == null && !string.IsNullOrEmpty(dto.Id))
+                {
+                    // Note: IPlaylistManager.GetPlaylists hydrates items without provider IDs
+                    // (DtoOptions(false)), so query the library directly instead
+                    var tetherQuery = new InternalItemsQuery(user)
+                    {
+                        IncludeItemTypes = [BaseItemKind.Playlist],
+                        Recursive = true,
+                    };
+
+                    existingPlaylist = _libraryManager.GetItemsResult(tetherQuery).Items
+                        .OfType<Playlist>()
+                        .FirstOrDefault(p => p.OwnerUserId == user.Id
+                            && string.Equals(p.GetProviderId(ProviderKeys.SmartLists), dto.Id, StringComparison.OrdinalIgnoreCase));
+
+                    if (existingPlaylist != null)
+                    {
+                        recoveredViaProviderId = true;
+                        logger.LogInformation("Recovered playlist '{PlaylistName}' ({PlaylistId}) for user {UserId} via SmartLists provider ID; stored Jellyfin playlist ID was stale",
+                            existingPlaylist.Name, existingPlaylist.Id, user.Id);
+                    }
+                }
+
                 // Now that we've found the existing playlist (or not), apply the new naming format
                 var smartPlaylistName = NameFormatter.FormatPlaylistName(dto.Name);
 
@@ -304,8 +331,17 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                         logger.LogDebug("Playlist public status changing from {OldPublic} to {NewPublic}", isCurrentlyPublic, dto.Public);
                     }
 
+                    // Retro-stamp the tether on playlists created before this mechanism existed
+                    var providerIdChanged = false;
+                    if (!string.IsNullOrEmpty(dto.Id)
+                        && !string.Equals(existingPlaylist.GetProviderId(ProviderKeys.SmartLists), dto.Id, StringComparison.OrdinalIgnoreCase))
+                    {
+                        providerIdChanged = true;
+                        existingPlaylist.SetProviderId(ProviderKeys.SmartLists, dto.Id);
+                    }
+
                     // Update the playlist if any changes are needed
-                    if (nameChanged || ownershipChanged || publicStatusChanged)
+                    if (nameChanged || ownershipChanged || publicStatusChanged || providerIdChanged)
                     {
                         await existingPlaylist.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken);
                         logger.LogDebug("Updated existing playlist: {PlaylistName}", existingPlaylist.Name);
@@ -316,6 +352,47 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
 
                     logger.LogDebug("Successfully updated existing playlist: {PlaylistName} with {ItemCount} items",
                         existingPlaylist.Name, newLinkedChildren.Length);
+
+                    if (recoveredViaProviderId)
+                    {
+                        var recoveredPlaylistId = existingPlaylist.Id.ToString("N");
+                        if (dto.UserPlaylists != null && dto.UserPlaylists.Count > 0)
+                        {
+                            var recoveredMapping = dto.UserPlaylists.FirstOrDefault(m => string.Equals(m.UserId, user.Id.ToString("N"), StringComparison.OrdinalIgnoreCase));
+                            if (recoveredMapping != null)
+                            {
+                                recoveredMapping.JellyfinPlaylistId = recoveredPlaylistId;
+                            }
+                            else
+                            {
+                                dto.UserPlaylists.Add(new SmartPlaylistDto.UserPlaylistMapping
+                                {
+                                    UserId = user.Id.ToString("N"),
+                                    JellyfinPlaylistId = recoveredPlaylistId
+                                });
+                            }
+
+                            dto.JellyfinPlaylistId = dto.UserPlaylists[0].JellyfinPlaylistId;
+                        }
+                        else
+                        {
+                            dto.JellyfinPlaylistId = recoveredPlaylistId;
+                        }
+
+                        if (saveCallback != null)
+                        {
+                            try
+                            {
+                                await saveCallback(dto);
+                            }
+                            catch (Exception saveEx)
+                            {
+                                logger.LogWarning(saveEx, "Failed to save recovered Jellyfin playlist ID for {PlaylistName}, but continuing with operation", dto.Name);
+                            }
+                        }
+                    }
+
+                    DeleteOrphanedTetheredPlaylists(dto, user, existingPlaylist.Id);
 
                     return (true, $"Updated playlist '{existingPlaylist.Name}' with {newLinkedChildren.Length} items", existingPlaylist.Id.ToString("N"));
                 }
@@ -331,6 +408,11 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                     {
                         logger.LogError("Failed to create playlist '{PlaylistName}' - no valid playlist ID returned", smartPlaylistName);
                         return (false, $"Failed to create playlist '{smartPlaylistName}' - the playlist could not be retrieved after creation", string.Empty);
+                    }
+
+                    if (Guid.TryParse(newPlaylistId, out var createdPlaylistGuid))
+                    {
+                        DeleteOrphanedTetheredPlaylists(dto, user, createdPlaylistGuid);
                     }
 
                     // Update the DTO with the new Jellyfin playlist ID
@@ -556,6 +638,9 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                         // Remove the smart playlist naming and keep just the base name
                         existingPlaylist.Name = dto.Name;
 
+                        // Playlist is being handed back to the user - remove the smart list tether
+                        existingPlaylist.ProviderIds?.Remove(ProviderKeys.SmartLists);
+
                         // Save the changes
                         await existingPlaylist.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
 
@@ -579,6 +664,9 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                             if (oldName == expectedName)
                             {
                                 existingPlaylist.Name = baseName;
+
+                                // Playlist is being handed back to the user - remove the smart list tether
+                                existingPlaylist.ProviderIds?.Remove(ProviderKeys.SmartLists);
 
                                 // Save the changes
                                 await existingPlaylist.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
@@ -710,6 +798,11 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
 
                 newPlaylist.LinkedChildren = linkedChildren;
 
+                if (!string.IsNullOrEmpty(dto.Id))
+                {
+                    newPlaylist.SetProviderId(ProviderKeys.SmartLists, dto.Id);
+                }
+
                 // Set MediaType before persisting to avoid a second write
                 var mediaType = DeterminePlaylistMediaType(dto);
                 SetPlaylistMediaType(newPlaylist, mediaType);
@@ -733,6 +826,16 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
 
                 // Apply custom metadata after metadata refresh to prevent providers from overwriting
                 await ApplyCustomMetadataAsync(newPlaylist, dto, user, cancellationToken).ConfigureAwait(false);
+
+                // Re-assert the tether: the cover-art refresh above runs with ReplaceAllMetadata,
+                // which rebuilds provider IDs from playlist.xml and can drop the stamp set before
+                // the first save. Persisting it last also writes it into playlist.xml.
+                if (!string.IsNullOrEmpty(dto.Id)
+                    && !string.Equals(newPlaylist.GetProviderId(ProviderKeys.SmartLists), dto.Id, StringComparison.OrdinalIgnoreCase))
+                {
+                    newPlaylist.SetProviderId(ProviderKeys.SmartLists, dto.Id);
+                    await newPlaylist.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
+                }
 
                 return newPlaylist.Id.ToString("N");
             }
@@ -1297,9 +1400,52 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
         }
 
         /// <summary>
+        /// Deletes duplicate Jellyfin playlists that carry this smart playlist's provider-ID
+        /// tether for this user but are not the tracked playlist. The tether proves the plugin
+        /// created them, so deletion cannot hit user-created playlists.
+        /// </summary>
+        private void DeleteOrphanedTetheredPlaylists(SmartPlaylistDto dto, User user, Guid canonicalPlaylistId)
+        {
+            if (string.IsNullOrEmpty(dto.Id))
+            {
+                return;
+            }
+
+            try
+            {
+                var query = new InternalItemsQuery(user)
+                {
+                    IncludeItemTypes = [BaseItemKind.Playlist],
+                    Recursive = true,
+                };
+
+                var orphans = _libraryManager.GetItemsResult(query).Items
+                    .OfType<Playlist>()
+                    .Where(p => p.Id != canonicalPlaylistId
+                        && p.OwnerUserId == user.Id
+                        && string.Equals(p.GetProviderId(ProviderKeys.SmartLists), dto.Id, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+
+                foreach (var orphan in orphans)
+                {
+                    _logger.LogWarning("Deleting orphaned duplicate playlist '{PlaylistName}' ({PlaylistId}) tethered to smart playlist {SmartListId} for user {UserId}",
+                        orphan.Name, orphan.Id, dto.Id, user.Id);
+                    _libraryManager.DeleteItem(orphan, new DeleteOptions { DeleteFileLocation = true }, true);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to clean up orphaned duplicate playlists for '{PlaylistName}', continuing", dto.Name);
+            }
+        }
+
+        /// <summary>
         /// Helper method to delete all Jellyfin playlists for a smart playlist across all users.
         /// Handles both multi-user playlists (UserPlaylists array) and legacy single-user playlists.
         /// This centralizes the deletion logic used by disable, delete, and visibility schedule operations.
+        /// Successfully deleted playlists have their stored Jellyfin playlist IDs cleared on the DTO;
+        /// failed deletions keep their IDs so deletion can be retried later. Callers are responsible
+        /// for persisting the DTO.
         /// </summary>
         /// <param name="playlistDto">The smart playlist DTO containing Jellyfin playlist IDs to delete</param>
         /// <param name="cancellationToken">Cancellation token</param>
@@ -1330,6 +1476,9 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                             await DeleteAsync(tempDto, cancellationToken).ConfigureAwait(false);
                             _logger.LogDebug("Deleted Jellyfin playlist {JellyfinPlaylistId} for user {UserId}",
                                 userMapping.JellyfinPlaylistId, userMapping.UserId);
+                            // Clear the mapping only on successful deletion; a failed delete keeps
+                            // its ID so the playlist can be found and deleted on a later attempt
+                            userMapping.JellyfinPlaylistId = null;
                         }
                         catch (Exception ex)
                         {
@@ -1338,6 +1487,9 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                         }
                     }
                 }
+
+                // Keep the backwards-compatibility field in sync (first user's playlist)
+                playlistDto.JellyfinPlaylistId = playlistDto.UserPlaylists[0].JellyfinPlaylistId;
             }
             else if (!string.IsNullOrEmpty(playlistDto.JellyfinPlaylistId))
             {
@@ -1347,6 +1499,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                 try
                 {
                     await DeleteAsync(playlistDto, cancellationToken).ConfigureAwait(false);
+                    playlistDto.JellyfinPlaylistId = null;
                 }
                 catch (Exception ex)
                 {

--- a/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
@@ -1428,9 +1428,18 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
 
                 foreach (var orphan in orphans)
                 {
-                    _logger.LogWarning("Deleting orphaned duplicate playlist '{PlaylistName}' ({PlaylistId}) tethered to smart playlist {SmartListId} for user {UserId}",
-                        orphan.Name, orphan.Id, dto.Id, user.Id);
-                    _libraryManager.DeleteItem(orphan, new DeleteOptions { DeleteFileLocation = true }, true);
+                    try
+                    {
+                        _logger.LogWarning("Deleting orphaned duplicate playlist '{PlaylistName}' ({PlaylistId}) tethered to smart playlist {SmartListId} for user {UserId}",
+                            orphan.Name, orphan.Id, dto.Id, user.Id);
+                        _libraryManager.DeleteItem(orphan, new DeleteOptions { DeleteFileLocation = true }, true);
+                    }
+                    catch (Exception deleteEx)
+                    {
+                        // Per-orphan catch so one failed deletion doesn't strand the rest
+                        _logger.LogWarning(deleteEx, "Failed to delete orphaned duplicate playlist '{PlaylistName}' ({PlaylistId}), continuing with remaining orphans",
+                            orphan.Name, orphan.Id);
+                    }
                 }
             }
             catch (Exception ex)

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/AutoRefreshService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/AutoRefreshService.cs
@@ -2320,7 +2320,9 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                 {
                     _logger.LogInformation("Visibility schedule: Disabling playlist '{Name}'", playlist.Name);
                     
-                    // Delete all Jellyfin playlists for all users using service method
+                    // Delete all Jellyfin playlists for all users using service method.
+                    // It clears the IDs of successfully deleted playlists on the DTO; failed
+                    // deletions keep their ID so deletion can be retried later.
                     // Cast to PlaylistService to access the helper method
                     if (_playlistService is Jellyfin.Plugin.SmartLists.Services.Playlists.PlaylistService playlistServiceImpl)
                     {
@@ -2330,18 +2332,10 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                     {
                         _logger.LogWarning("Unable to cast playlist service to PlaylistService implementation");
                     }
-                    
-                    // Clear Jellyfin IDs and disable (same as manual disable)
+
+                    // Disable (same as manual disable)
                     playlist.Enabled = false;
-                    playlist.JellyfinPlaylistId = null;
-                    if (playlist.UserPlaylists != null)
-                    {
-                        foreach (var userMapping in playlist.UserPlaylists)
-                        {
-                            userMapping.JellyfinPlaylistId = null;
-                        }
-                    }
-                    
+
                     await _playlistStore.SaveAsync(playlist).ConfigureAwait(false);
                 }
             }
@@ -2412,23 +2406,24 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                 {
                     _logger.LogInformation("Visibility schedule: Disabling collection '{Name}'", collection.Name);
                     
-                    // Delete Jellyfin collection before disabling
+                    // Delete Jellyfin collection before disabling.
+                    // DeleteAsync clears the ID if the Jellyfin collection is gone; a failed
+                    // deletion keeps it so deletion can be retried later.
                     if (!string.IsNullOrEmpty(collection.JellyfinCollectionId))
                     {
                         try
                         {
                             await _collectionService.DeleteAsync(collection).ConfigureAwait(false);
-                            _logger.LogDebug("Deleted Jellyfin collection {JellyfinCollectionId} for collection '{Name}' via visibility schedule", collection.JellyfinCollectionId, collection.Name);
+                            _logger.LogDebug("Deleted Jellyfin collection for collection '{Name}' via visibility schedule", collection.Name);
                         }
                         catch (Exception deleteEx)
                         {
                             _logger.LogWarning(deleteEx, "Failed to delete Jellyfin collection for '{Name}'", collection.Name);
                         }
                     }
-                    
-                    // Clear Jellyfin ID and disable (same as manual disable)
+
+                    // Disable (same as manual disable)
                     collection.Enabled = false;
-                    collection.JellyfinCollectionId = null;
                     await _collectionStore.SaveAsync(collection).ConfigureAwait(false);
                 }
             }


### PR DESCRIPTION
## What
Stops the plugin from ever creating duplicate Jellyfin playlists/collections when its stored item ID goes stale, and automatically cleans up duplicates it provably created.

## Why
Bug report: all smart playlists got an empty duplicate named like `Name [Smart]11111`, even disabled ones. Root cause chain:
- Jellyfin core appends `1` to the playlist **folder** name per collision (`GetTargetPath`), and all users share one playlists directory — multi-user smart playlists collide by design, so folders with trailing `1`s accumulate.
- The plugin finds its items by stored Jellyfin item ID only (name fallback was removed on purpose — duplicate names are legal). Any stale ID (DB migration, restore, failed save) meant "not found" → create duplicate.
- Disable flows cleared stored IDs even when the Jellyfin delete failed, permanently orphaning items; library scans later re-imported orphaned folders as empty playlists named after the folder — exactly the reported symptom.

## Changes
- **Provider-ID tether**: created playlists/collections are stamped with `ProviderIds["SmartLists"] = <smart list DTO ID>` (new shared `ProviderKeys.SmartLists` constant). Existing items are retro-stamped on their next refresh. The tether persists in the DB and playlist.xml, so it survives restarts and even a DB rebuild + rescan.
  - Playlist create path re-asserts the stamp after cover generation — that refresh runs `ReplaceAllMetadata=true`, which rebuilds provider IDs from playlist.xml and would drop a not-yet-persisted stamp. Collections refresh with `ReplaceAllMetadata=false` and don't need this.
- **Recovery instead of duplicate**: on an ID-lookup miss, the item is re-found via the tether (owner + provider ID for playlists, provider ID for collections) and the recovered ID is written back to the DTO. Never matches by name.
- **Keep IDs on failed delete**: `DeleteAllJellyfinPlaylistsForUsersAsync` (playlists) and `DeleteAsync` (collections) now clear stored IDs only when the item was actually deleted or is already gone; a failed delete keeps the ID so deletion can be retried. The eight disable/visibility-schedule call sites no longer blanket-clear.
- **Orphan sweep**: every refresh deletes items that carry this smart list's tether but aren't the tracked item. The tether proves the plugin created them, so user-created playlists/collections can never be hit.

## Verification
Exercised live against the dev Jellyfin 12 container:
- Corrupted stored IDs → recovery log lines, no duplicates created, DTO IDs restored (playlist + collection).
- Planted a real bait playlist with a forged tether row → swept on next refresh, canonical item untouched.
- Disable/enable cycles; tether persistence across container restarts in DB and playlist.xml.
- Both target frameworks build clean (warnings-as-errors).

Notes:
- Existing pre-fix orphans (like the reporter's current `[Smart]11111` playlists) carry no tether and must be deleted manually once; the sweep prevents any new ones.
- `.claude/skills/verify/SKILL.md` documents the dev-container verification recipe used here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsYUGfTYy8xkQeUiNbjNQ5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery when playlist or collection links become outdated.
  - Prevented valid Jellyfin IDs from being cleared when deletion fails, allowing cleanup to be retried.
  - Improved handling of duplicate SmartLists playlists and collections.
  - Preserved and restored SmartLists associations during refreshes and updates.
  - Improved cleanup when returning playlists or collections to regular user-managed items.

- **Documentation**
  - Added an end-to-end verification guide for testing SmartLists with a local Jellyfin environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->