### PR TITLE
Mid-block rotation hold for Least Recently Watched Round Robin

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs
@@ -582,7 +582,12 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
                     var lastPlayed = aggregateLastPlayed
                         ?? LastPlayedOrderBase.GetLastPlayedDateFromUserData(userData);
 
-                    if (lastPlayed > DateTime.MinValue &&
+                    // Only fully played items advance the rotation: Jellyfin stamps LastPlayedDate
+                    // on any playback, so a half-watched episode must not send its group to the
+                    // back. Folder items keep the aggregate date (their Played flag is unreliable).
+                    var countsForRecency = aggregateLastPlayed != null || userData?.Played == true;
+
+                    if (countsForRecency && lastPlayed > DateTime.MinValue &&
                         (!recency.TryGetValue(key, out var existing) || lastPlayed > existing))
                     {
                         recency[key] = lastPlayed;

--- a/Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs
@@ -472,7 +472,10 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
         /// pool (rules like "Playback Status is Unwatched" remove watched items from the results,
         /// so recency derived from filtered items would see every group as never watched).
         /// Set by SmartList before <see cref="RoundRobinBase.PreComputePositions"/>.
-        /// Groups absent from the map are treated as never watched and sort first.
+        /// Groups absent from the map are treated as never watched and sort first — including
+        /// groups held mid-block: with Collections grouping and air-date order, a group whose
+        /// next unwatched episode aired within <see cref="RoundRobinBase.AirBlockWindowDays"/>
+        /// days of its most recently watched one stays at the front until the block is finished.
         /// </summary>
         public Dictionary<string, DateTime> GroupRecency { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
@@ -488,6 +491,10 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
         /// Builds the group key → most recent LastPlayedDate map for one user across the given items.
         /// Container items (Series/Season/MusicAlbum) use the aggregate-over-children date when the
         /// refresh cache has their children, mirroring LastPlayedOrderBase.
+        /// When <paramref name="airBlockWindowDays"/> is set (Collections grouping with air-date
+        /// order), groups that are mid-way through an air block — the earliest unwatched air date
+        /// lies within the window of the most recently watched item's air date — are omitted from
+        /// the map so they hold their spot at the front of the rotation until the block is finished.
         /// </summary>
         internal static Dictionary<string, DateTime> BuildGroupRecency(
             IEnumerable<BaseItem> items,
@@ -496,7 +503,8 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
             IUserDataManager? userDataManager,
             RefreshQueueService.RefreshCache? refreshCache,
             ILogger? logger,
-            Dictionary<Guid, string>? collectionGroupKeys = null)
+            Dictionary<Guid, string>? collectionGroupKeys = null,
+            int? airBlockWindowDays = null)
         {
             var recency = new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
             if (string.IsNullOrEmpty(groupByField) || userDataManager == null || user == null)
@@ -504,6 +512,11 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
                 logger?.LogWarning("Least Recently Watched Round Robin: missing GroupByField or user context - groups fall back to alphabetical order");
                 return recency;
             }
+
+            // Per-group (airDate, lastPlayed) pairs, collected only when the mid-block hold is active
+            var groupItems = airBlockWindowDays.HasValue
+                ? new Dictionary<string, List<(DateTime Air, DateTime LastPlayed)>>(StringComparer.OrdinalIgnoreCase)
+                : null;
 
             foreach (var item in items)
             {
@@ -522,6 +535,17 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
                     {
                         recency[key] = lastPlayed;
                     }
+
+                    if (groupItems != null)
+                    {
+                        if (!groupItems.TryGetValue(key, out var list))
+                        {
+                            list = new List<(DateTime Air, DateTime LastPlayed)>();
+                            groupItems[key] = list;
+                        }
+
+                        list.Add((OrderUtilities.GetReleaseDate(item).Date, lastPlayed));
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -529,7 +553,69 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
                 }
             }
 
+            if (groupItems != null && airBlockWindowDays.HasValue)
+            {
+                ApplyMidBlockHold(recency, groupItems, Math.Clamp(airBlockWindowDays.Value, 0, 30), logger);
+            }
+
             return recency;
+        }
+
+        /// <summary>
+        /// Removes groups that are mid-way through an air block from the recency map: a group whose
+        /// earliest unwatched air date is at or after — and within <paramref name="windowDays"/> days
+        /// of — the air date of its most recently watched item sorts with the never-watched groups
+        /// at the front, so the rest of the block plays before the group rotates to the back.
+        /// Groups with no watch data, or without air dates on the relevant items, are left untouched.
+        /// </summary>
+        internal static void ApplyMidBlockHold(
+            Dictionary<string, DateTime> recency,
+            Dictionary<string, List<(DateTime Air, DateTime LastPlayed)>> groupItems,
+            int windowDays,
+            ILogger? logger)
+        {
+            foreach (var kvp in groupItems)
+            {
+                if (!recency.ContainsKey(kvp.Key))
+                {
+                    continue; // never watched - already at the front
+                }
+
+                // Air date of the most recently watched item in the group
+                var watchedAir = DateTime.MinValue;
+                var bestPlayed = DateTime.MinValue;
+                foreach (var (air, played) in kvp.Value)
+                {
+                    if (played > bestPlayed)
+                    {
+                        bestPlayed = played;
+                        watchedAir = air;
+                    }
+                }
+
+                if (watchedAir == DateTime.MinValue)
+                {
+                    continue; // watched item has no air date - normal rotation
+                }
+
+                // Earliest unwatched air date at or after the watched one
+                var nextUnwatchedAir = DateTime.MaxValue;
+                foreach (var (air, played) in kvp.Value)
+                {
+                    if (played == DateTime.MinValue && air > DateTime.MinValue && air >= watchedAir && air < nextUnwatchedAir)
+                    {
+                        nextUnwatchedAir = air;
+                    }
+                }
+
+                if (nextUnwatchedAir != DateTime.MaxValue && (nextUnwatchedAir - watchedAir).TotalDays <= windowDays)
+                {
+                    recency.Remove(kvp.Key);
+                    logger?.LogDebug(
+                        "Least Recently Watched Round Robin: holding group '{GroupKey}' at the front - next unwatched episode aired {Days} day(s) after the last watched one (window {Window})",
+                        kvp.Key, (nextUnwatchedAir - watchedAir).TotalDays, windowDays);
+                }
+            }
         }
     }
 }

--- a/Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs
@@ -47,6 +47,12 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
         public const int DefaultAirBlockWindowDays = 3;
 
         /// <summary>
+        /// Maximum allowed air-block window in days. The interleave and the mid-block hold both
+        /// clamp to the same bounds so they always agree on block boundaries.
+        /// </summary>
+        public const int MaxAirBlockWindowDays = 30;
+
+        /// <summary>
         /// Window in days for chaining episodes of different shows into one interleave block,
         /// active only when grouping by Collections with air-date within-group order.
         /// 0 means same-day only. Set from SortOption.AirBlockWindowDays (null = default).
@@ -57,6 +63,13 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
         /// When true, items within each group are shuffled instead of sorted in natural order.
         /// </summary>
         protected virtual bool ShuffleWithinGroups => false;
+
+        /// <summary>
+        /// True when this order interleaves air blocks: Collections grouping with air-date
+        /// within-group order (shuffle wins over air-date order, so shuffled variants never
+        /// use blocks). Single source of the gate shared by SmartList and the interleave.
+        /// </summary>
+        internal bool UsesAirBlocks => GroupByField == "Collections" && OrderWithinGroupsByAirDate && !ShuffleWithinGroups;
 
         /// <summary>
         /// Pre-computed interleave positions for each item.
@@ -77,7 +90,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
         /// With Collections grouping and air-date order, each cycle emits one air block
         /// (episodes that aired within <see cref="AirBlockWindowDays"/> days of each other) instead of one item.
         /// </summary>
-        public void PreComputePositions(IEnumerable<BaseItem> items, ILogger? logger = null)
+        public virtual void PreComputePositions(IEnumerable<BaseItem> items, ILogger? logger = null)
         {
             ItemPositions = BuildInterleavedPositions(items, GroupByField, OrderGroupKeys, Name, logger, ShuffleWithinGroups, CollectionGroupKeys, OrderWithinGroupsByAirDate, AirBlockWindowDays);
         }
@@ -202,7 +215,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
             }
             else
             {
-                int windowDays = Math.Clamp(airBlockWindowDays, 0, 30);
+                int windowDays = Math.Clamp(airBlockWindowDays, 0, MaxAirBlockWindowDays);
                 var groupBlocks = new Dictionary<string, List<List<BaseItem>>>(StringComparer.OrdinalIgnoreCase);
                 foreach (var kvp in groups)
                 {
@@ -489,47 +502,66 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
         }
 
         /// <summary>
-        /// Builds the group key → most recent LastPlayedDate map for one user across the given items.
-        /// Container items (Series/Season/MusicAlbum) use the aggregate-over-children date when the
-        /// refresh cache has their children, mirroring LastPlayedOrderBase.
-        /// When <paramref name="airBlockWindowDays"/> is set (Collections grouping with air-date
-        /// order), groups that are mid-way through an air block — the block containing the most
-        /// recently watched item still has unwatched items — are omitted from the map so they hold
-        /// their spot at the front of the rotation until the block is finished.
+        /// Per-group collection items the user has interacted with (Played flag set or a
+        /// LastPlayedDate), with their per-user LastPlayedDate and air date. Collected from the
+        /// UNFILTERED pool by <see cref="BuildGroupRecencyAndHoldState"/> when air blocks are
+        /// active; anchors the mid-block hold. In-progress items (a LastPlayedDate but no Played
+        /// flag) appear here AND in <see cref="UnwatchedCollectionItemIds"/>.
         /// </summary>
-        internal static Dictionary<string, DateTime> BuildGroupRecency(
+        internal Dictionary<string, List<(BaseItem Item, DateTime LastPlayed, DateTime Air)>>? WatchedByGroup { get; private set; }
+
+        /// <summary>
+        /// Ids of collection-member items whose Played flag is unset, from the UNFILTERED pool.
+        /// Matches the "Playback Status" rule semantics: imported watch states without a
+        /// timestamp count as watched, started-but-unfinished items count as unwatched.
+        /// </summary>
+        internal HashSet<Guid>? UnwatchedCollectionItemIds { get; private set; }
+
+        /// <summary>
+        /// Builds <see cref="GroupRecency"/> (group key → most recent per-user LastPlayedDate)
+        /// for one user across the given items. Container items (Series/Season/MusicAlbum) use
+        /// the aggregate-over-children date when the refresh cache has their children, mirroring
+        /// LastPlayedOrderBase. When air blocks are active (<see cref="RoundRobinBase.UsesAirBlocks"/>),
+        /// also collects the per-group watch state the mid-block hold needs; the hold itself runs
+        /// later, in <see cref="PreComputePositions"/>, once the playlist's filtered items are known.
+        /// </summary>
+        internal void BuildGroupRecencyAndHoldState(
             IEnumerable<BaseItem> items,
-            string? groupByField,
             User user,
             IUserDataManager? userDataManager,
             RefreshQueueService.RefreshCache? refreshCache,
-            ILogger? logger,
-            Dictionary<Guid, string>? collectionGroupKeys = null,
-            int? airBlockWindowDays = null)
+            ILogger? logger)
         {
             var recency = new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
-            if (string.IsNullOrEmpty(groupByField) || userDataManager == null || user == null)
+            GroupRecency = recency;
+            WatchedByGroup = null;
+            UnwatchedCollectionItemIds = null;
+
+            if (string.IsNullOrEmpty(GroupByField) || userDataManager == null || user == null)
             {
                 logger?.LogWarning("Least Recently Watched Round Robin: missing GroupByField or user context - groups fall back to alphabetical order");
-                return recency;
+                return;
             }
 
-            // Per-group items with their per-user last played dates, collected only when the mid-block hold is active
-            var groupItems = airBlockWindowDays.HasValue
-                ? new Dictionary<string, List<(BaseItem Item, DateTime LastPlayed)>>(StringComparer.OrdinalIgnoreCase)
-                : null;
+            var collectHoldState = UsesAirBlocks && CollectionGroupKeys != null;
+            if (collectHoldState)
+            {
+                WatchedByGroup = new Dictionary<string, List<(BaseItem Item, DateTime LastPlayed, DateTime Air)>>(StringComparer.OrdinalIgnoreCase);
+                UnwatchedCollectionItemIds = new HashSet<Guid>();
+            }
 
             foreach (var item in items)
             {
                 try
                 {
-                    var key = ExtractGroupKey(item, groupByField, collectionGroupKeys);
+                    var key = ExtractGroupKey(item, GroupByField, CollectionGroupKeys);
+
+                    var userData = refreshCache != null
+                        ? UserDataCacheHelper.GetCachedUserData(user, item, refreshCache, userDataManager)
+                        : userDataManager.GetUserData(user, item);
 
                     var lastPlayed = LastPlayedOrderBase.GetAggregateLastPlayedDate(item, user, userDataManager, refreshCache)
-                        ?? LastPlayedOrderBase.GetLastPlayedDateFromUserData(
-                            refreshCache != null
-                                ? UserDataCacheHelper.GetCachedUserData(user, item, refreshCache, userDataManager)
-                                : userDataManager.GetUserData(user, item));
+                        ?? LastPlayedOrderBase.GetLastPlayedDateFromUserData(userData);
 
                     if (lastPlayed > DateTime.MinValue &&
                         (!recency.TryGetValue(key, out var existing) || lastPlayed > existing))
@@ -537,15 +569,23 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
                         recency[key] = lastPlayed;
                     }
 
-                    if (groupItems != null)
+                    if (collectHoldState && CollectionGroupKeys!.ContainsKey(item.Id))
                     {
-                        if (!groupItems.TryGetValue(key, out var list))
+                        if (userData?.Played == true || lastPlayed > DateTime.MinValue)
                         {
-                            list = new List<(BaseItem Item, DateTime LastPlayed)>();
-                            groupItems[key] = list;
+                            if (!WatchedByGroup!.TryGetValue(key, out var list))
+                            {
+                                list = new List<(BaseItem Item, DateTime LastPlayed, DateTime Air)>();
+                                WatchedByGroup[key] = list;
+                            }
+
+                            list.Add((item, lastPlayed, OrderUtilities.GetReleaseDate(item).Date));
                         }
 
-                        list.Add((item, lastPlayed));
+                        if (userData?.Played != true)
+                        {
+                            UnwatchedCollectionItemIds!.Add(item.Id);
+                        }
                     }
                 }
                 catch (Exception ex)
@@ -553,96 +593,124 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
                     logger?.LogWarning(ex, "Error reading last played date for item {ItemName}", item.Name);
                 }
             }
-
-            if (groupItems != null && airBlockWindowDays.HasValue)
-            {
-                ApplyMidBlockHold(recency, groupItems, Math.Clamp(airBlockWindowDays.Value, 0, 30), logger);
-            }
-
-            return recency;
         }
 
         /// <summary>
-        /// Removes groups that are mid-way through an air block from the recency map: the group's
-        /// air blocks are rebuilt exactly as the interleave builds them (air-date order +
-        /// <see cref="RoundRobinBase.ChunkIntoAirBlocks"/>, so blocks only chain across different
-        /// shows), and a group whose most recently watched item sits in a block that still has an
-        /// unwatched item airing at or after it sorts with the never-watched groups at the front,
-        /// so the rest of the block plays before the group rotates to the back. Single-show groups
-        /// always form blocks of one and rotate normally, and a finished block rotates even when
-        /// the next block aired within the window.
-        /// Groups with no watch data, or without air dates on the relevant items, are left untouched.
+        /// Applies the mid-block hold against the playlist's filtered items, then computes
+        /// interleave positions as usual. A collection group mid-way through an air block keeps
+        /// its front-of-rotation spot only while the playlist can still play something from that
+        /// block.
         /// </summary>
-        internal static void ApplyMidBlockHold(
-            Dictionary<string, DateTime> recency,
-            Dictionary<string, List<(BaseItem Item, DateTime LastPlayed)>> groupItems,
-            int windowDays,
-            ILogger? logger)
+        public override void PreComputePositions(IEnumerable<BaseItem> items, ILogger? logger = null)
         {
-            foreach (var kvp in groupItems)
+            var itemsList = items as List<BaseItem> ?? items.ToList();
+            ApplyMidBlockHold(itemsList, logger);
+            base.PreComputePositions(itemsList, logger);
+        }
+
+        /// <summary>
+        /// Removes groups that are mid-way through an air block from <see cref="GroupRecency"/>
+        /// so they sort with the never-watched groups at the front until the block is finished.
+        /// Block topology is the union of the playlist's FILTERED items and the user's watched
+        /// items (watched items anchor a block even when a "Playback Status" rule hides them),
+        /// rebuilt with the interleave's own pipeline (air-date sort +
+        /// <see cref="RoundRobinBase.ChunkIntoAirBlocks"/>). A hold fires only when the anchor's
+        /// block still has an unwatched item the playlist can actually show — items excluded by
+        /// other rules never pin a group. The anchor is the most recently played item, with ties
+        /// broken by latest air date so bulk-marked histories resolve deterministically.
+        /// </summary>
+        internal void ApplyMidBlockHold(List<BaseItem> filteredItems, ILogger? logger)
+        {
+            if (WatchedByGroup == null || WatchedByGroup.Count == 0 || UnwatchedCollectionItemIds == null || CollectionGroupKeys == null)
             {
-                if (!recency.ContainsKey(kvp.Key))
+                return;
+            }
+
+            // Visible items per group with watch data (single pass over the playlist items)
+            var visibleByGroup = new Dictionary<string, List<BaseItem>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var item in filteredItems)
+            {
+                if (CollectionGroupKeys.TryGetValue(item.Id, out var key) && WatchedByGroup.ContainsKey(key))
                 {
-                    continue; // never watched - already at the front
+                    if (!visibleByGroup.TryGetValue(key, out var list))
+                    {
+                        list = new List<BaseItem>();
+                        visibleByGroup[key] = list;
+                    }
+
+                    list.Add(item);
+                }
+            }
+
+            var windowDays = Math.Clamp(AirBlockWindowDays, 0, MaxAirBlockWindowDays);
+
+            foreach (var kvp in WatchedByGroup)
+            {
+                if (!GroupRecency.ContainsKey(kvp.Key) || !visibleByGroup.TryGetValue(kvp.Key, out var visible))
+                {
+                    continue; // no recency to override, or nothing this playlist can play
                 }
 
-                // Most recently watched item in the group
-                BaseItem? watched = null;
+                // Anchor: most recently played item, ties broken by latest air date
+                BaseItem? anchor = null;
                 var bestPlayed = DateTime.MinValue;
-                var lastPlayedById = new Dictionary<Guid, DateTime>();
-                foreach (var (item, played) in kvp.Value)
+                var bestAir = DateTime.MinValue;
+                foreach (var (item, lastPlayed, air) in kvp.Value)
                 {
-                    lastPlayedById[item.Id] = played;
-                    if (played > bestPlayed)
+                    if (lastPlayed > bestPlayed || (lastPlayed > DateTime.MinValue && lastPlayed == bestPlayed && air > bestAir))
                     {
-                        bestPlayed = played;
-                        watched = item;
+                        anchor = item;
+                        bestPlayed = lastPlayed;
+                        bestAir = air;
                     }
                 }
 
-                if (watched == null)
+                if (anchor == null || bestAir == DateTime.MinValue)
                 {
-                    continue; // no watch data - normal rotation
+                    continue; // no dated watch history - normal rotation
                 }
 
-                var watchedId = watched.Id;
-                var watchedAir = OrderUtilities.GetReleaseDate(watched).Date;
-                if (watchedAir == DateTime.MinValue)
+                // Block topology: filtered items plus watched items, deduped by id
+                var unionIds = new HashSet<Guid>();
+                var union = new List<BaseItem>(visible.Count + kvp.Value.Count);
+                foreach (var item in visible)
                 {
-                    continue; // watched item has no air date - normal rotation
+                    if (unionIds.Add(item.Id))
+                    {
+                        union.Add(item);
+                    }
                 }
 
-                // Rebuild this group's air blocks the same way the interleave does and find the
-                // block containing the watched item.
-                var sorted = new List<BaseItem>(kvp.Value.Count);
-                foreach (var (item, _) in kvp.Value)
+                foreach (var (item, _, _) in kvp.Value)
                 {
-                    sorted.Add(item);
+                    if (unionIds.Add(item.Id))
+                    {
+                        union.Add(item);
+                    }
                 }
 
-                sorted.Sort((a, b) => CompareWithinGroupByAirDate(a, b));
-
-                foreach (var block in ChunkIntoAirBlocks(sorted, windowDays))
+                var visibleIds = new HashSet<Guid>();
+                foreach (var item in visible)
                 {
-                    if (!block.Exists(i => i.Id == watchedId))
+                    visibleIds.Add(item.Id);
+                }
+
+                union.Sort((a, b) => CompareWithinGroupByAirDate(a, b));
+
+                var anchorId = anchor.Id;
+                foreach (var block in ChunkIntoAirBlocks(union, windowDays))
+                {
+                    if (!block.Exists(i => i.Id == anchorId))
                     {
                         continue;
                     }
 
-                    // Hold only while THAT block still has an unwatched item at or after the
-                    // watched air date.
-                    foreach (var item in block)
+                    if (block.Exists(i => visibleIds.Contains(i.Id) && UnwatchedCollectionItemIds.Contains(i.Id)))
                     {
-                        if (lastPlayedById.TryGetValue(item.Id, out var played)
-                            && played == DateTime.MinValue
-                            && OrderUtilities.GetReleaseDate(item).Date >= watchedAir)
-                        {
-                            recency.Remove(kvp.Key);
-                            logger?.LogDebug(
-                                "Least Recently Watched Round Robin: holding group '{GroupKey}' at the front - its current air block still has unwatched item(s) (window {Window})",
-                                kvp.Key, windowDays);
-                            break;
-                        }
+                        GroupRecency.Remove(kvp.Key);
+                        logger?.LogDebug(
+                            "Least Recently Watched Round Robin: holding group '{GroupKey}' at the front - its current air block still has unwatched item(s) in the playlist (window {Window})",
+                            kvp.Key, windowDays);
                     }
 
                     break;

--- a/Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs
@@ -569,11 +569,17 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
                 {
                     var key = ExtractGroupKey(item, GroupByField, CollectionGroupKeys);
 
-                    var userData = refreshCache != null
-                        ? UserDataCacheHelper.GetCachedUserData(user, item, refreshCache, userDataManager)
-                        : userDataManager.GetUserData(user, item);
+                    // Fetch user data lazily: only when the aggregate date can't answer recency,
+                    // or when the item feeds the mid-block hold (Played flag needed).
+                    var isHoldMember = collectHoldState && CollectionGroupKeys!.ContainsKey(item.Id);
+                    var aggregateLastPlayed = LastPlayedOrderBase.GetAggregateLastPlayedDate(item, user, userDataManager, refreshCache);
+                    var userData = aggregateLastPlayed == null || isHoldMember
+                        ? (refreshCache != null
+                            ? UserDataCacheHelper.GetCachedUserData(user, item, refreshCache, userDataManager)
+                            : userDataManager.GetUserData(user, item))
+                        : null;
 
-                    var lastPlayed = LastPlayedOrderBase.GetAggregateLastPlayedDate(item, user, userDataManager, refreshCache)
+                    var lastPlayed = aggregateLastPlayed
                         ?? LastPlayedOrderBase.GetLastPlayedDateFromUserData(userData);
 
                     if (lastPlayed > DateTime.MinValue &&
@@ -582,7 +588,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
                         recency[key] = lastPlayed;
                     }
 
-                    if (collectHoldState && CollectionGroupKeys!.ContainsKey(item.Id))
+                    if (isHoldMember)
                     {
                         if (userData?.Played == true || lastPlayed > DateTime.MinValue)
                         {
@@ -666,13 +672,30 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
                     continue; // no recency to override, or nothing this playlist can play
                 }
 
-                // Anchor: most recently played item, ties broken by latest air date
+                // Anchor: most recently played item, ties broken by latest air date, then by
+                // item id so equal timestamps AND air dates (bulk marks) stay deterministic.
                 BaseItem? anchor = null;
                 var bestPlayed = DateTime.MinValue;
                 var bestAir = DateTime.MinValue;
                 foreach (var (item, lastPlayed, air) in kvp.Value)
                 {
-                    if (lastPlayed > bestPlayed || (lastPlayed > DateTime.MinValue && lastPlayed == bestPlayed && air > bestAir))
+                    if (lastPlayed == DateTime.MinValue)
+                    {
+                        continue; // no timestamp - never anchors
+                    }
+
+                    var cmp = lastPlayed.CompareTo(bestPlayed);
+                    if (cmp == 0)
+                    {
+                        cmp = air.CompareTo(bestAir);
+                    }
+
+                    if (cmp == 0 && anchor != null)
+                    {
+                        cmp = item.Id.CompareTo(anchor.Id);
+                    }
+
+                    if (anchor == null || cmp > 0)
                     {
                         anchor = item;
                         bestPlayed = lastPlayed;

--- a/Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs
@@ -496,10 +496,19 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
         protected override List<string> OrderGroupKeys(IEnumerable<string> keys)
         {
             return keys
-                .OrderBy(k => GroupRecency.TryGetValue(k, out var d) ? d : DateTime.MinValue)
+                .OrderBy(k => HeldGroups.Contains(k) || !GroupRecency.TryGetValue(k, out var d) ? DateTime.MinValue : d)
                 .ThenBy(k => k, OrderUtilities.SharedNaturalComparer)
                 .ToList();
         }
+
+        /// <summary>
+        /// Groups currently held mid-block: they sort as never watched (front of the rotation)
+        /// regardless of their recency. Recomputed from scratch on every
+        /// <see cref="PreComputePositions"/> call, so intermediate passes (e.g. per-group limits
+        /// sorting rule-group subsets) never leave a stale hold behind — the final pass over the
+        /// playlist's real item set wins.
+        /// </summary>
+        internal HashSet<string> HeldGroups { get; } = new(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Per-group collection items the user has interacted with (Played flag set or a
@@ -511,9 +520,13 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
         internal Dictionary<string, List<(BaseItem Item, DateTime LastPlayed, DateTime Air)>>? WatchedByGroup { get; private set; }
 
         /// <summary>
-        /// Ids of collection-member items whose Played flag is unset, from the UNFILTERED pool.
-        /// Matches the "Playback Status" rule semantics: imported watch states without a
-        /// timestamp count as watched, started-but-unfinished items count as unwatched.
+        /// Ids of collection-member items that count as unwatched for the hold, from the
+        /// UNFILTERED pool. For regular items this matches the "Playback Status" rule semantics:
+        /// Played flag unset is unwatched, so imported watch states without a timestamp count as
+        /// watched and started-but-unfinished items count as unwatched. Folder items (Series and
+        /// other containers) with any aggregate watch activity count as watched instead — Jellyfin
+        /// does not reliably persist the Played flag on folder user-data rows, so a fully-watched
+        /// Series would otherwise hold its group forever.
         /// </summary>
         internal HashSet<Guid>? UnwatchedCollectionItemIds { get; private set; }
 
@@ -582,7 +595,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
                             list.Add((item, lastPlayed, OrderUtilities.GetReleaseDate(item).Date));
                         }
 
-                        if (userData?.Played != true)
+                        if (userData?.Played != true && !(item.IsFolder && lastPlayed > DateTime.MinValue))
                         {
                             UnwatchedCollectionItemIds!.Add(item.Id);
                         }
@@ -609,11 +622,11 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
         }
 
         /// <summary>
-        /// Removes groups that are mid-way through an air block from <see cref="GroupRecency"/>
-        /// so they sort with the never-watched groups at the front until the block is finished.
-        /// Block topology is the union of the playlist's FILTERED items and the user's watched
-        /// items (watched items anchor a block even when a "Playback Status" rule hides them),
-        /// rebuilt with the interleave's own pipeline (air-date sort +
+        /// Recomputes <see cref="HeldGroups"/>: groups mid-way through an air block sort with the
+        /// never-watched groups at the front until the block is finished. Block topology is the
+        /// union of the playlist's FILTERED items and the user's watched items (watched items
+        /// anchor a block even when a "Playback Status" rule hides them), rebuilt with the
+        /// interleave's own pipeline (air-date sort +
         /// <see cref="RoundRobinBase.ChunkIntoAirBlocks"/>). A hold fires only when the anchor's
         /// block still has an unwatched item the playlist can actually show — items excluded by
         /// other rules never pin a group. The anchor is the most recently played item, with ties
@@ -621,6 +634,8 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
         /// </summary>
         internal void ApplyMidBlockHold(List<BaseItem> filteredItems, ILogger? logger)
         {
+            HeldGroups.Clear();
+
             if (WatchedByGroup == null || WatchedByGroup.Count == 0 || UnwatchedCollectionItemIds == null || CollectionGroupKeys == null)
             {
                 return;
@@ -707,7 +722,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
 
                     if (block.Exists(i => visibleIds.Contains(i.Id) && UnwatchedCollectionItemIds.Contains(i.Id)))
                     {
-                        GroupRecency.Remove(kvp.Key);
+                        HeldGroups.Add(kvp.Key);
                         logger?.LogDebug(
                             "Least Recently Watched Round Robin: holding group '{GroupKey}' at the front - its current air block still has unwatched item(s) in the playlist (window {Window})",
                             kvp.Key, windowDays);

--- a/Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs
@@ -474,8 +474,9 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
         /// Set by SmartList before <see cref="RoundRobinBase.PreComputePositions"/>.
         /// Groups absent from the map are treated as never watched and sort first — including
         /// groups held mid-block: with Collections grouping and air-date order, a group whose
-        /// next unwatched episode aired within <see cref="RoundRobinBase.AirBlockWindowDays"/>
-        /// days of its most recently watched one stays at the front until the block is finished.
+        /// most recently watched item sits in an air block (see
+        /// <see cref="RoundRobinBase.ChunkIntoAirBlocks"/>) that still has unwatched items
+        /// stays at the front until the block is finished.
         /// </summary>
         public Dictionary<string, DateTime> GroupRecency { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
@@ -492,9 +493,9 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
         /// Container items (Series/Season/MusicAlbum) use the aggregate-over-children date when the
         /// refresh cache has their children, mirroring LastPlayedOrderBase.
         /// When <paramref name="airBlockWindowDays"/> is set (Collections grouping with air-date
-        /// order), groups that are mid-way through an air block — the earliest unwatched air date
-        /// lies within the window of the most recently watched item's air date — are omitted from
-        /// the map so they hold their spot at the front of the rotation until the block is finished.
+        /// order), groups that are mid-way through an air block — the block containing the most
+        /// recently watched item still has unwatched items — are omitted from the map so they hold
+        /// their spot at the front of the rotation until the block is finished.
         /// </summary>
         internal static Dictionary<string, DateTime> BuildGroupRecency(
             IEnumerable<BaseItem> items,
@@ -513,9 +514,9 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
                 return recency;
             }
 
-            // Per-group (airDate, lastPlayed) pairs, collected only when the mid-block hold is active
+            // Per-group items with their per-user last played dates, collected only when the mid-block hold is active
             var groupItems = airBlockWindowDays.HasValue
-                ? new Dictionary<string, List<(DateTime Air, DateTime LastPlayed)>>(StringComparer.OrdinalIgnoreCase)
+                ? new Dictionary<string, List<(BaseItem Item, DateTime LastPlayed)>>(StringComparer.OrdinalIgnoreCase)
                 : null;
 
             foreach (var item in items)
@@ -540,11 +541,11 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
                     {
                         if (!groupItems.TryGetValue(key, out var list))
                         {
-                            list = new List<(DateTime Air, DateTime LastPlayed)>();
+                            list = new List<(BaseItem Item, DateTime LastPlayed)>();
                             groupItems[key] = list;
                         }
 
-                        list.Add((OrderUtilities.GetReleaseDate(item).Date, lastPlayed));
+                        list.Add((item, lastPlayed));
                     }
                 }
                 catch (Exception ex)
@@ -562,15 +563,19 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
         }
 
         /// <summary>
-        /// Removes groups that are mid-way through an air block from the recency map: a group whose
-        /// earliest unwatched air date is at or after — and within <paramref name="windowDays"/> days
-        /// of — the air date of its most recently watched item sorts with the never-watched groups
-        /// at the front, so the rest of the block plays before the group rotates to the back.
+        /// Removes groups that are mid-way through an air block from the recency map: the group's
+        /// air blocks are rebuilt exactly as the interleave builds them (air-date order +
+        /// <see cref="RoundRobinBase.ChunkIntoAirBlocks"/>, so blocks only chain across different
+        /// shows), and a group whose most recently watched item sits in a block that still has an
+        /// unwatched item airing at or after it sorts with the never-watched groups at the front,
+        /// so the rest of the block plays before the group rotates to the back. Single-show groups
+        /// always form blocks of one and rotate normally, and a finished block rotates even when
+        /// the next block aired within the window.
         /// Groups with no watch data, or without air dates on the relevant items, are left untouched.
         /// </summary>
         internal static void ApplyMidBlockHold(
             Dictionary<string, DateTime> recency,
-            Dictionary<string, List<(DateTime Air, DateTime LastPlayed)>> groupItems,
+            Dictionary<string, List<(BaseItem Item, DateTime LastPlayed)>> groupItems,
             int windowDays,
             ILogger? logger)
         {
@@ -581,39 +586,66 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
                     continue; // never watched - already at the front
                 }
 
-                // Air date of the most recently watched item in the group
-                var watchedAir = DateTime.MinValue;
+                // Most recently watched item in the group
+                BaseItem? watched = null;
                 var bestPlayed = DateTime.MinValue;
-                foreach (var (air, played) in kvp.Value)
+                var lastPlayedById = new Dictionary<Guid, DateTime>();
+                foreach (var (item, played) in kvp.Value)
                 {
+                    lastPlayedById[item.Id] = played;
                     if (played > bestPlayed)
                     {
                         bestPlayed = played;
-                        watchedAir = air;
+                        watched = item;
                     }
                 }
 
+                if (watched == null)
+                {
+                    continue; // no watch data - normal rotation
+                }
+
+                var watchedId = watched.Id;
+                var watchedAir = OrderUtilities.GetReleaseDate(watched).Date;
                 if (watchedAir == DateTime.MinValue)
                 {
                     continue; // watched item has no air date - normal rotation
                 }
 
-                // Earliest unwatched air date at or after the watched one
-                var nextUnwatchedAir = DateTime.MaxValue;
-                foreach (var (air, played) in kvp.Value)
+                // Rebuild this group's air blocks the same way the interleave does and find the
+                // block containing the watched item.
+                var sorted = new List<BaseItem>(kvp.Value.Count);
+                foreach (var (item, _) in kvp.Value)
                 {
-                    if (played == DateTime.MinValue && air > DateTime.MinValue && air >= watchedAir && air < nextUnwatchedAir)
-                    {
-                        nextUnwatchedAir = air;
-                    }
+                    sorted.Add(item);
                 }
 
-                if (nextUnwatchedAir != DateTime.MaxValue && (nextUnwatchedAir - watchedAir).TotalDays <= windowDays)
+                sorted.Sort((a, b) => CompareWithinGroupByAirDate(a, b));
+
+                foreach (var block in ChunkIntoAirBlocks(sorted, windowDays))
                 {
-                    recency.Remove(kvp.Key);
-                    logger?.LogDebug(
-                        "Least Recently Watched Round Robin: holding group '{GroupKey}' at the front - next unwatched episode aired {Days} day(s) after the last watched one (window {Window})",
-                        kvp.Key, (nextUnwatchedAir - watchedAir).TotalDays, windowDays);
+                    if (!block.Exists(i => i.Id == watchedId))
+                    {
+                        continue;
+                    }
+
+                    // Hold only while THAT block still has an unwatched item at or after the
+                    // watched air date.
+                    foreach (var item in block)
+                    {
+                        if (lastPlayedById.TryGetValue(item.Id, out var played)
+                            && played == DateTime.MinValue
+                            && OrderUtilities.GetReleaseDate(item).Date >= watchedAir)
+                        {
+                            recency.Remove(kvp.Key);
+                            logger?.LogDebug(
+                                "Least Recently Watched Round Robin: holding group '{GroupKey}' at the front - its current air block still has unwatched item(s) (window {Window})",
+                                kvp.Key, windowDays);
+                            break;
+                        }
+                    }
+
+                    break;
                 }
             }
         }

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -781,13 +781,10 @@ namespace Jellyfin.Plugin.SmartLists.Core
 
                 foreach (var lrwOrder in Orders.OfType<RoundRobinLeastRecentlyWatchedOrder>())
                 {
-                    var airBlockWindowDays = lrwOrder.GroupByField == "Collections" && lrwOrder.OrderWithinGroupsByAirDate
-                        ? lrwOrder.AirBlockWindowDays
-                        : (int?)null;
-                    lrwOrder.GroupRecency = RoundRobinLeastRecentlyWatchedOrder.BuildGroupRecency(
-                        itemsArray, lrwOrder.GroupByField, user, userDataManager, refreshCache, logger,
-                        lrwOrder.GroupByField == "Collections" ? collectionGroupKeys : null,
-                        airBlockWindowDays);
+                    // Reads the order's own GroupByField/CollectionGroupKeys (injected above) and,
+                    // when air blocks are active, collects the state for the mid-block hold that
+                    // runs later in PreComputePositions against the filtered items.
+                    lrwOrder.BuildGroupRecencyAndHoldState(itemsArray, user, userDataManager, refreshCache, logger);
                 }
 
                 // Media type filtering is now handled at the API level in PlaylistService.GetAllUserMedia()

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -781,9 +781,13 @@ namespace Jellyfin.Plugin.SmartLists.Core
 
                 foreach (var lrwOrder in Orders.OfType<RoundRobinLeastRecentlyWatchedOrder>())
                 {
+                    var airBlockWindowDays = lrwOrder.GroupByField == "Collections" && lrwOrder.OrderWithinGroupsByAirDate
+                        ? lrwOrder.AirBlockWindowDays
+                        : (int?)null;
                     lrwOrder.GroupRecency = RoundRobinLeastRecentlyWatchedOrder.BuildGroupRecency(
                         itemsArray, lrwOrder.GroupByField, user, userDataManager, refreshCache, logger,
-                        lrwOrder.GroupByField == "Collections" ? collectionGroupKeys : null);
+                        lrwOrder.GroupByField == "Collections" ? collectionGroupKeys : null,
+                        airBlockWindowDays);
                 }
 
                 // Media type filtering is now handled at the API level in PlaylistService.GetAllUserMedia()

--- a/docs/content/examples/common-use-cases.md
+++ b/docs/content/examples/common-use-cases.md
@@ -121,7 +121,7 @@ Have franchise collections like NCIS or One Chicago where crossover episodes spa
 - **Sort by**: Least Recently Watched Round Robin (Interleave), **Group By**: Collection, **Order Within Group**: Air Date
 - **Auto Refresh**: On All Changes
 
-Result: Each collection becomes one slot in the rotation and plays chronologically across its shows — crossovers stay in order, and a spinoff only starts appearing once the timeline reaches its premiere. Episodes from different shows that aired within the **Air Window** (default 3 days) play back-to-back, so a crossover night comes as one run instead of being spread across rotation cycles. Shows not in any collection rotate as themselves. Watch anything in a franchise and the whole franchise moves to the back of the rotation.
+Result: Each collection becomes one slot in the rotation and plays chronologically across its shows — crossovers stay in order, and a spinoff only starts appearing once the timeline reaches its premiere. Episodes from different shows that aired within the **Air Window** (default 3 days) play back-to-back, so a crossover night comes as one run instead of being spread across rotation cycles. Shows not in any collection rotate as themselves. Watch anything in a franchise and the whole franchise moves to the back of the rotation — unless you stopped mid-way through a crossover block, in which case the collection stays at the front until you finish it.
 
 ### TV Channel with Commercials (Bumpers)
 Take any of the TV Channel playlists above and weave "commercial break" clips between the episodes:

--- a/docs/content/user-guide/sorting-and-limits.md
+++ b/docs/content/user-guide/sorting-and-limits.md
@@ -257,7 +257,7 @@ Unlike Random Round Robin, the rotation is not shuffled — it is derived entire
 
 With other auto-refresh modes the rotation still advances, but only at the next refresh (scheduled or on library changes).
 
-With **Group By: Collection**, the whole franchise carries one recency — watching any member sends the entire collection group to the back of the rotation. The exception is an unfinished air block: with **Order Within Group: Air Date**, a collection whose next unwatched episode aired within the **Air Window** of the one you just watched stays at the front until that block is finished, so watching part 1 of a crossover night never pushes parts 2 and 3 to the bottom.
+With **Group By: Collection**, the whole franchise carries one recency — watching any member sends the entire collection group to the back of the rotation. The exception is an unfinished air block: with **Order Within Group: Air Date**, a collection stays at the front while the air block you just watched from still has unwatched episodes, so watching part 1 of a crossover night never pushes parts 2 and 3 to the bottom. Once the block is finished, the collection rotates to the back as usual.
 
 !!! note "Per-user rotation"
     For playlists shared with multiple users, each user gets their own rotation based on their own watch history. Collections use the [reference user's](user-selection.md#collections-reference-user) watch history, so all users see the same rotation.

--- a/docs/content/user-guide/sorting-and-limits.md
+++ b/docs/content/user-guide/sorting-and-limits.md
@@ -257,7 +257,7 @@ Unlike Random Round Robin, the rotation is not shuffled — it is derived entire
 
 With other auto-refresh modes the rotation still advances, but only at the next refresh (scheduled or on library changes).
 
-With **Group By: Collection**, the whole franchise carries one recency — watching any member sends the entire collection group to the back of the rotation.
+With **Group By: Collection**, the whole franchise carries one recency — watching any member sends the entire collection group to the back of the rotation. The exception is an unfinished air block: with **Order Within Group: Air Date**, a collection whose next unwatched episode aired within the **Air Window** of the one you just watched stays at the front until that block is finished, so watching part 1 of a crossover night never pushes parts 2 and 3 to the bottom.
 
 !!! note "Per-user rotation"
     For playlists shared with multiple users, each user gets their own rotation based on their own watch history. Collections use the [reference user's](user-selection.md#collections-reference-user) watch history, so all users see the same rotation.

--- a/docs/content/user-guide/sorting-and-limits.md
+++ b/docs/content/user-guide/sorting-and-limits.md
@@ -257,7 +257,7 @@ Unlike Random Round Robin, the rotation is not shuffled — it is derived entire
 
 With other auto-refresh modes the rotation still advances, but only at the next refresh (scheduled or on library changes).
 
-With **Group By: Collection**, the whole franchise carries one recency — watching any member sends the entire collection group to the back of the rotation. The exception is an unfinished air block: with **Order Within Group: Air Date**, a collection stays at the front while the air block you just watched from still has unwatched episodes, so watching part 1 of a crossover night never pushes parts 2 and 3 to the bottom. Once the block is finished, the collection rotates to the back as usual.
+With **Group By: Collection**, the whole franchise carries one recency — watching any member sends the entire collection group to the back of the rotation. The exception is an unfinished air block: with **Order Within Group: Air Date**, a collection stays at the front while the air block you just watched from still has unwatched episodes **in the playlist**, so watching part 1 of a crossover night never pushes parts 2 and 3 to the bottom. Once the block is finished, the collection rotates to the back as usual — episodes hidden by the playlist's other rules never keep a collection at the front.
 
 !!! note "Per-user rotation"
     For playlists shared with multiple users, each user gets their own rotation based on their own watch history. Collections use the [reference user's](user-selection.md#collections-reference-user) watch history, so all users see the same rotation.

--- a/docs/content/user-guide/sorting-and-limits.md
+++ b/docs/content/user-guide/sorting-and-limits.md
@@ -232,7 +232,7 @@ Both the show rotation and the episode order within each show are random, and re
 4. No Sort Order is needed — both group order and item order are always randomized
 
 ### Least Recently Watched Round Robin (Interleave)
-Rotates through your shows starting with the one you watched **least** recently — shows you have never watched come first, and the show you watched most recently goes to the back of the rotation. Watch an episode of Show A today, and on the next refresh Show A moves to the end of the rotation while the other shows shift forward. Within each group, items stay in natural order (episodes by season/episode number), or air-date order if you set **Order Within Group** to Air Date.
+Rotates through your shows starting with the one you watched **least** recently — shows you have never watched come first, and the show you watched most recently goes to the back of the rotation. Watch an episode of Show A today, and on the next refresh Show A moves to the end of the rotation while the other shows shift forward. Only **fully watched** episodes advance the rotation: stopping half-way through an episode doesn't send the show to the back, so you can pick it up again from the front. Within each group, items stay in natural order (episodes by season/episode number), or air-date order if you set **Order Within Group** to Air Date.
 
 Unlike Random Round Robin, the rotation is not shuffled — it is derived entirely from your watch history, so it "continues where you left off" across refreshes, and refreshing without watching anything produces the same order.
 

--- a/docs/superpowers/specs/2026-07-15-mid-block-rotation-hold-design.md
+++ b/docs/superpowers/specs/2026-07-15-mid-block-rotation-hold-design.md
@@ -28,22 +28,34 @@ For each group, computed from the **unfiltered** media pool (same pool the
 recency map already uses):
 
 1. Find the most recently watched item (max per-user `LastPlayedDate`) and its
-   air date `wAir` (`OrderUtilities.GetReleaseDate(...).Date`).
-2. Find the earliest-airing **unwatched** item (per-user `LastPlayedDate`
-   missing/`MinValue`, from the same derivation the recency map uses) with a
-   known air date at or after `wAir`.
-3. If it aired **within the window** of `wAir` (`(nextAir - wAir).TotalDays <= window`),
-   the group is **mid-block**: omit it from the recency map, so it sorts with
-   the never-watched groups at the front (existing alphabetical tie-break).
-4. Otherwise (block finished, no unwatched left, or no air-date data): the
-   group gets its normal recency (max LastPlayedDate) and rotates as today.
+   air date `wAir` (`OrderUtilities.GetReleaseDate(...).Date`); no air date →
+   normal rotation.
+2. Rebuild the group's air blocks exactly as the interleave does
+   (`CompareWithinGroupByAirDate` sort + `ChunkIntoAirBlocks`, which chains
+   only across *different* shows) and locate the block containing the watched
+   item.
+3. If **that block** still has an unwatched item (per-user `LastPlayedDate`
+   missing/`MinValue`) with a known air date at or after `wAir`, the group is
+   **mid-block**: omit it from the recency map, so it sorts with the
+   never-watched groups at the front (existing alphabetical tie-break).
+4. Otherwise (block finished, no unwatched left in it, or no air-date data):
+   the group gets its normal recency (max LastPlayedDate) and rotates as today.
+
+> **Revised during review** from an air-date-distance rule
+> (`nextUnwatchedAir - wAir <= window`; block membership was originally out of
+> scope). The distance rule permanently front-pinned any group whose air
+> cadence fits inside the window: single-show fallback groups with daily
+> episodes, and whole collections whenever the window ≥ the shows' weekly
+> cadence. Block membership fixes both: single-show groups form blocks of one
+> and rotate after every watch, and a finished block rotates even when the
+> next block aired within the window.
 
 Consequences:
 
 - Watch part 1 of a same-night crossover → parts 2–3 stay at the top next
   refresh.
-- Watch the last part of the block → next unwatched episode aired > window
-  later → the group rotates to the back as before.
+- Watch the last part of the block → the group rotates to the back as before,
+  even when the next block aired within the window.
 - Never-watched groups and mid-block groups share the front (both absent from
   the recency map); alphabetical tie-break orders them.
 - Watched item with no air date, or no unwatched item with an air date →
@@ -51,10 +63,10 @@ Consequences:
 - Rewatching an old crossover part whose partner is unwatched pins the group
   to the front — acceptable: the rewatcher is being set up to continue.
 
-**Documented approximation:** the hold is air-date-distance based, not
-block-membership based. A same-show double-header (blocks split `{A1,B1}`,
-`{A2}`) still holds the group after watching A1 for same-day A2 — desirable
-in practice (the user is continuing that night's content).
+**Known trade-off:** because blocks split same-show double-headers
+(`{A1,B1}`, `{A2}`), finishing `{A1,B1}` does not hold the group for same-day
+`A2` — the group rotates, and `A2` plays when the rotation returns. Accepted
+in exchange for never front-pinning cadence-matched groups.
 
 ## Changes
 

--- a/docs/superpowers/specs/2026-07-15-mid-block-rotation-hold-design.md
+++ b/docs/superpowers/specs/2026-07-15-mid-block-rotation-hold-design.md
@@ -47,6 +47,14 @@ recency map already uses):
    by the playlist's other rules never keep a hold alive.
 4. Otherwise the group keeps its normal recency and rotates as today.
 
+**Recency itself counts only fully played items** (folded in from requester
+feedback, all LRW groupings): Jellyfin stamps `LastPlayedDate` on any playback,
+so a half-watched episode used to send its whole group to the back of the
+rotation. Non-folder items now contribute to `GroupRecency` only when their
+Played flag is set; folder items keep the aggregate-date behavior. In-progress
+items still anchor the mid-block hold (latest interaction) while counting as
+unwatched for block completion.
+
 The hold runs in `PreComputePositions` (which every sort path calls with the
 filtered items) and **recomputes `HeldGroups` from scratch on every call** —
 intermediate passes (per-group limits sort rule-group subsets before the

--- a/docs/superpowers/specs/2026-07-15-mid-block-rotation-hold-design.md
+++ b/docs/superpowers/specs/2026-07-15-mid-block-rotation-hold-design.md
@@ -29,8 +29,8 @@ recency map already uses):
 
 1. **Anchor**: the group's most recently played item (max per-user
    `LastPlayedDate` from the unfiltered pool, collection members only), ties
-   broken by latest air date so bulk-marked histories resolve
-   deterministically. No dated watch history → normal rotation.
+   broken by latest air date, then by item id, so bulk-marked histories
+   resolve deterministically. No dated watch history → normal rotation.
 2. **Topology**: union of the playlist's FILTERED items in the group and the
    user's watched items (watched = Played flag set or a LastPlayedDate —
    watched items anchor a block even when a "Playback Status" rule hides
@@ -71,8 +71,9 @@ Consequences:
   refresh.
 - Watch the last part of the block → the group rotates to the back as before,
   even when the next block aired within the window.
-- Never-watched groups and mid-block groups share the front (both absent from
-  the recency map); alphabetical tie-break orders them.
+- Never-watched groups and mid-block groups share the front (held groups keep
+  their recency entry but sort with the never-watched key); alphabetical
+  tie-break orders them.
 - Watched item with no air date, or no unwatched item with an air date →
   normal rotation (hold never triggers on missing metadata).
 - Rewatching an old crossover part whose partner is unwatched pins the group

--- a/docs/superpowers/specs/2026-07-15-mid-block-rotation-hold-design.md
+++ b/docs/superpowers/specs/2026-07-15-mid-block-rotation-hold-design.md
@@ -39,15 +39,21 @@ recency map already uses):
    `MaxAirBlockWindowDays` clamp). Locate the block containing the anchor.
 3. **Hold** iff that block still has an item that is both **visible in the
    playlist** and **unwatched** (Played flag unset — imported watch states
-   without timestamps count as watched, in-progress items count as unwatched):
-   omit the group from the recency map so it sorts with the never-watched
-   groups at the front (alphabetical tie-break). Items excluded by the
-   playlist's other rules never keep a hold alive.
+   without timestamps count as watched, in-progress items count as unwatched;
+   folder items like Series count as watched once they have any aggregate
+   watch activity, since Jellyfin does not reliably persist the folder Played
+   flag): add the group to `HeldGroups`, which `OrderGroupKeys` sorts with the
+   never-watched groups at the front (alphabetical tie-break). Items excluded
+   by the playlist's other rules never keep a hold alive.
 4. Otherwise the group keeps its normal recency and rotates as today.
 
 The hold runs in `PreComputePositions` (which every sort path calls with the
-filtered items); `BuildGroupRecencyAndHoldState` collects the per-group watch
-state from the unfiltered pool beforehand, for collection members only.
+filtered items) and **recomputes `HeldGroups` from scratch on every call** —
+intermediate passes (per-group limits sort rule-group subsets before the
+global sort) never leave a stale hold behind; the final pass over the real
+item set wins. `BuildGroupRecencyAndHoldState` collects the per-group watch
+state from the unfiltered pool beforehand, for collection members only, and
+`GroupRecency` itself is never mutated by the hold.
 
 > **Revision history:** v1 was an air-date-distance rule — it permanently
 > front-pinned any group whose air cadence fit inside the window. v2 used

--- a/docs/superpowers/specs/2026-07-15-mid-block-rotation-hold-design.md
+++ b/docs/superpowers/specs/2026-07-15-mid-block-rotation-hold-design.md
@@ -27,28 +27,37 @@ Active only when ALL hold (the same gate as air blocks, plus LRW):
 For each group, computed from the **unfiltered** media pool (same pool the
 recency map already uses):
 
-1. Find the most recently watched item (max per-user `LastPlayedDate`) and its
-   air date `wAir` (`OrderUtilities.GetReleaseDate(...).Date`); no air date →
-   normal rotation.
-2. Rebuild the group's air blocks exactly as the interleave does
-   (`CompareWithinGroupByAirDate` sort + `ChunkIntoAirBlocks`, which chains
-   only across *different* shows) and locate the block containing the watched
-   item.
-3. If **that block** still has an unwatched item (per-user `LastPlayedDate`
-   missing/`MinValue`) with a known air date at or after `wAir`, the group is
-   **mid-block**: omit it from the recency map, so it sorts with the
-   never-watched groups at the front (existing alphabetical tie-break).
-4. Otherwise (block finished, no unwatched left in it, or no air-date data):
-   the group gets its normal recency (max LastPlayedDate) and rotates as today.
+1. **Anchor**: the group's most recently played item (max per-user
+   `LastPlayedDate` from the unfiltered pool, collection members only), ties
+   broken by latest air date so bulk-marked histories resolve
+   deterministically. No dated watch history → normal rotation.
+2. **Topology**: union of the playlist's FILTERED items in the group and the
+   user's watched items (watched = Played flag set or a LastPlayedDate —
+   watched items anchor a block even when a "Playback Status" rule hides
+   them), sorted and chunked with the interleave's own pipeline
+   (`CompareWithinGroupByAirDate` + `ChunkIntoAirBlocks`, shared
+   `MaxAirBlockWindowDays` clamp). Locate the block containing the anchor.
+3. **Hold** iff that block still has an item that is both **visible in the
+   playlist** and **unwatched** (Played flag unset — imported watch states
+   without timestamps count as watched, in-progress items count as unwatched):
+   omit the group from the recency map so it sorts with the never-watched
+   groups at the front (alphabetical tie-break). Items excluded by the
+   playlist's other rules never keep a hold alive.
+4. Otherwise the group keeps its normal recency and rotates as today.
 
-> **Revised during review** from an air-date-distance rule
-> (`nextUnwatchedAir - wAir <= window`; block membership was originally out of
-> scope). The distance rule permanently front-pinned any group whose air
-> cadence fits inside the window: single-show fallback groups with daily
-> episodes, and whole collections whenever the window ≥ the shows' weekly
-> cadence. Block membership fixes both: single-show groups form blocks of one
-> and rotate after every watch, and a finished block rotates even when the
-> next block aired within the window.
+The hold runs in `PreComputePositions` (which every sort path calls with the
+filtered items); `BuildGroupRecencyAndHoldState` collects the per-group watch
+state from the unfiltered pool beforehand, for collection members only.
+
+> **Revision history:** v1 was an air-date-distance rule — it permanently
+> front-pinned any group whose air cadence fit inside the window. v2 used
+> block membership over the unfiltered pool — review found rule-excluded
+> unwatched block-mates (e.g. a Tag or Series rule hiding one crossover show)
+> and Played-without-date imports still pinned groups forever, date-only
+> watched-ness released holds early for in-progress episodes, and timestamp
+> ties made the anchor nondeterministic. v3 (this design) scopes the
+> unwatched check to playlist-visible items, uses the Played flag for
+> watched-ness, and tie-breaks the anchor by air date.
 
 Consequences:
 
@@ -63,24 +72,35 @@ Consequences:
 - Rewatching an old crossover part whose partner is unwatched pins the group
   to the front — acceptable: the rewatcher is being set up to continue.
 
-**Known trade-off:** because blocks split same-show double-headers
-(`{A1,B1}`, `{A2}`), finishing `{A1,B1}` does not hold the group for same-day
-`A2` — the group rotates, and `A2` plays when the rotation returns. Accepted
-in exchange for never front-pinning cadence-matched groups.
+**Known trade-offs (accepted):**
+
+- Blocks split same-show double-headers (`{A1,B1}`, `{A2}`): finishing
+  `{A1,B1}` does not hold the group for same-day `A2` — accepted in exchange
+  for never front-pinning cadence-matched groups.
+- The interleave chunks blocks from the filtered items only, while the hold
+  reasons over filtered ∪ watched; a held cycle can therefore emit an episode
+  the hold considered part of the *next* block (cosmetic — one extra episode
+  in the held cycle, never a pin).
+- Two simultaneously held groups sort alphabetically (held groups share the
+  never-watched front cluster), not by their pre-hold recency.
 
 ## Changes
 
 ### Backend only — no DTO, no UI, no new setting
 
-- `Core/Orders/RoundRobinOrder.cs` — `RoundRobinLeastRecentlyWatchedOrder.BuildGroupRecency`:
-  new optional parameter `int? airBlockWindowDays = null`. Null → exact current
-  single-pass behavior (all non-collection callers). When set: collect per-group
-  `(airDate, lastPlayed)` pairs in the existing loop, then post-process each
-  group with the rule above; log at Debug when a group is held mid-block.
-  Update the `GroupRecency` XML doc to mention the hold.
-- `Core/SmartList.cs` (~line 784) — the LRW injection passes the window when
-  the gate matches:
-  `lrwOrder.GroupByField == "Collections" && lrwOrder.OrderWithinGroupsByAirDate ? Math.Clamp(lrwOrder.AirBlockWindowDays, 0, 30) : (int?)null`.
+- `Core/Orders/RoundRobinOrder.cs` — `RoundRobinBase`: `MaxAirBlockWindowDays`
+  const (shared clamp), `UsesAirBlocks` computed property (single gate:
+  Collections + air-date order + not shuffled), `PreComputePositions` made
+  virtual. `RoundRobinLeastRecentlyWatchedOrder`:
+  `BuildGroupRecencyAndHoldState` (instance method replacing the static
+  `BuildGroupRecency`; identical recency behavior, plus `WatchedByGroup` /
+  `UnwatchedCollectionItemIds` collection for collection members when
+  `UsesAirBlocks`), `ApplyMidBlockHold(filteredItems, logger)` applying the
+  rule above, and a `PreComputePositions` override that runs the hold before
+  computing positions; logs at Debug when a group is held.
+- `Core/SmartList.cs` (~line 782) — the LRW injection becomes
+  `lrwOrder.BuildGroupRecencyAndHoldState(itemsArray, user, userDataManager, refreshCache, logger);`
+  (the order reads its own injected `GroupByField`/`CollectionGroupKeys`).
 
 ### Docs
 


### PR DESCRIPTION
## What
With Least Recently Watched Round Robin grouped by Collections with Air Date order, watching part of a crossover air block no longer rotates the whole collection to the back: the group is held at the front until the playlist has nothing left to show from that block.

## Why
Follow-up to crossover air blocks (#451), requested by the same user: watching part 1 of a crossover night moved parts 2–3 to the bottom of the rotation, because the whole collection carries one recency.

## Changes
- `RoundRobinOrder.cs`: `BuildGroupRecencyAndHoldState` (replaces the static `BuildGroupRecency`; same recency semantics) collects per-group watch state for collection members; `ApplyMidBlockHold` recomputes a `HeldGroups` set inside `PreComputePositions` — block topology is the union of the playlist's filtered items and the user's watched items, and a hold fires only while the anchor's block still has an unwatched item the playlist can actually show.
- Watched-ness uses the Played flag (imported watch states without timestamps count as watched; in-progress episodes count as unwatched); folders with aggregate watch activity count as watched (folder Played flags aren't reliably persisted). Anchor ties (bulk-marked histories) break deterministically by latest air date.
- `RoundRobinBase`: shared `UsesAirBlocks` gate, `MaxAirBlockWindowDays` clamp constant, `PreComputePositions` made virtual.
- `SmartList.cs`: LRW injection reduced to one call; the hold runs later with the filtered items, so per-group-limit subset passes never leave a stale hold (the final pass wins).
- LRW recency now ignores partial plays (all groupings): only fully played episodes advance the rotation — watching half an episode no longer sends the show to the back (folded in from requester feedback).
- Docs: LRW collection-recency note, partial-play note and the Franchise TV Channel recipe.

Spec (with review revision history): `docs/superpowers/specs/2026-07-15-mid-block-rotation-hold-design.md`

E2E-verified against local Jellyfin: hold on part-1 watch, release on block completion, no hold for rule-excluded block-mates, SeriesName grouping regression, fixture watch-states cleaned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsYUGfTYy8xkQeUiNbjNQ5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced least-recently-watched round-robin handling for collections/crossover air-date blocks, including mid-block “hold” behavior.
  - Air-block holds now support configurable windows up to 30 days.
- **Bug Fixes**
  - Fixed cases where hidden items could incorrectly keep a collection at the front.
  - Rotation ordering is recalculated to avoid stale results.
- **Documentation**
  - Updated examples and user guidance to clarify how unfinished air blocks preserve front placement until completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->