### PR TITLE
Lock smart collections to prevent TMDbBoxSets deleting them

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
@@ -592,7 +592,9 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                         existingCollection.Name = dto.Name;
 
                         // Collection is being handed back to the user - remove the smart list tether
+                        // and unlock it so Jellyfin's metadata fetchers work again for the user
                         existingCollection.ProviderIds?.Remove(ProviderKeys.SmartLists);
+                        existingCollection.IsLocked = false;
 
                         // Save the changes
                         await existingCollection.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
@@ -619,7 +621,9 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                                 existingCollection.Name = baseName;
 
                                 // Collection is being handed back to the user - remove the smart list tether
+                                // and unlock it so Jellyfin's metadata fetchers work again for the user
                                 existingCollection.ProviderIds?.Remove(ProviderKeys.SmartLists);
+                                existingCollection.IsLocked = false;
 
                                 // Save the changes
                                 await existingCollection.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
@@ -794,7 +798,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                     
                     var parameters = createMethod.GetParameters();
                     object? taskResult = null;
-                    
+                    var itemsAddedViaOptions = false;
+
                     if (parameters.Length == 1 && parameters[0].ParameterType.Name == "CollectionCreationOptions")
                     {
                         // Use CollectionCreationOptions
@@ -814,10 +819,39 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                             nameProperty.SetValue(options, formattedName);
                             _logger.LogDebug("Set Name to: {Name}", formattedName);
                         }
-                        
-                        // Note: We'll add items using AddToCollectionAsync after creation instead of setting ItemIdList
-                        _logger.LogDebug("Collection will be created empty, items will be added via AddToCollectionAsync");
-                        
+
+                        // Lock the collection at creation: CollectionManager queues a metadata
+                        // refresh on create/add, and the TMDB boxset fetcher would stamp a TMDB ID
+                        // on it by name match. TMDbBoxSets deletes boxsets with unmatched TMDB IDs (#433).
+                        var isLockedProperty = optType.GetProperty("IsLocked");
+                        if (isLockedProperty != null)
+                        {
+                            isLockedProperty.SetValue(options, true);
+                            _logger.LogDebug("Set IsLocked to true");
+                        }
+
+                        // Pass the items at creation: CollectionManager then adds them internally and
+                        // queues a single metadata refresh, instead of the two queued refreshes that an
+                        // empty create followed by a separate AddToCollectionAsync call would produce.
+                        // Fewer concurrent refreshes = no colliding collection.xml saver writes (#433).
+                        var itemIdListProperty = optType.GetProperty("ItemIdList");
+                        if (itemIdListProperty != null && itemIds.Count > 0)
+                        {
+                            itemIdListProperty.SetValue(options, itemIds.Select(id => id.ToString("N")).ToArray());
+                            itemsAddedViaOptions = true;
+                            _logger.LogDebug("Set ItemIdList with {Count} items", itemIds.Count);
+                        }
+
+                        // Stamp the SmartLists tether at creation so no separate save is needed for it
+                        var providerIdsProperty = optType.GetProperty("ProviderIds");
+                        if (providerIdsProperty != null && !string.IsNullOrEmpty(dto.Id))
+                        {
+                            // OrdinalIgnoreCase matches BaseItem.ProviderIds' contract — CollectionManager
+                            // assigns this dictionary to the new BoxSet by reference
+                            providerIdsProperty.SetValue(options, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { [ProviderKeys.SmartLists] = dto.Id });
+                            _logger.LogDebug("Set SmartLists tether provider ID at creation");
+                        }
+
                         _logger.LogDebug("Invoking CreateCollectionAsync with CollectionCreationOptions");
                         taskResult = createMethod.Invoke(_collectionManager, new object[] { options });
                     }
@@ -826,6 +860,10 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                         // Use direct parameters
                         _logger.LogDebug("Invoking CreateCollectionAsync with direct parameters");
                         taskResult = createMethod.Invoke(_collectionManager, new object[] { formattedName, itemIds.ToArray() });
+
+                        // Items are passed positionally here, so the AddToCollectionAsync
+                        // fallback below must not re-add them.
+                        itemsAddedViaOptions = true;
                     }
                     
                     if (taskResult != null)
@@ -843,8 +881,10 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                             collectionId = baseItem.Id;
                             _logger.LogDebug("Collection created via ICollectionManager with ID: {CollectionId}", collectionId);
                             
-                            // Add items to the collection using AddToCollectionAsync
-                            if (itemIds.Count > 0)
+                            // Fallback only: items are normally passed via ItemIdList at creation.
+                            // Calling AddToCollectionAsync separately queues a second core refresh
+                            // that races the first one's collection.xml writes (#433).
+                            if (!itemsAddedViaOptions && itemIds.Count > 0)
                             {
                                 _logger.LogDebug("Adding {Count} items to collection {CollectionId} using AddToCollectionAsync", itemIds.Count, collectionId);
                                 var addMethod = _collectionManager.GetType().GetMethod("AddToCollectionAsync");
@@ -896,7 +936,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                             
                             boxSetType.GetProperty("Name")?.SetValue(boxSet, formattedName);
                             boxSetType.GetProperty("LinkedChildren")?.SetValue(boxSet, linkedChildren);
-                            
+                            boxSetType.GetProperty("IsLocked")?.SetValue(boxSet, true);
+
                             // Add to library manager - use CreateItemAsync if available, otherwise try UpdateToRepositoryAsync
                             var createItemMethod = _libraryManager.GetType().GetMethod("CreateItemAsync", new[] { typeof(BaseItem), typeof(CancellationToken) });
                             if (createItemMethod != null)
@@ -945,7 +986,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                         
                         boxSetType.GetProperty("Name")?.SetValue(boxSet, formattedName);
                         boxSetType.GetProperty("LinkedChildren")?.SetValue(boxSet, linkedChildren);
-                        
+                        boxSetType.GetProperty("IsLocked")?.SetValue(boxSet, true);
+
                         // Add to library manager - use CreateItemAsync if available, otherwise try UpdateToRepositoryAsync
                         var createItemMethod = _libraryManager.GetType().GetMethod("CreateItemAsync", new[] { typeof(BaseItem), typeof(CancellationToken) });
                         if (createItemMethod != null)
@@ -978,28 +1020,18 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
             {
                 _logger.LogDebug("Retrieved new collection: Name = {Name}", retrievedItem.Name);
 
-                // Handle custom images and auto-generation
-                // Logic: Custom images uploaded via SmartLists take precedence over auto-generation
-                // Auto-generation only happens for Primary/Thumb if no custom versions exist
-                var hasCustomPrimary = dto.CustomImages?.ContainsKey("Primary") == true;
-                var hasCustomThumb = dto.CustomImages?.ContainsKey("Thumb") == true;
-
                 // Always call ApplyCustomImagesToCollectionAsync - it handles both:
                 // 1. Applying custom images if any exist
                 // 2. Cleaning up orphaned images when custom images are deleted
                 await ApplyCustomImagesToCollectionAsync(retrievedItem, dto, cancellationToken).ConfigureAwait(false);
 
-                // Only trigger auto-generation if no custom Primary AND no custom Thumb uploaded
-                // (RefreshCollectionMetadataAsync already checks for manually uploaded images in Jellyfin)
-                if (!hasCustomPrimary && !hasCustomThumb)
-                {
-                    // Pass linkedChildren to avoid stale cache issues - the collection object may not have
-                    // updated LinkedChildren yet after AddToCollectionAsync, especially for large libraries
-                    await RefreshCollectionMetadataAsync(retrievedItem, linkedChildren, cancellationToken).ConfigureAwait(false);
-                }
+                // No direct metadata refresh here: CollectionManager already queued one for the new
+                // collection, and a second refresh running in parallel is what produced concurrent
+                // collection.xml saver IOExceptions (#433). Cover images are generated by
+                // SetPhotoForCollection inside FinalizeCollectionMetadataAsync below.
 
-                // Always set the name after metadata refresh to ensure it's correct
-                // This prevents metadata providers from overwriting our intended name
+                // Re-fetch and finalize: sets the intended name, generates cover images, and
+                // enforces the metadata lock (core's queued create-refresh runs in the background)
                 retrievedItem = _libraryManager.GetItemById(collectionId);
                 if (retrievedItem != null && retrievedItem.GetBaseItemKind() == BaseItemKind.BoxSet)
                 {
@@ -1046,6 +1078,17 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
 
             // Auto-generate collection images (SetPhotoForCollection handles per-type manual image checks).
             await SetPhotoForCollection(collection, linkedChildren, cancellationToken).ConfigureAwait(false);
+
+            // Every create/refresh path funnels through here, so this is the one place that
+            // guarantees smart collections stay locked and carry no stray TMDB ID. A stray
+            // TMDB ID (stamped by Jellyfin's name-matching boxset fetcher) makes the
+            // TMDbBoxSets plugin delete the collection as "orphaned" (#433).
+            metadataChanged |= collection.ProviderIds?.Remove(MetadataProvider.Tmdb.ToString()) == true;
+            if (!collection.IsLocked)
+            {
+                collection.IsLocked = true;
+                metadataChanged = true;
+            }
 
             metadataChanged |= SetCollectionDisplayOrder(collection);
             if (metadataChanged)

--- a/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
@@ -798,7 +798,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                     
                     var parameters = createMethod.GetParameters();
                     object? taskResult = null;
-                    var itemsAddedViaOptions = false;
+                    var itemsAddedAtCreation = false;
 
                     if (parameters.Length == 1 && parameters[0].ParameterType.Name == "CollectionCreationOptions")
                     {
@@ -838,7 +838,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                         if (itemIdListProperty != null && itemIds.Count > 0)
                         {
                             itemIdListProperty.SetValue(options, itemIds.Select(id => id.ToString("N")).ToArray());
-                            itemsAddedViaOptions = true;
+                            itemsAddedAtCreation = true;
                             _logger.LogDebug("Set ItemIdList with {Count} items", itemIds.Count);
                         }
 
@@ -863,9 +863,9 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
 
                         // Items are passed positionally here, so the AddToCollectionAsync
                         // fallback below must not re-add them.
-                        itemsAddedViaOptions = true;
+                        itemsAddedAtCreation = true;
                     }
-                    
+
                     if (taskResult != null)
                     {
                         // Await the task and extract the result
@@ -884,7 +884,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                             // Fallback only: items are normally passed via ItemIdList at creation.
                             // Calling AddToCollectionAsync separately queues a second core refresh
                             // that races the first one's collection.xml writes (#433).
-                            if (!itemsAddedViaOptions && itemIds.Count > 0)
+                            if (!itemsAddedAtCreation && itemIds.Count > 0)
                             {
                                 _logger.LogDebug("Adding {Count} items to collection {CollectionId} using AddToCollectionAsync", itemIds.Count, collectionId);
                                 var addMethod = _collectionManager.GetType().GetMethod("AddToCollectionAsync");
@@ -924,38 +924,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                     
                     if (boxSetType != null)
                     {
-                        var boxSet = Activator.CreateInstance(boxSetType);
-                        if (boxSet != null)
-                        {
-                            var baseItem = (BaseItem)boxSet;
-                            
-                            // Set ID first - must be set before persisting
-                            var newCollectionId = Guid.NewGuid();
-                            boxSetType.GetProperty("Id")?.SetValue(boxSet, newCollectionId);
-                            _logger.LogDebug("Generated new collection ID: {CollectionId}", newCollectionId);
-                            
-                            boxSetType.GetProperty("Name")?.SetValue(boxSet, formattedName);
-                            boxSetType.GetProperty("LinkedChildren")?.SetValue(boxSet, linkedChildren);
-                            boxSetType.GetProperty("IsLocked")?.SetValue(boxSet, true);
-
-                            // Add to library manager - use CreateItemAsync if available, otherwise try UpdateToRepositoryAsync
-                            var createItemMethod = _libraryManager.GetType().GetMethod("CreateItemAsync", new[] { typeof(BaseItem), typeof(CancellationToken) });
-                            if (createItemMethod != null)
-                            {
-                                await ((Task)createItemMethod.Invoke(_libraryManager, new object[] { baseItem, cancellationToken })!).ConfigureAwait(false);
-                            }
-                            else
-                            {
-                                // Fallback: try UpdateToRepositoryAsync
-                                await baseItem.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
-                            }
-                            collectionId = baseItem.Id;
-                            _logger.LogDebug("BoxSet created with ID: {CollectionId}", collectionId);
-                        }
-                        else
-                        {
-                            throw new InvalidOperationException("Failed to create BoxSet instance via reflection");
-                        }
+                        collectionId = await CreateBoxSetViaReflectionAsync(boxSetType, formattedName, linkedChildren, cancellationToken).ConfigureAwait(false);
                     }
                     else
                     {
@@ -967,45 +936,14 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
             {
                 _logger.LogWarning(ex, "Failed to create collection via ICollectionManager, trying reflection-based BoxSet creation");
                 // Fallback: Create BoxSet using reflection
-                var boxSetType = typeof(BaseItem).Assembly.GetType("MediaBrowser.Controller.Entities.BoxSet") 
+                var boxSetType = typeof(BaseItem).Assembly.GetType("MediaBrowser.Controller.Entities.BoxSet")
                     ?? AppDomain.CurrentDomain.GetAssemblies()
                         .SelectMany(a => a.GetTypes())
                         .FirstOrDefault(t => t.Name == "BoxSet" && t.IsSubclassOf(typeof(BaseItem)));
-                
+
                 if (boxSetType != null)
                 {
-                    var boxSet = Activator.CreateInstance(boxSetType);
-                    if (boxSet != null)
-                    {
-                        var baseItem = (BaseItem)boxSet;
-                        
-                        // Set ID first - must be set before persisting
-                        var newCollectionId = Guid.NewGuid();
-                        boxSetType.GetProperty("Id")?.SetValue(boxSet, newCollectionId);
-                        _logger.LogDebug("Generated new collection ID: {CollectionId}", newCollectionId);
-                        
-                        boxSetType.GetProperty("Name")?.SetValue(boxSet, formattedName);
-                        boxSetType.GetProperty("LinkedChildren")?.SetValue(boxSet, linkedChildren);
-                        boxSetType.GetProperty("IsLocked")?.SetValue(boxSet, true);
-
-                        // Add to library manager - use CreateItemAsync if available, otherwise try UpdateToRepositoryAsync
-                        var createItemMethod = _libraryManager.GetType().GetMethod("CreateItemAsync", new[] { typeof(BaseItem), typeof(CancellationToken) });
-                        if (createItemMethod != null)
-                        {
-                            await ((Task)createItemMethod.Invoke(_libraryManager, new object[] { baseItem, cancellationToken })!).ConfigureAwait(false);
-                        }
-                        else
-                        {
-                            // Fallback: try UpdateToRepositoryAsync
-                            await baseItem.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
-                        }
-                        collectionId = baseItem.Id;
-                        _logger.LogDebug("BoxSet created with ID: {CollectionId}", collectionId);
-                    }
-                    else
-                    {
-                        throw new InvalidOperationException("Failed to create BoxSet instance via reflection");
-                    }
+                    collectionId = await CreateBoxSetViaReflectionAsync(boxSetType, formattedName, linkedChildren, cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
@@ -1054,6 +992,41 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                 _logger.LogWarning("Failed to retrieve newly created collection with ID {CollectionId}", collectionId);
                 return string.Empty;
             }
+        }
+
+        /// <summary>
+        /// Creates a BoxSet directly via reflection - fallback when ICollectionManager.CreateCollectionAsync
+        /// is unavailable or failed. The BoxSet is created locked so metadata fetchers can't stamp a TMDB ID on it (#433).
+        /// </summary>
+        private async Task<Guid> CreateBoxSetViaReflectionAsync(Type boxSetType, string formattedName, LinkedChild[] linkedChildren, CancellationToken cancellationToken)
+        {
+            var boxSet = Activator.CreateInstance(boxSetType)
+                ?? throw new InvalidOperationException("Failed to create BoxSet instance via reflection");
+            var baseItem = (BaseItem)boxSet;
+
+            // Set ID first - must be set before persisting
+            var newCollectionId = Guid.NewGuid();
+            boxSetType.GetProperty("Id")?.SetValue(boxSet, newCollectionId);
+            _logger.LogDebug("Generated new collection ID: {CollectionId}", newCollectionId);
+
+            boxSetType.GetProperty("Name")?.SetValue(boxSet, formattedName);
+            boxSetType.GetProperty("LinkedChildren")?.SetValue(boxSet, linkedChildren);
+            boxSetType.GetProperty("IsLocked")?.SetValue(boxSet, true);
+
+            // Add to library manager - use CreateItemAsync if available, otherwise try UpdateToRepositoryAsync
+            var createItemMethod = _libraryManager.GetType().GetMethod("CreateItemAsync", new[] { typeof(BaseItem), typeof(CancellationToken) });
+            if (createItemMethod != null)
+            {
+                await ((Task)createItemMethod.Invoke(_libraryManager, new object[] { baseItem, cancellationToken })!).ConfigureAwait(false);
+            }
+            else
+            {
+                // Fallback: try UpdateToRepositoryAsync
+                await baseItem.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
+            }
+
+            _logger.LogDebug("BoxSet created with ID: {CollectionId}", baseItem.Id);
+            return baseItem.Id;
         }
 
         private Task ApplyCustomMetadataAsync(BaseItem item, SmartListDto dto, User ownerUser, CancellationToken cancellationToken)

--- a/docs/content/user-guide/configuration.md
+++ b/docs/content/user-guide/configuration.md
@@ -40,6 +40,9 @@ Before creating your first list, it's important to understand the differences be
 - **Can Contain Collections**: Unlike playlists, collections can contain other collection objects (creating "meta-collections") when using the "Include collections only" option with the Collection name field
 - **Use cases**: Organizing related content for browsing (e.g., "Action Movies", "Holiday Collection", "Director's Collection")
 
+!!! info "Smart collections are metadata-locked"
+    SmartLists creates its collections with Jellyfin's **"Lock this item"** flag enabled, and re-applies it on every refresh. This prevents Jellyfin's metadata fetchers from matching the collection against online databases by name and stamping a foreign TMDB ID on it — a mismatch that causes the TMDbBoxSets plugin to delete the collection as "orphaned". The lock does not affect cover image generation or any metadata set through SmartLists. If you untick the lock manually, it will be re-enabled on the next refresh.
+
 #### Automatic Image Generation
 
 SmartLists automatically generates cover images for collections when no custom images have been provided. Auto-generation occurs only if:


### PR DESCRIPTION
## What
Stops smart collections from disappearing (#433) by locking them against metadata fetchers, and eliminates the concurrent `collection.xml` saver IOExceptions from the same issue.

## Why
Jellyfin queues a metadata refresh whenever a collection is created or gets items added. The TMDB boxset fetcher matches collections **by name** and stamps a foreign TMDB ID on them (reproduced: a smart collection named "Avengers" gets `Tmdb: 522577` seconds after creation). Since TMDbBoxSets added orphan cleanup (jellyfin-plugin-tmdbboxsets#113, Dec 2025), it deletes any boxset whose TMDB ID doesn't map to actual movies — which is always the case for rule-driven smart collections. The reporter's log shows exactly this: `Removing orphaned box set "Comics [Smart]" ("1275896")`.

The same issue thread's `Error in metadata saver` IOExceptions came from the creation path running three overlapping metadata refreshes (two core-queued + the plugin's own direct `RefreshSingleItem`), each writing `collection.xml` with no cross-writer lock.

## Changes
- Create collections with `IsLocked = true` — Jellyfin skips metadata providers for locked items while image refresh still runs; cover collage generation is unaffected.
- Enforce the lock and strip stray `Tmdb` provider IDs centrally in `FinalizeCollectionMetadataAsync`, which every create/refresh path flows through — collections that already carry a TMDB ID heal on their first refresh after updating.
- Pass `ItemIdList` + the SmartLists provider-ID tether via `CollectionCreationOptions`, so core adds items internally and queues **one** background refresh instead of two (the old separate `AddToCollectionAsync` call is kept as a guarded fallback for unknown ABIs); the tether dictionary uses `OrdinalIgnoreCase` to match `BaseItem.ProviderIds`' contract.
- Drop the redundant direct `RefreshSingleItem` on the creation path — its cover-image job was already done by `SetPhotoForCollection`.
- Unlock collections and remove the tether when the `[Smart]` suffix is removed and the collection is handed back to the user.
- Docs: note in the user guide that smart collections are metadata-locked and why.

## Verification
E2E against the local dev Jellyfin (12.0.0): new collection never acquires a TMDB ID (pre-fix: stamped within seconds), stays locked, gets its collage; a manually stamped+unlocked collection is stripped and re-locked on refresh; suffix-removal hands back an unlocked, untethered collection; playlists unaffected; zero `[ERR]` lines. Behavior note: `ItemsAddedToCollection` no longer fires at creation (core's internal add uses `fireEvent: false`) — consistent with the update path, which never fired it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBFLcyWKuktDSu9acy68zg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved smart-collection refresh/creation locking to prevent competing metadata and image updates.
  * Ensured smart collections are correctly locked/unlocked during rename/prefix-suffix cleanup while keeping SmartLists association consistent.
  * Prevented duplicate item writes during smart-collection creation.
  * Consolidated cover image behavior and removed conflicting TMDb provider associations during metadata finalization.

* **Documentation**
  * Added a note explaining that Smart collections are metadata-locked by SmartLists, including how refresh affects the lock and what it does/doesn’t impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->