### PR TITLE
Use series Sort Title to order same-day crossover episodes

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs
@@ -379,8 +379,9 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
         /// <summary>
         /// Compares two items within the same group by air date (premiere date, day precision).
         /// Missing dates are DateTime.MinValue and sort first (Release Date sort convention).
-        /// Same-day ties put episodes before non-episodes, then fall back to natural order,
-        /// so multi-part crossovers airing the same day keep their episode order.
+        /// Same-day ties put episodes before non-episodes, then episodes of different series
+        /// compare by series Sort Title (so users can order a crossover night), then fall back
+        /// to natural order.
         /// </summary>
         internal static int CompareWithinGroupByAirDate(BaseItem a, BaseItem b)
         {
@@ -396,7 +397,29 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
                 return episodeCompare;
             }
 
+            // Same-day tie between episodes of different series: the series Sort Title decides.
+            // Air time is not in Jellyfin metadata (provider dates are day-precision), so users
+            // order a crossover night by editing the series' Sort Title.
+            if (a is Episode epA && b is Episode epB && epA.SeriesId != epB.SeriesId)
+            {
+                var seriesCompare = OrderUtilities.SharedNaturalComparer.Compare(GetSeriesSortName(epA), GetSeriesSortName(epB));
+                if (seriesCompare != 0)
+                {
+                    return seriesCompare;
+                }
+            }
+
             return CompareWithinGroup(a, b);
+        }
+
+        /// <summary>
+        /// Gets the sort name of an episode's series (custom Sort Title when set, otherwise the
+        /// series' computed sort name), falling back to the denormalized series name.
+        /// </summary>
+        private static string GetSeriesSortName(Episode episode)
+        {
+            var sortName = episode.Series?.SortName;
+            return string.IsNullOrEmpty(sortName) ? episode.SeriesName ?? string.Empty : sortName;
         }
 
         /// <summary>

--- a/docs/content/user-guide/sorting-and-limits.md
+++ b/docs/content/user-guide/sorting-and-limits.md
@@ -148,7 +148,7 @@ Interleaves items across groups defined by a field you choose (e.g., Series Name
 All round robin variants except Shuffled Round Robin (where shuffling always wins) let you choose how items are ordered inside each group:
 
 - **Season/Episode (default)**: Natural order — episodes by season/episode number, audio by disc/track number, other items by name.
-- **Air Date**: Premiere date order (day precision). Items airing on the same day keep their episode order, and items with no date come first.
+- **Air Date**: Premiere date order (day precision). Items airing on the same day keep their episode order, and items with no date come first. When episodes of *different* shows share an air date (a crossover night), the shows' **Sort Title** decides who goes first — air *time* isn't part of Jellyfin metadata, so edit the Sort Title on the series to control the order.
 
 Air Date is made for franchise viewing: combine **Group By: Collection** with **Order Within Group: Air Date** and crossover episodes that span multiple shows play in airing order, while a spinoff only enters the rotation once the timeline reaches its premiere.
 


### PR DESCRIPTION
## Summary

With **Group By: Collection** + **Order Within Group: Air Date**, episodes of *different* shows sharing an air date (a crossover night) tie-broke on season/episode number — meaningless across shows, so whichever show had the lower season number always led the night. Air *time* is not available in Jellyfin metadata (provider air dates are day-precision; non-midnight `PremiereDate` values are just local-midnight timezone artifacts), so there was no way to control the order.

Same-day ties between episodes of different series now compare by the **series Sort Title** (custom Sort Title when set, otherwise the series' computed sort name, falling back to the series name). This makes the workaround users already reach for — editing Sort Title on the series — actually work for crossover nights.

- Same-series ordering unchanged: season/episode still decides.
- The tie-break only runs on same-day cross-series comparisons (rare path; no cost on the common date-differs path).
- Applies everywhere `CompareWithinGroupByAirDate` is used, so the interleave and the LRW mid-block hold keep agreeing on block order.

## Testing

Verified against local Jellyfin (12.0 RC, net10.0 build, 0 warnings):

1. Two shows with identical air dates in one collection, plain Round Robin by Collection with Air Date order → same-day pairs play back-to-back, alphabetical series order by default (Alpha, Beta).
2. Set the second show's Sort Title to sort first → refresh → it now leads every same-day pair (Beta, Alpha).
3. Reset Sort Title, fixtures cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsYUGfTYy8xkQeUiNbjNQ5

https://github.com/jyourstone/jellyfin-smartlists-plugin/issues/440

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Round Robin ordering for episodes from different series released on the same day.
  * Uses each series’ Sort Title to provide consistent crossover-night ordering.

* **Documentation**
  * Clarified that Air Date ordering uses Sort Title for same-day episodes and does not consider air time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->