### PR TITLE
Weekly cleanup task now sweeps orphaned tethered Jellyfin items

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
@@ -578,6 +578,13 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                     _logger.LogInformation("Removing smart collection suffix from '{CollectionName}' (ID: {CollectionId})",
                         oldName, existingCollection.Id);
 
+                    // Collection is being handed back to the user - always remove the smart list tether
+                    // and unlock it so Jellyfin's metadata fetchers work again, regardless of whether the
+                    // name still matches an expected smart format, so the weekly cleanup sweep doesn't
+                    // delete an item the user chose to keep.
+                    existingCollection.ProviderIds?.Remove(ProviderKeys.SmartLists);
+                    existingCollection.IsLocked = false;
+
                     // Get the current smart collection name format to see what needs to be removed
                     var currentSmartName = NameFormatter.FormatPlaylistName(dto.Name);
 
@@ -586,14 +593,6 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                     {
                         // Remove the smart collection naming and keep just the base name
                         existingCollection.Name = dto.Name;
-
-                        // Collection is being handed back to the user - remove the smart list tether
-                        // and unlock it so Jellyfin's metadata fetchers work again for the user
-                        existingCollection.ProviderIds?.Remove(ProviderKeys.SmartLists);
-                        existingCollection.IsLocked = false;
-
-                        // Save the changes
-                        await existingCollection.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
 
                         _logger.LogDebug("Successfully renamed collection from '{OldName}' to '{NewName}'",
                             oldName, dto.Name);
@@ -616,14 +615,6 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                             {
                                 existingCollection.Name = baseName;
 
-                                // Collection is being handed back to the user - remove the smart list tether
-                                // and unlock it so Jellyfin's metadata fetchers work again for the user
-                                existingCollection.ProviderIds?.Remove(ProviderKeys.SmartLists);
-                                existingCollection.IsLocked = false;
-
-                                // Save the changes
-                                await existingCollection.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
-
                                 _logger.LogDebug("Successfully renamed collection from '{OldName}' to '{NewName}' (removed prefix/suffix)",
                                     oldName, baseName);
                             }
@@ -639,6 +630,9 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                                 oldName, currentSmartName);
                         }
                     }
+
+                    // Save the changes (tether removal/unlock always applies; name change applies only when matched above)
+                    await existingCollection.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (Exception ex)

--- a/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
@@ -574,6 +574,17 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
 
                 if (existingCollection != null)
                 {
+                    var tether = existingCollection.GetProviderId(ProviderKeys.SmartLists);
+                    if (!string.IsNullOrEmpty(tether) && !string.Equals(tether, dto.Id, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _logger.LogWarning("Stored ID '{JellyfinCollectionId}' points at an item tethered to a different smart list ('{CollectionName}'). Skipping.",
+                            dto.JellyfinCollectionId, existingCollection.Name);
+                        existingCollection = null;
+                    }
+                }
+
+                if (existingCollection != null)
+                {
                     var oldName = existingCollection.Name;
                     _logger.LogInformation("Removing smart collection suffix from '{CollectionName}' (ID: {CollectionId})",
                         oldName, existingCollection.Id);
@@ -633,6 +644,31 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
 
                     // Save the changes (tether removal/unlock always applies; name change applies only when matched above)
                     await existingCollection.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
+                }
+
+                // Fallback sweep: find any remaining collections still tethered to this dto (e.g. the
+                // real kept item under a stale or mismatched stored ID) and strip them too, so the
+                // weekly cleanup sweep doesn't delete an item the user chose to keep.
+                if (!string.IsNullOrEmpty(dto.Id))
+                {
+                    var tetherQuery = new InternalItemsQuery
+                    {
+                        IncludeItemTypes = [BaseItemKind.BoxSet],
+                        Recursive = true,
+                    };
+
+                    var remainingTethered = _libraryManager.GetItemsResult(tetherQuery).Items
+                        .Where(b => (existingCollection == null || b.Id != existingCollection.Id)
+                            && string.Equals(b.GetProviderId(ProviderKeys.SmartLists), dto.Id, StringComparison.OrdinalIgnoreCase));
+
+                    foreach (var collectionToClear in remainingTethered)
+                    {
+                        collectionToClear.ProviderIds?.Remove(ProviderKeys.SmartLists);
+                        collectionToClear.IsLocked = false;
+                        await collectionToClear.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
+                        _logger.LogInformation("Stripped smart list tether from collection '{CollectionName}' (ID: {CollectionId}) via fallback sweep; stored ID was stale or mismatched.",
+                            collectionToClear.Name, collectionToClear.Id);
+                    }
                 }
             }
             catch (Exception ex)

--- a/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionStore.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionStore.cs
@@ -67,7 +67,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
         public async Task<SmartCollectionDto[]> GetAllAsync()
         {
             // Use shared helper to read files once
-            var (_, collections) = await _fileSystem.GetAllSmartListsAsync().ConfigureAwait(false);
+            var (_, collections, _) = await _fileSystem.GetAllSmartListsAsync().ConfigureAwait(false);
             return collections;
         }
 

--- a/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
@@ -657,12 +657,47 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                         }
                     }
 
+                    var handledPlaylistIds = new HashSet<Guid>();
                     foreach (var id in idsToClear)
                     {
                         if (Guid.TryParse(id, out var guid) && _libraryManager.GetItemById(guid) is Playlist playlistToClear)
                         {
+                            var tether = playlistToClear.GetProviderId(ProviderKeys.SmartLists);
+                            if (!string.IsNullOrEmpty(tether) && !string.Equals(tether, dto.Id, StringComparison.OrdinalIgnoreCase))
+                            {
+                                _logger.LogWarning("Stored ID '{JellyfinPlaylistId}' points at an item tethered to a different smart list ('{PlaylistName}'). Skipping.",
+                                    id, playlistToClear.Name);
+                                continue;
+                            }
+
                             playlistToClear.ProviderIds?.Remove(ProviderKeys.SmartLists);
                             await playlistToClear.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
+                            handledPlaylistIds.Add(guid);
+                        }
+                    }
+
+                    // Fallback sweep: find any remaining playlists still tethered to this dto (e.g. the
+                    // real kept item under a stale or mismatched stored ID) and strip them too, so the
+                    // weekly cleanup sweep doesn't delete an item the user chose to keep.
+                    if (!string.IsNullOrEmpty(dto.Id))
+                    {
+                        var tetherQuery = new InternalItemsQuery
+                        {
+                            IncludeItemTypes = [BaseItemKind.Playlist],
+                            Recursive = true,
+                        };
+
+                        var remainingTethered = _libraryManager.GetItemsResult(tetherQuery).Items
+                            .OfType<Playlist>()
+                            .Where(p => !handledPlaylistIds.Contains(p.Id)
+                                && string.Equals(p.GetProviderId(ProviderKeys.SmartLists), dto.Id, StringComparison.OrdinalIgnoreCase));
+
+                        foreach (var playlistToClear in remainingTethered)
+                        {
+                            playlistToClear.ProviderIds?.Remove(ProviderKeys.SmartLists);
+                            await playlistToClear.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
+                            _logger.LogInformation("Stripped smart list tether from playlist '{PlaylistName}' (ID: {PlaylistId}) via fallback sweep; stored ID was stale or mismatched.",
+                                playlistToClear.Name, playlistToClear.Id);
                         }
                     }
 
@@ -688,6 +723,17 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                 else
                 {
                     _logger.LogWarning("No Jellyfin playlist ID available for playlist '{PlaylistName}'.", dto.Name);
+                }
+
+                if (existingPlaylist != null)
+                {
+                    var tether = existingPlaylist.GetProviderId(ProviderKeys.SmartLists);
+                    if (!string.IsNullOrEmpty(tether) && !string.Equals(tether, dto.Id, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _logger.LogWarning("Stored ID '{JellyfinPlaylistId}' points at an item tethered to a different smart list ('{PlaylistName}'). Skipping.",
+                            dto.JellyfinPlaylistId, existingPlaylist.Name);
+                        existingPlaylist = null;
+                    }
                 }
 
                 if (existingPlaylist != null)
@@ -749,6 +795,32 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
 
                     // Save the changes (tether removal always applies; name change applies only when matched above)
                     await existingPlaylist.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
+                }
+
+                // Fallback sweep: find any remaining playlists still tethered to this dto (e.g. the
+                // real kept item under a stale or mismatched stored ID) and strip them too, so the
+                // weekly cleanup sweep doesn't delete an item the user chose to keep.
+                if (!string.IsNullOrEmpty(dto.Id))
+                {
+                    var tetherQuery = new InternalItemsQuery(user)
+                    {
+                        IncludeItemTypes = [BaseItemKind.Playlist],
+                        Recursive = true,
+                    };
+
+                    var remainingTethered = _libraryManager.GetItemsResult(tetherQuery).Items
+                        .OfType<Playlist>()
+                        .Where(p => p.OwnerUserId == user.Id
+                            && (existingPlaylist == null || p.Id != existingPlaylist.Id)
+                            && string.Equals(p.GetProviderId(ProviderKeys.SmartLists), dto.Id, StringComparison.OrdinalIgnoreCase));
+
+                    foreach (var playlistToClear in remainingTethered)
+                    {
+                        playlistToClear.ProviderIds?.Remove(ProviderKeys.SmartLists);
+                        await playlistToClear.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
+                        _logger.LogInformation("Stripped smart list tether from playlist '{PlaylistName}' (ID: {PlaylistId}) via fallback sweep; stored ID was stale or mismatched.",
+                            playlistToClear.Name, playlistToClear.Id);
+                    }
                 }
             }
             catch (Exception ex)

--- a/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
@@ -636,6 +636,36 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                 if (user == null)
                 {
                     _logger.LogWarning("No user found for playlist '{PlaylistName}'. Cannot remove smart suffix.", dto.Name);
+
+                    // Multi-user playlists have no single owner (UserId is legacy/empty). Still strip the
+                    // tether from every stored Jellyfin playlist so the weekly cleanup sweep doesn't delete
+                    // items the user chose to keep.
+                    var idsToClear = new List<string>();
+                    if (!string.IsNullOrEmpty(dto.JellyfinPlaylistId))
+                    {
+                        idsToClear.Add(dto.JellyfinPlaylistId);
+                    }
+
+                    if (dto.UserPlaylists != null)
+                    {
+                        foreach (var mapping in dto.UserPlaylists)
+                        {
+                            if (!string.IsNullOrEmpty(mapping.JellyfinPlaylistId))
+                            {
+                                idsToClear.Add(mapping.JellyfinPlaylistId);
+                            }
+                        }
+                    }
+
+                    foreach (var id in idsToClear)
+                    {
+                        if (Guid.TryParse(id, out var guid) && _libraryManager.GetItemById(guid) is Playlist playlistToClear)
+                        {
+                            playlistToClear.ProviderIds?.Remove(ProviderKeys.SmartLists);
+                            await playlistToClear.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
+                        }
+                    }
+
                     return;
                 }
 
@@ -666,6 +696,11 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                     _logger.LogInformation("Removing smart playlist '{PlaylistName}' (ID: {PlaylistId}) for user '{UserName}'",
                         oldName, existingPlaylist.Id, user.Username);
 
+                    // Playlist is being handed back to the user - always remove the smart list tether,
+                    // regardless of whether the name still matches an expected smart format, so the
+                    // weekly cleanup sweep doesn't delete an item the user chose to keep.
+                    existingPlaylist.ProviderIds?.Remove(ProviderKeys.SmartLists);
+
                     // Get the current smart playlist name format to see what needs to be removed
                     var currentSmartName = NameFormatter.FormatPlaylistName(dto.Name);
 
@@ -674,12 +709,6 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                     {
                         // Remove the smart playlist naming and keep just the base name
                         existingPlaylist.Name = dto.Name;
-
-                        // Playlist is being handed back to the user - remove the smart list tether
-                        existingPlaylist.ProviderIds?.Remove(ProviderKeys.SmartLists);
-
-                        // Save the changes
-                        await existingPlaylist.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
 
                         _logger.LogDebug("Successfully renamed playlist from '{OldName}' to '{NewName}' for user '{UserName}'",
                             oldName, dto.Name, user.Username);
@@ -702,12 +731,6 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                             {
                                 existingPlaylist.Name = baseName;
 
-                                // Playlist is being handed back to the user - remove the smart list tether
-                                existingPlaylist.ProviderIds?.Remove(ProviderKeys.SmartLists);
-
-                                // Save the changes
-                                await existingPlaylist.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
-
                                 _logger.LogDebug("Successfully renamed playlist from '{OldName}' to '{NewName}' for user '{UserName}' (removed prefix/suffix)",
                                     oldName, baseName, user.Username);
                             }
@@ -723,6 +746,9 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                                 oldName, currentSmartName);
                         }
                     }
+
+                    // Save the changes (tether removal always applies; name change applies only when matched above)
+                    await existingPlaylist.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (Exception ex)

--- a/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistStore.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistStore.cs
@@ -74,7 +74,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
         public async Task<SmartPlaylistDto[]> GetAllAsync()
         {
             // Use shared helper to read files once
-            var (playlists, _) = await _fileSystem.GetAllSmartListsAsync().ConfigureAwait(false);
+            var (playlists, _, _) = await _fileSystem.GetAllSmartListsAsync().ConfigureAwait(false);
             return playlists;
         }
 

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/BackupService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/BackupService.cs
@@ -418,7 +418,13 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
         /// </summary>
         private async Task<int> CreateBackupZipAsync(string backupFilePath, CancellationToken cancellationToken)
         {
-            var (playlists, collections, _) = await _fileSystem.GetAllSmartListsAsync().ConfigureAwait(false);
+            var (playlists, collections, skippedFiles) = await _fileSystem.GetAllSmartListsAsync().ConfigureAwait(false);
+            if (skippedFiles > 0)
+            {
+                throw new InvalidOperationException(
+                    string.Create(CultureInfo.InvariantCulture, $"Cannot create a complete backup: {skippedFiles} smart list file(s) failed to load."));
+            }
+
             var allLists = playlists.Cast<SmartListDto>().Concat(collections.Cast<SmartListDto>()).ToList();
 
             if (allLists.Count == 0)

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/BackupService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/BackupService.cs
@@ -418,7 +418,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
         /// </summary>
         private async Task<int> CreateBackupZipAsync(string backupFilePath, CancellationToken cancellationToken)
         {
-            var (playlists, collections) = await _fileSystem.GetAllSmartListsAsync().ConfigureAwait(false);
+            var (playlists, collections, _) = await _fileSystem.GetAllSmartListsAsync().ConfigureAwait(false);
             var allLists = playlists.Cast<SmartListDto>().Concat(collections.Cast<SmartListDto>()).ToList();
 
             if (allLists.Count == 0)

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/BackupService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/BackupService.cs
@@ -449,8 +449,14 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                     continue;
                 }
 
-                await AddSmartListToArchiveAsync(archive, list.Id, cancellationToken).ConfigureAwait(false);
-                archivedCount++;
+                if (await AddSmartListToArchiveAsync(archive, list.Id, cancellationToken).ConfigureAwait(false))
+                {
+                    archivedCount++;
+                }
+                else
+                {
+                    _logger.LogWarning("Smart list {ListId} ('{ListName}') vanished during backup; not counted as archived", list.Id, list.Name);
+                }
             }
 
             _logger.LogDebug("Backed up {ListCount} smart lists to {BackupFile}", archivedCount, backupFilePath);
@@ -458,20 +464,26 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
         }
 
         /// <summary>
-        /// Adds a smart list and its images to the archive.
+        /// Adds a smart list and its images to the archive. Returns false when the list's
+        /// config vanished between enumeration and archiving (e.g. deleted mid-backup) so
+        /// the caller doesn't count it as archived.
         /// </summary>
-        private async Task AddSmartListToArchiveAsync(ZipArchive archive, string listId, CancellationToken cancellationToken)
+        private async Task<bool> AddSmartListToArchiveAsync(ZipArchive archive, string listId, CancellationToken cancellationToken)
         {
             var folderPath = _fileSystem.GetSmartListFolderPath(listId);
 
             // Add config.json
             var configPath = _fileSystem.GetSmartListConfigPath(listId);
-            if (File.Exists(configPath))
+            if (!File.Exists(configPath))
             {
-                var entryName = $"{listId}/config.json";
-                var entry = archive.CreateEntry(entryName);
-                using var entryStream = entry.Open();
-                using var fileStream = File.OpenRead(configPath);
+                return false;
+            }
+
+            var entryName = $"{listId}/config.json";
+            var entry = archive.CreateEntry(entryName);
+            using (var entryStream = entry.Open())
+            using (var fileStream = File.OpenRead(configPath))
+            {
                 await fileStream.CopyToAsync(entryStream, cancellationToken).ConfigureAwait(false);
             }
 
@@ -496,6 +508,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                     await imageFileStream.CopyToAsync(imageEntryStream, cancellationToken).ConfigureAwait(false);
                 }
             }
+
+            return true;
         }
 
         private static bool IsWindowsStylePath(string path)

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/CleanupTask.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/CleanupTask.cs
@@ -104,7 +104,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                 // Clean up orphaned folders (folders without config.json). This phase owns
                 // progress 0-80; the tether sweep that follows is comparatively quick.
                 var folderProgress = new Progress<double>(p => progress.Report(p * 0.8));
-                await CleanupOrphanedFoldersAsync(playlists, collections, skippedFiles, folderProgress, cancellationToken).ConfigureAwait(false);
+                await CleanupOrphanedFoldersAsync(folderProgress, cancellationToken).ConfigureAwait(false);
 
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -131,11 +131,13 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
 
         /// <summary>
         /// Cleans up orphaned folders in the smartlists directory.
-        /// A folder is orphaned if:
-        /// - It's a GUID folder without a config.json file
-        /// - It's a GUID folder whose ID is not in the active smart lists
+        /// A folder is orphaned only if it's a GUID folder without a config.json file. A folder
+        /// whose config.json exists but whose ID is absent from a store snapshot is never treated
+        /// as orphaned here: with a complete store read, that can only mean the list was created
+        /// after the snapshot was taken (deleting it would destroy a brand-new list) or a
+        /// folder-name/config-ID mismatch (deleting risks data loss) - neither is a safe deletion.
         /// </summary>
-        private Task CleanupOrphanedFoldersAsync(SmartPlaylistDto[] playlists, SmartCollectionDto[] collections, int skippedFiles, IProgress<double> progress, CancellationToken cancellationToken)
+        private Task CleanupOrphanedFoldersAsync(IProgress<double> progress, CancellationToken cancellationToken)
         {
             var basePath = _fileSystem.BasePath;
 
@@ -169,35 +171,6 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                 return Task.CompletedTask;
             }
 
-            // Get all existing smart list IDs from the snapshot handed down by ExecuteAsync
-            var existingSmartListIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (var playlist in playlists)
-            {
-                if (!string.IsNullOrEmpty(playlist.Id))
-                {
-                    existingSmartListIds.Add(playlist.Id);
-                }
-            }
-
-            foreach (var collection in collections)
-            {
-                if (!string.IsNullOrEmpty(collection.Id))
-                {
-                    existingSmartListIds.Add(collection.Id);
-                }
-            }
-
-            // A partial store read must not classify unparsed lists' folders as deleted -
-            // only apply the ID-based criterion when every smart list file loaded cleanly.
-            var applyIdCriterion = skippedFiles == 0;
-            if (!applyIdCriterion)
-            {
-                _logger.LogWarning(
-                    "Skipped ID-based orphaned folder cleanup: {SkippedFiles} smart list file(s) failed to load",
-                    skippedFiles);
-            }
-
             // Find and delete orphaned folders
             var orphanedCount = 0;
             var processedCount = 0;
@@ -206,13 +179,9 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var smartListId = Path.GetFileName(folderPath);
                 var configPath = Path.Combine(folderPath, "config.json");
 
-                // Folder is orphaned if:
-                // 1. No config.json exists, OR
-                // 2. Smart list ID is not in active lists (only checked on a full store read)
-                var isOrphaned = !File.Exists(configPath) || (applyIdCriterion && !existingSmartListIds.Contains(smartListId));
+                var isOrphaned = !File.Exists(configPath);
 
                 if (isOrphaned)
                 {
@@ -254,9 +223,12 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
         {
             // Items created during (or shortly before) the sweep are skipped as likely
             // mid-creation by a concurrent refresh. Jellyfin persists DateCreated as local
-            // wall-clock time on some paths, so the threshold carries a 26-hour margin to be
-            // timezone-proof; young leftovers are simply reaped on a later run instead.
-            var recencyThreshold = DateTime.UtcNow.AddHours(-26);
+            // wall-clock time on some paths, so the raw value can sit anywhere from 12 hours
+            // behind to 14 hours ahead of UTC; a 40-hour margin keeps the guard effective across
+            // all offsets (26h base + 14h positive-offset worst case), and the mid-sweep race it
+            // defends against spans seconds, so the margin dwarfs it. Young leftovers are simply
+            // reaped on a later run instead.
+            var recencyThreshold = DateTime.UtcNow.AddHours(-40);
 
             if (skippedFiles > 0)
             {
@@ -439,14 +411,43 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
         }
 
         /// <summary>
-        /// Nulls any stored Jellyfin playlist/collection ID that references a just-deleted orphan,
-        /// then persists the mutated DTOs. Per-DTO save failures are logged and skipped so one
-        /// failure doesn't block clearing the rest.
+        /// Nulls any stored Jellyfin playlist/collection ID that references a just-deleted orphan.
+        /// The DTOs passed in are a snapshot taken before the delete loop, so they're used only to
+        /// identify which smart lists have a dangling stored ID; each candidate is reloaded fresh
+        /// from its store immediately before mutating and saving, so a concurrent edit made during
+        /// the delete loop isn't overwritten. A failed save is logged but not retried - the
+        /// dangling ID then persists until the list is next saved (accepted trade-off).
         /// </summary>
         private async Task ClearDanglingStoredIdsAsync(SmartPlaylistDto[] playlists, SmartCollectionDto[] collections, HashSet<Guid> deletedOrphanIds)
         {
-            foreach (var playlist in playlists)
+            foreach (var snapshotPlaylist in playlists)
             {
+                var hasDanglingId = (snapshotPlaylist.UserPlaylists?.Any(mapping =>
+                        !string.IsNullOrEmpty(mapping.JellyfinPlaylistId)
+                        && Guid.TryParse(mapping.JellyfinPlaylistId, out var mappedId)
+                        && deletedOrphanIds.Contains(mappedId)) ?? false)
+                    || (!string.IsNullOrEmpty(snapshotPlaylist.JellyfinPlaylistId)
+                        && Guid.TryParse(snapshotPlaylist.JellyfinPlaylistId, out var legacyMappedId)
+                        && deletedOrphanIds.Contains(legacyMappedId));
+
+                if (!hasDanglingId)
+                {
+                    continue;
+                }
+
+                if (!Guid.TryParse(snapshotPlaylist.Id, out var playlistGuid))
+                {
+                    _logger.LogDebug("Skipping dangling ID clear: smart list {SmartListId} has an unparsable ID", snapshotPlaylist.Id);
+                    continue;
+                }
+
+                var playlist = await _playlistStore.GetByIdAsync(playlistGuid).ConfigureAwait(false);
+                if (playlist == null)
+                {
+                    _logger.LogDebug("Skipping dangling ID clear: smart list {SmartListId} was deleted meanwhile", snapshotPlaylist.Id);
+                    continue;
+                }
+
                 var mutated = false;
 
                 if (playlist.UserPlaylists != null)
@@ -467,8 +468,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                 }
 
                 if (!string.IsNullOrEmpty(playlist.JellyfinPlaylistId)
-                    && Guid.TryParse(playlist.JellyfinPlaylistId, out var legacyMappedId)
-                    && deletedOrphanIds.Contains(legacyMappedId))
+                    && Guid.TryParse(playlist.JellyfinPlaylistId, out var legacyMappedIdReloaded)
+                    && deletedOrphanIds.Contains(legacyMappedIdReloaded))
                 {
                     _logger.LogDebug(
                         "Clearing dangling legacy JellyfinPlaylistId {JellyfinPlaylistId} on smart list {SmartListId}",
@@ -490,11 +491,31 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                 }
             }
 
-            foreach (var collection in collections)
+            foreach (var snapshotCollection in collections)
             {
-                if (string.IsNullOrEmpty(collection.JellyfinCollectionId)
-                    || !Guid.TryParse(collection.JellyfinCollectionId, out var mappedCollectionId)
+                if (string.IsNullOrEmpty(snapshotCollection.JellyfinCollectionId)
+                    || !Guid.TryParse(snapshotCollection.JellyfinCollectionId, out var mappedCollectionId)
                     || !deletedOrphanIds.Contains(mappedCollectionId))
+                {
+                    continue;
+                }
+
+                if (!Guid.TryParse(snapshotCollection.Id, out var collectionGuid))
+                {
+                    _logger.LogDebug("Skipping dangling ID clear: smart list {SmartListId} has an unparsable ID", snapshotCollection.Id);
+                    continue;
+                }
+
+                var collection = await _collectionStore.GetByIdAsync(collectionGuid).ConfigureAwait(false);
+                if (collection == null)
+                {
+                    _logger.LogDebug("Skipping dangling ID clear: smart list {SmartListId} was deleted meanwhile", snapshotCollection.Id);
+                    continue;
+                }
+
+                if (string.IsNullOrEmpty(collection.JellyfinCollectionId)
+                    || !Guid.TryParse(collection.JellyfinCollectionId, out var reloadedMappedCollectionId)
+                    || !deletedOrphanIds.Contains(reloadedMappedCollectionId))
                 {
                     continue;
                 }

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/CleanupTask.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/CleanupTask.cs
@@ -4,7 +4,17 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.SmartLists.Core.Constants;
+using Jellyfin.Plugin.SmartLists.Core.Models;
+using Jellyfin.Plugin.SmartLists.Services.Collections;
+using Jellyfin.Plugin.SmartLists.Services.Playlists;
 using Jellyfin.Plugin.SmartLists.Utilities;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Playlists;
+using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -12,21 +22,31 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
 {
     /// <summary>
     /// Scheduled task that cleans up orphaned data from SmartLists.
-    /// This includes orphaned folders without config.json and legacy image folders.
+    /// This includes orphaned folders without config.json, legacy image folders,
+    /// and leftover Jellyfin playlists/collections tethered to deleted or disabled smart lists.
     /// </summary>
     public class CleanupTask : IScheduledTask
     {
         private readonly SmartListImageService _imageService;
         private readonly ISmartListFileSystem _fileSystem;
+        private readonly ILibraryManager _libraryManager;
+        private readonly PlaylistStore _playlistStore;
+        private readonly CollectionStore _collectionStore;
         private readonly ILogger<CleanupTask> _logger;
 
         public CleanupTask(
             SmartListImageService imageService,
             ISmartListFileSystem fileSystem,
+            ILibraryManager libraryManager,
+            PlaylistStore playlistStore,
+            CollectionStore collectionStore,
             ILogger<CleanupTask> logger)
         {
             _imageService = imageService;
             _fileSystem = fileSystem;
+            _libraryManager = libraryManager;
+            _playlistStore = playlistStore;
+            _collectionStore = collectionStore;
             _logger = logger;
         }
 
@@ -43,7 +63,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
         /// <summary>
         /// Gets the description of the task.
         /// </summary>
-        public string Description => "Cleans up orphaned data from SmartLists, including custom images from deleted lists.";
+        public string Description => "Cleans up orphaned data from SmartLists, including custom images from deleted lists and leftover Jellyfin playlists/collections from deleted or disabled smart lists.";
 
         /// <summary>
         /// Gets the category of the task.
@@ -77,12 +97,24 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
 
             try
             {
-                // Clean up orphaned folders (folders without config.json)
-                await CleanupOrphanedFoldersAsync(progress, cancellationToken).ConfigureAwait(false);
+                // Read the store once and hand the same snapshot to both phases below,
+                // so they agree on what "exists" means even if a save lands mid-run.
+                var (playlists, collections, skippedFiles) = await _fileSystem.GetAllSmartListsAsync().ConfigureAwait(false);
+
+                // Clean up orphaned folders (folders without config.json). This phase owns
+                // progress 0-80; the tether sweep that follows is comparatively quick.
+                var folderProgress = new Progress<double>(p => progress.Report(p * 0.8));
+                await CleanupOrphanedFoldersAsync(playlists, collections, skippedFiles, folderProgress, cancellationToken).ConfigureAwait(false);
+
+                cancellationToken.ThrowIfCancellationRequested();
+
+                // Clean up Jellyfin items tethered to deleted or disabled smart lists
+                await CleanupOrphanedTetheredItemsAsync(playlists, collections, skippedFiles, cancellationToken).ConfigureAwait(false);
 
                 // Clean up legacy images folder if it exists
                 CleanupLegacyImagesFolder();
 
+                progress.Report(100);
                 _logger.LogInformation("Smart Lists cleanup task completed");
             }
             catch (OperationCanceledException)
@@ -103,14 +135,14 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
         /// - It's a GUID folder without a config.json file
         /// - It's a GUID folder whose ID is not in the active smart lists
         /// </summary>
-        private async Task CleanupOrphanedFoldersAsync(IProgress<double> progress, CancellationToken cancellationToken)
+        private Task CleanupOrphanedFoldersAsync(SmartPlaylistDto[] playlists, SmartCollectionDto[] collections, int skippedFiles, IProgress<double> progress, CancellationToken cancellationToken)
         {
             var basePath = _fileSystem.BasePath;
 
             if (!Directory.Exists(basePath))
             {
                 progress.Report(100);
-                return;
+                return Task.CompletedTask;
             }
 
             // Get all GUID folders in smartlists/, excluding special folders
@@ -134,11 +166,10 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
             {
                 progress.Report(100);
                 _logger.LogInformation("No folders to clean up");
-                return;
+                return Task.CompletedTask;
             }
 
-            // Get all existing smart list IDs
-            var (playlists, collections) = await _fileSystem.GetAllSmartListsAsync().ConfigureAwait(false);
+            // Get all existing smart list IDs from the snapshot handed down by ExecuteAsync
             var existingSmartListIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var playlist in playlists)
@@ -157,6 +188,16 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                 }
             }
 
+            // A partial store read must not classify unparsed lists' folders as deleted -
+            // only apply the ID-based criterion when every smart list file loaded cleanly.
+            var applyIdCriterion = skippedFiles == 0;
+            if (!applyIdCriterion)
+            {
+                _logger.LogWarning(
+                    "Skipped ID-based orphaned folder cleanup: {SkippedFiles} smart list file(s) failed to load",
+                    skippedFiles);
+            }
+
             // Find and delete orphaned folders
             var orphanedCount = 0;
             var processedCount = 0;
@@ -170,8 +211,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
 
                 // Folder is orphaned if:
                 // 1. No config.json exists, OR
-                // 2. Smart list ID is not in active lists (shouldn't happen if config exists, but defensive)
-                var isOrphaned = !File.Exists(configPath) || !existingSmartListIds.Contains(smartListId);
+                // 2. Smart list ID is not in active lists (only checked on a full store read)
+                var isOrphaned = !File.Exists(configPath) || (applyIdCriterion && !existingSmartListIds.Contains(smartListId));
 
                 if (isOrphaned)
                 {
@@ -194,6 +235,284 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
             _logger.LogInformation(
                 "Folder cleanup completed. Checked {TotalCount} folders, removed {OrphanedCount} orphaned folders",
                 guidFolders.Count, orphanedCount);
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Deletes Jellyfin playlists/collections that carry the plugin's provider-ID tether
+        /// but whose smart list no longer exists or is disabled (leftovers from failed deletions).
+        /// The enabled-list exemption is kind- and user-aware: a tethered Playlist item is only
+        /// exempt if it belongs to a user still enabled on that smart list, so leftover playlists
+        /// of users removed from a still-enabled list get reaped. A partial store read (some smart
+        /// list files failed to load) aborts the sweep entirely, since a file that failed to parse
+        /// is indistinguishable from a deleted list and treating it as deleted would be destructive.
+        /// Stored Jellyfin IDs referencing a deleted item are cleared from the smart list DTOs
+        /// after deletion, so this doesn't leave dangling pointers behind.
+        /// </summary>
+        private async Task CleanupOrphanedTetheredItemsAsync(SmartPlaylistDto[] playlists, SmartCollectionDto[] collections, int skippedFiles, CancellationToken cancellationToken)
+        {
+            // Items created during (or shortly before) the sweep are skipped as likely
+            // mid-creation by a concurrent refresh. Jellyfin persists DateCreated as local
+            // wall-clock time on some paths, so the threshold carries a 26-hour margin to be
+            // timezone-proof; young leftovers are simply reaped on a later run instead.
+            var recencyThreshold = DateTime.UtcNow.AddHours(-26);
+
+            if (skippedFiles > 0)
+            {
+                _logger.LogWarning(
+                    "Skipping tethered item cleanup: {SkippedFiles} smart list file(s) failed to load; cannot safely distinguish deleted lists",
+                    skippedFiles);
+                return;
+            }
+
+            var (enabledCollectionIds, enabledPlaylistUsers) = BuildTetherExemptions(playlists, collections);
+
+            var query = new InternalItemsQuery
+            {
+                IncludeItemTypes = [BaseItemKind.Playlist, BaseItemKind.BoxSet],
+                Recursive = true,
+                // DB-side narrowing; the in-memory filter below remains the fail-safe.
+                HasAnyProviderId = new Dictionary<string, string> { [ProviderKeys.SmartLists] = string.Empty },
+            };
+
+            var candidates = _libraryManager.GetItemsResult(query).Items
+                .Where(item => IsOrphanedTetheredItem(item, enabledCollectionIds, enabledPlaylistUsers))
+                .ToList();
+
+            if (candidates.Count == 0)
+            {
+                _logger.LogDebug("No orphaned tethered Jellyfin items found");
+                return;
+            }
+
+            // TOCTOU guard: re-read the store immediately before deleting and re-check every
+            // candidate against a fresh snapshot, so a save/enable that happened between the
+            // initial read and now isn't misclassified as deleted.
+            var (freshPlaylists, freshCollections, freshSkippedFiles) = await _fileSystem.GetAllSmartListsAsync().ConfigureAwait(false);
+            if (freshSkippedFiles > 0)
+            {
+                _logger.LogWarning(
+                    "Aborting tethered item cleanup: re-read found {SkippedFiles} smart list file(s) failed to load; cannot safely distinguish deleted lists",
+                    freshSkippedFiles);
+                return;
+            }
+
+            var (freshEnabledCollectionIds, freshEnabledPlaylistUsers) = BuildTetherExemptions(freshPlaylists, freshCollections);
+
+            var orphans = new List<BaseItem>();
+            var skippedRecentCount = 0;
+            var reExemptedCount = 0;
+
+            foreach (var candidate in candidates)
+            {
+                if (candidate.DateCreated >= recencyThreshold)
+                {
+                    // Recently created (possibly mid-sweep by a concurrent refresh) - not an orphan.
+                    skippedRecentCount++;
+                    continue;
+                }
+
+                if (!IsOrphanedTetheredItem(candidate, freshEnabledCollectionIds, freshEnabledPlaylistUsers))
+                {
+                    reExemptedCount++;
+                    continue;
+                }
+
+                orphans.Add(candidate);
+            }
+
+            if (orphans.Count == 0)
+            {
+                _logger.LogDebug("No orphaned tethered Jellyfin items remained after re-check");
+                return;
+            }
+
+            var deletedOrphanIds = new HashSet<Guid>();
+            var deletedCount = 0;
+            foreach (var orphan in orphans)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                try
+                {
+                    _logger.LogWarning(
+                        "Deleting orphaned {ItemKind} '{ItemName}' ({ItemId}) tethered to missing or disabled smart list {SmartListId}",
+                        orphan.GetBaseItemKind(), orphan.Name, orphan.Id, orphan.GetProviderId(ProviderKeys.SmartLists));
+                    _libraryManager.DeleteItem(orphan, new DeleteOptions { DeleteFileLocation = true }, true);
+                    deletedCount++;
+                    deletedOrphanIds.Add(orphan.Id);
+                }
+                catch (Exception ex)
+                {
+                    // Per-item catch so one failed deletion doesn't strand the rest
+                    _logger.LogWarning(ex, "Failed to delete orphaned tethered item '{ItemName}' ({ItemId}), continuing", orphan.Name, orphan.Id);
+                }
+            }
+
+            if (deletedOrphanIds.Count > 0)
+            {
+                // Every other delete path in this plugin clears stored IDs on success; leaving
+                // them here would dangle pointers that Jellyfin's deterministic path-based item
+                // IDs could later rebind to an unrelated item.
+                await ClearDanglingStoredIdsAsync(freshPlaylists, freshCollections, deletedOrphanIds).ConfigureAwait(false);
+            }
+
+            _logger.LogInformation("Tethered item cleanup completed. Removed {DeletedCount} of {OrphanCount} orphaned items", deletedCount, orphans.Count);
+            if (skippedRecentCount > 0 || reExemptedCount > 0)
+            {
+                _logger.LogDebug(
+                    "Tethered item cleanup: skipped {SkippedRecentCount} recently-created item(s), re-exempted {ReExemptedCount} item(s) on re-check",
+                    skippedRecentCount, reExemptedCount);
+            }
+        }
+
+        /// <summary>
+        /// Builds the kind-aware exemption structures from a smart list snapshot: enabled
+        /// collection IDs, and enabled playlist IDs mapped to the set of user GUIDs still
+        /// configured for that playlist (from <see cref="SmartPlaylistDto.UserPlaylists"/> plus
+        /// the legacy single-user field).
+        /// </summary>
+        private static (HashSet<string> EnabledCollectionIds, Dictionary<string, HashSet<Guid>> EnabledPlaylistUsers) BuildTetherExemptions(
+            SmartPlaylistDto[] playlists, SmartCollectionDto[] collections)
+        {
+            var enabledCollectionIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var collection in collections)
+            {
+                if (!string.IsNullOrEmpty(collection.Id) && collection.Enabled)
+                {
+                    enabledCollectionIds.Add(collection.Id);
+                }
+            }
+
+            var enabledPlaylistUsers = new Dictionary<string, HashSet<Guid>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var playlist in playlists)
+            {
+                if (string.IsNullOrEmpty(playlist.Id) || !playlist.Enabled)
+                {
+                    continue;
+                }
+
+                var users = new HashSet<Guid>();
+
+                if (playlist.UserPlaylists != null)
+                {
+                    foreach (var mapping in playlist.UserPlaylists)
+                    {
+                        if (Guid.TryParse(mapping.UserId, out var userId))
+                        {
+                            users.Add(userId);
+                        }
+                    }
+                }
+
+                if (!string.IsNullOrEmpty(playlist.UserId) && Guid.TryParse(playlist.UserId, out var legacyUserId))
+                {
+                    users.Add(legacyUserId);
+                }
+
+                enabledPlaylistUsers[playlist.Id] = users;
+            }
+
+            return (enabledCollectionIds, enabledPlaylistUsers);
+        }
+
+        /// <summary>
+        /// Determines whether a tethered Jellyfin item is orphaned: untethered items are never
+        /// orphans; a Playlist is exempt only if its tether matches an enabled playlist and its
+        /// owner is still in that playlist's user set; a BoxSet is exempt if its tether matches
+        /// an enabled collection; anything else is treated as not orphaned (defensive).
+        /// </summary>
+        private static bool IsOrphanedTetheredItem(BaseItem item, HashSet<string> enabledCollectionIds, Dictionary<string, HashSet<Guid>> enabledPlaylistUsers)
+        {
+            var tether = item.GetProviderId(ProviderKeys.SmartLists);
+            if (string.IsNullOrEmpty(tether))
+            {
+                return false;
+            }
+
+            return item switch
+            {
+                Playlist playlist => !(enabledPlaylistUsers.TryGetValue(tether, out var users) && users.Contains(playlist.OwnerUserId)),
+                BoxSet => !enabledCollectionIds.Contains(tether),
+                _ => false,
+            };
+        }
+
+        /// <summary>
+        /// Nulls any stored Jellyfin playlist/collection ID that references a just-deleted orphan,
+        /// then persists the mutated DTOs. Per-DTO save failures are logged and skipped so one
+        /// failure doesn't block clearing the rest.
+        /// </summary>
+        private async Task ClearDanglingStoredIdsAsync(SmartPlaylistDto[] playlists, SmartCollectionDto[] collections, HashSet<Guid> deletedOrphanIds)
+        {
+            foreach (var playlist in playlists)
+            {
+                var mutated = false;
+
+                if (playlist.UserPlaylists != null)
+                {
+                    foreach (var mapping in playlist.UserPlaylists)
+                    {
+                        if (!string.IsNullOrEmpty(mapping.JellyfinPlaylistId)
+                            && Guid.TryParse(mapping.JellyfinPlaylistId, out var mappedId)
+                            && deletedOrphanIds.Contains(mappedId))
+                        {
+                            _logger.LogDebug(
+                                "Clearing dangling JellyfinPlaylistId {JellyfinPlaylistId} for user {UserId} on smart list {SmartListId}",
+                                mapping.JellyfinPlaylistId, mapping.UserId, playlist.Id);
+                            mapping.JellyfinPlaylistId = null;
+                            mutated = true;
+                        }
+                    }
+                }
+
+                if (!string.IsNullOrEmpty(playlist.JellyfinPlaylistId)
+                    && Guid.TryParse(playlist.JellyfinPlaylistId, out var legacyMappedId)
+                    && deletedOrphanIds.Contains(legacyMappedId))
+                {
+                    _logger.LogDebug(
+                        "Clearing dangling legacy JellyfinPlaylistId {JellyfinPlaylistId} on smart list {SmartListId}",
+                        playlist.JellyfinPlaylistId, playlist.Id);
+                    playlist.JellyfinPlaylistId = null;
+                    mutated = true;
+                }
+
+                if (mutated)
+                {
+                    try
+                    {
+                        await _playlistStore.SaveAsync(playlist).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Failed to clear dangling stored playlist ID(s) for smart list {SmartListId}", playlist.Id);
+                    }
+                }
+            }
+
+            foreach (var collection in collections)
+            {
+                if (string.IsNullOrEmpty(collection.JellyfinCollectionId)
+                    || !Guid.TryParse(collection.JellyfinCollectionId, out var mappedCollectionId)
+                    || !deletedOrphanIds.Contains(mappedCollectionId))
+                {
+                    continue;
+                }
+
+                _logger.LogDebug(
+                    "Clearing dangling JellyfinCollectionId {JellyfinCollectionId} on smart list {SmartListId}",
+                    collection.JellyfinCollectionId, collection.Id);
+                collection.JellyfinCollectionId = null;
+
+                try
+                {
+                    await _collectionStore.SaveAsync(collection).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to clear dangling stored collection ID for smart list {SmartListId}", collection.Id);
+                }
+            }
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/SmartListFileSystem.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/SmartListFileSystem.cs
@@ -55,8 +55,11 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
 
         /// <summary>
         /// Reads all smart list files and returns them grouped by type.
+        /// SkippedFiles counts files that were enumerated but failed to read/parse/deserialize;
+        /// callers performing destructive cleanup must treat SkippedFiles > 0 as
+        /// "the store read is incomplete - do not treat absent lists as deleted".
         /// </summary>
-        Task<(SmartPlaylistDto[] Playlists, SmartCollectionDto[] Collections)> GetAllSmartListsAsync();
+        Task<(SmartPlaylistDto[] Playlists, SmartCollectionDto[] Collections, int SkippedFiles)> GetAllSmartListsAsync();
     }
 
     /// <summary>
@@ -297,12 +300,16 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
         /// <summary>
         /// Reads all smart list files once and returns them grouped by type.
         /// This is more efficient than having each store read files separately.
+        /// SkippedFiles counts files that were enumerated but failed to read/parse/deserialize;
+        /// callers performing destructive cleanup must treat SkippedFiles > 0 as
+        /// "the store read is incomplete - do not treat absent lists as deleted".
         /// </summary>
-        public async Task<(SmartPlaylistDto[] Playlists, SmartCollectionDto[] Collections)> GetAllSmartListsAsync()
+        public async Task<(SmartPlaylistDto[] Playlists, SmartCollectionDto[] Collections, int SkippedFiles)> GetAllSmartListsAsync()
         {
             var filePaths = GetAllSmartListFilePaths();
             var playlists = new List<SmartPlaylistDto>();
             var collections = new List<SmartCollectionDto>();
+            var skippedFiles = 0;
 
             foreach (var filePath in filePaths)
             {
@@ -311,7 +318,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                     // Read file content as JSON document to check Type field first
                     var jsonContent = await File.ReadAllTextAsync(filePath).ConfigureAwait(false);
                     using var jsonDoc = JsonDocument.Parse(jsonContent);
-                    
+
                     if (!jsonDoc.RootElement.TryGetProperty("Type", out var typeElement))
                     {
                         // Legacy file without Type field - default to Playlist
@@ -321,6 +328,12 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                             ApplyPostProcessing(playlist);
                             playlists.Add(playlist);
                         }
+                        else
+                        {
+                            skippedFiles++;
+                            _logger?.LogWarning("Skipping smart list file {FilePath}: deserialized to null", filePath);
+                        }
+
                         continue;
                     }
 
@@ -336,6 +349,11 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                             ApplyPostProcessing(playlist);
                             playlists.Add(playlist);
                         }
+                        else
+                        {
+                            skippedFiles++;
+                            _logger?.LogWarning("Skipping smart list file {FilePath}: deserialized to null", filePath);
+                        }
                     }
                     else if (listType == SmartListType.Collection)
                     {
@@ -345,16 +363,27 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                             ApplyPostProcessing(collection);
                             collections.Add(collection);
                         }
+                        else
+                        {
+                            skippedFiles++;
+                            _logger?.LogWarning("Skipping smart list file {FilePath}: deserialized to null", filePath);
+                        }
+                    }
+                    else
+                    {
+                        skippedFiles++;
+                        _logger?.LogWarning("Skipping smart list file {FilePath}: unrecognized list type", filePath);
                     }
                 }
                 catch (Exception ex)
                 {
                     // Skip invalid files and continue loading others, but log for diagnostics
+                    skippedFiles++;
                     _logger?.LogWarning(ex, "Skipping invalid smart list file {FilePath}", filePath);
                 }
             }
 
-            return (playlists.ToArray(), collections.ToArray());
+            return (playlists.ToArray(), collections.ToArray(), skippedFiles);
         }
     }
 }

--- a/docs/content/user-guide/configuration.md
+++ b/docs/content/user-guide/configuration.md
@@ -411,6 +411,15 @@ To transfer your smart lists to another Jellyfin server:
 2. Copy the ZIP file to the destination server
 3. On the destination server, use **Restore from File** to import the lists
 
+## Cleanup Task
+
+SmartLists includes a maintenance task that removes orphaned data. It runs weekly (Sunday at 4:00 AM by default) and can also be run manually from Jellyfin Dashboard → Scheduled Tasks → "SmartLists cleanup task".
+
+The task cleans up:
+
+- **Orphaned plugin data**: leftover configuration folders and legacy image folders from deleted lists
+- **Leftover Jellyfin playlists and collections**: items created by SmartLists whose smart list has since been deleted or disabled. This can happen if a deletion failed (for example, due to a locked file) when the list was deleted or disabled. Only items carrying SmartLists' hidden ownership marker are ever touched — playlists and collections you created yourself are never affected, including Jellyfin lists you chose to keep when deleting a smart list.
+
 ## Performance Settings
 
 ### Processing Batch Size


### PR DESCRIPTION
## What
Extends the weekly SmartLists cleanup task to delete Jellyfin playlists/collections that carry the plugin's provider-ID tether but whose smart list has been deleted or disabled.

## Why
The per-refresh orphan sweeps from #449 only run for enabled lists — leftovers from failed deletions of deleted or disabled smart lists (the #446 scenario) lingered forever with no reaper. The weekly task is the natural home for a global, tether-verified sweep, and it doubles as a manually runnable "clean up now" button in the Scheduled Tasks dashboard.

## Changes
- **CleanupTask**: new tether sweep — enabled lists are exempt (per-refresh sweeps own those), exemption is kind- and user-aware (reaps playlist→collection conversion ghosts and leftovers of users removed from still-enabled lists), DB-side `HasAnyProviderId` narrowing (verified on both target ABIs), single store read shared by both phases, scaled progress reporting, cancellation checks, and failures propagate so the task shows as failed instead of green
- **Partial-read safety**: `GetAllSmartListsAsync` now returns a skipped-file count; any failed config read aborts both destructive phases — a corrupt config can no longer be mistaken for a deleted list
- **TOCTOU guard**: fresh store re-read plus timezone-proof recency check immediately before deleting, so lists created or re-enabled mid-sweep are never hit
- **Keep-flow fix**: `RemoveSmartSuffixAsync` (playlists + collections) always strips the tether from a kept item, even when it was renamed and the rename step is skipped — previously a kept-but-renamed item would have been swept as an orphan later
- **Dangling-ID hygiene**: stored Jellyfin IDs referencing swept items are cleared from the DTOs, matching every other delete path
- Docs: cleanup task section added to the configuration guide

## Verification
Live against the dev container (Jellyfin 12): deleted-list and disabled-list playlist leftovers reaped, forged-tether BoxSet reaped, corrupt-config abort of both phases (baits untouched, warning logged), kept+renamed playlist survives with tether stripped, stored ID cleared on the disabled DTO, all 17 enabled canonical lists untouched. Both TFMs build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBFLcyWKuktDSu9acy68zg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Cleanup Task now also removes leftover Jellyfin playlists and collections tethered to deleted or disabled SmartLists (in addition to orphaned plugin data/images).

- **Bug Fixes**
  - Cleanup avoids destructive changes when SmartLists files can’t be fully read, and cleans up tether links more consistently.
  - SmartLists backup now fails if the SmartLists store read is incomplete (instead of continuing).

- **Documentation**
  - Updated the user guide with details about the weekly Cleanup Task and how to run it manually via Jellyfin Scheduled Tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->