### PR TITLE
Fix All Users checkbox state sync in edit/clone/clear-form flows

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
@@ -407,6 +407,11 @@
     // ===== FORM DEFAULTS POPULATION (DRY) =====
     // Helper function to apply all form defaults from config
     SmartLists.applyFormDefaults = function (page, config) {
+        // clearForm's async config fetch can resolve after a subsequent edit/clone
+        // populate - never clobber a form that is no longer blank
+        if (SmartLists.getElementValue(page, '#playlistName', '')) {
+            return;
+        }
         // Set default list type
         SmartLists.setElementValue(page, '#listType', config.DefaultListType || 'Playlist');
         SmartLists.handleListTypeChange(page);
@@ -467,6 +472,10 @@
 
     // Fallback defaults when config fails to load
     SmartLists.applyFallbackDefaults = function (page) {
+        // Same stale-async-resolve protection as applyFormDefaults
+        if (SmartLists.getElementValue(page, '#playlistName', '')) {
+            return;
+        }
         SmartLists.setElementValue(page, '#listType', 'Playlist');
         SmartLists.handleListTypeChange(page);
         SmartLists.setElementValue(page, '#playlistMaxItems', 500);
@@ -559,6 +568,10 @@
                         SmartLists.setUserIdValueWithRetry(page, page._pendingCollectionUserId);
                         page._pendingCollectionUserId = null; // Clear after use
                     } else {
+                        // Repopulating the options auto-selects the first user; clear it so
+                        // setCurrentUserAsDefault's edit-mode guard doesn't mistake it for
+                        // an intentional selection (e.g. Clear Form while editing)
+                        userSelect.value = '';
                         // Set current user as default for new collections
                         SmartLists.setCurrentUserAsDefault(page);
                     }
@@ -2674,10 +2687,12 @@
             // When switching types during edit mode, transfer the user selection.
             // Priority: current UI state (most accurate) > pending IDs (may be stale from earlier toggles)
             var currentEditState = SmartLists.getPageEditState(page);
+            if (isCollection && SmartLists.setAllUsersSelected) {
+                // Collections have no All Users concept - always clear the hidden
+                // checkbox so stale checked state can't survive collection mode
+                SmartLists.setAllUsersSelected(page, false);
+            }
             if (isCollection && (currentEditState.editMode || currentEditState.cloneMode)) {
-                if (SmartLists.setAllUsersSelected) {
-                    SmartLists.setAllUsersSelected(page, false);
-                }
                 // Switching to Collection: check current checkbox selection first (highest priority)
                 var selectedCheckboxes = page.querySelectorAll('#userMultiSelectOptions .user-multi-select-checkbox:checked');
                 if (selectedCheckboxes.length > 0) {

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
@@ -588,6 +588,7 @@
                     // Check if there are pending userIds to set (from edit/clone mode)
                     if (page._pendingAllUsers && SmartLists.setAllUsersSelected) {
                         SmartLists.setAllUsersSelected(page, true);
+                        delete page._pendingAllUsers; // Consumed - the checkbox now carries the state
                     } else if (page._pendingUserIds && Array.isArray(page._pendingUserIds) && page._pendingUserIds.length > 0) {
                         // Use setTimeout to ensure checkboxes are fully rendered
                         setTimeout(function () {

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -753,6 +753,61 @@
         }
     };
 
+    // Shared by editPlaylist and clonePlaylist: stash the list's user selection
+    // for the async loadUsers to apply, keeping All Users state authoritative
+    SmartLists.stagePendingUserSelection = function (page, playlist, isCollection) {
+        if (!isCollection) {
+            page._pendingAllUsers = playlist.AllUsers === true;
+            // A stale single-select value from a previous collection edit must not
+            // leak into handleListTypeChange's edit-mode user transfer
+            const userSelect = page.querySelector('#playlistUser');
+            if (userSelect) {
+                userSelect.value = '';
+            }
+            if (page._pendingAllUsers) {
+                // All-users playlists: don't repopulate individual checkboxes from the
+                // expanded UserPlaylists snapshot - it would contradict the All Users state
+                page._pendingUserIds = null;
+            } else {
+                // Playlists can have multiple users
+                let userIds = [];
+                if (playlist.UserPlaylists && playlist.UserPlaylists.length > 0) {
+                    userIds = playlist.UserPlaylists.map(function (up) { return up.UserId; });
+                } else if (playlist.UserId) {
+                    userIds = [String(playlist.UserId)];
+                }
+                // Store userIds to set after users are loaded (loadUsers is async)
+                page._pendingUserIds = userIds;
+            }
+        } else {
+            page._pendingAllUsers = false;
+            // Collections: store the user ID to prevent setCurrentUserAsDefault from overwriting
+            if (playlist.UserId) {
+                page._pendingCollectionUserId = String(playlist.UserId);
+            }
+        }
+    };
+
+    // Shared by editPlaylist and clonePlaylist: apply the staged selection to the
+    // form now if users are already loaded; loadUsers finishes the job otherwise
+    SmartLists.applyPendingUserSelection = function (page) {
+        const checkboxes = page.querySelectorAll('#userMultiSelectOptions .user-multi-select-checkbox');
+        // Sync the All Users checkbox from server truth unconditionally so a stale
+        // checked box from a previously viewed all-users playlist can't survive
+        if (SmartLists.setAllUsersSelected) {
+            SmartLists.setAllUsersSelected(page, page._pendingAllUsers === true);
+        }
+        if (page._pendingAllUsers) {
+            page._pendingAllUsers = false;
+        } else if (checkboxes.length > 0 && page._pendingUserIds) {
+            // Users already loaded, set immediately
+            if (SmartLists.setSelectedUserIds) {
+                SmartLists.setSelectedUserIds(page, page._pendingUserIds);
+            }
+            page._pendingUserIds = null; // Clear since we set it
+        }
+    };
+
     SmartLists.clearForm = function (page) {
         // Only handle form clearing - edit mode management should be done by caller
 
@@ -760,6 +815,7 @@
         delete page._editingPlaylistCreatedByUserId;
         delete page._pendingAllUsers;
         delete page._pendingUserIds;
+        delete page._pendingCollectionUserId;
         delete page._metadataTagsWasManaged;
 
         SmartLists.setElementValue(page, '#playlistName', '');
@@ -866,24 +922,7 @@
 
                 // Extract userIds BEFORE calling handleListTypeChange (which triggers loadUsers)
                 // This ensures pendingUserIds is set before loadUsers checks for it
-                let userIds = [];
-                if (!isCollection) {
-                    page._pendingAllUsers = playlist.AllUsers === true;
-                    // Playlists can have multiple users
-                    if (playlist.UserPlaylists && playlist.UserPlaylists.length > 0) {
-                        userIds = playlist.UserPlaylists.map(function (up) { return up.UserId; });
-                    } else if (playlist.UserId) {
-                        userIds = [String(playlist.UserId)];
-                    }
-                    // Store userIds to set after users are loaded (loadUsers is async)
-                    page._pendingUserIds = userIds;
-                } else {
-                    page._pendingAllUsers = false;
-                    // Collections: store the user ID to prevent setCurrentUserAsDefault from overwriting
-                    if (playlist.UserId) {
-                        page._pendingCollectionUserId = String(playlist.UserId);
-                    }
-                }
+                SmartLists.stagePendingUserSelection(page, playlist, isCollection);
 
                 // Set list type
                 SmartLists.setElementValue(page, '#listType', listType);
@@ -965,25 +1004,9 @@
                         SmartLists.setUserIdValueWithRetry(page, userIdString);
                     }
                 } else {
-                    // Playlists can have multiple users
-                    // userIds were already extracted and stored in page._pendingUserIds above
-                    // Try to set immediately if users are already loaded, otherwise wait for loadUsers
-                    const checkboxes = page.querySelectorAll('#userMultiSelectOptions .user-multi-select-checkbox');
-                    if (page._pendingAllUsers && SmartLists.setAllUsersSelected) {
-                        SmartLists.setAllUsersSelected(page, true);
-                        page._pendingAllUsers = false;
-                    } else if (checkboxes.length > 0 && page._pendingUserIds) {
-                        // Users already loaded, set immediately
-                        if (SmartLists.setSelectedUserIds) {
-                            SmartLists.setSelectedUserIds(page, page._pendingUserIds);
-                        }
-                        page._pendingUserIds = null; // Clear since we set it
-                    }
+                    // Playlists can have multiple users; selection was staged above
+                    SmartLists.applyPendingUserSelection(page);
                     // If checkboxes don't exist yet, loadUsers will set them when it finishes
-
-                    if (SmartLists.updatePublicCheckboxVisibility) {
-                        SmartLists.updatePublicCheckboxVisibility(page);
-                    }
                 }
 
                 // Clear existing rules (applies to both playlists and collections)
@@ -1113,24 +1136,7 @@
 
                 // Extract userIds BEFORE calling handleListTypeChange (which triggers loadUsers)
                 // This ensures pendingUserIds is set before loadUsers checks for it
-                let userIds = [];
-                if (!isCollection) {
-                    page._pendingAllUsers = playlist.AllUsers === true;
-                    // Playlists can have multiple users
-                    if (playlist.UserPlaylists && playlist.UserPlaylists.length > 0) {
-                        userIds = playlist.UserPlaylists.map(function (up) { return up.UserId; });
-                    } else if (playlist.UserId) {
-                        userIds = [String(playlist.UserId)];
-                    }
-                    // Store userIds to set after users are loaded (loadUsers is async)
-                    page._pendingUserIds = userIds;
-                } else {
-                    page._pendingAllUsers = false;
-                    // Collections: store the source user ID to prevent setCurrentUserAsDefault from overwriting
-                    if (playlist.UserId) {
-                        page._pendingCollectionUserId = String(playlist.UserId);
-                    }
-                }
+                SmartLists.stagePendingUserSelection(page, playlist, isCollection);
 
                 // Set playlist name FIRST (before switchToTab) to prevent populateFormDefaults from being called
                 // switchToTab checks if name is empty and calls populateFormDefaults if so, which would regenerate checkboxes
@@ -1211,25 +1217,9 @@
                         SmartLists.setUserIdValueWithRetry(page, userIdString);
                     }
                 } else {
-                    // Playlists can have multiple users
-                    // userIds were already extracted and stored in page._pendingUserIds above
-                    // Try to set immediately if users are already loaded, otherwise wait for loadUsers
-                    const checkboxes = page.querySelectorAll('#userMultiSelectOptions .user-multi-select-checkbox');
-                    if (page._pendingAllUsers && SmartLists.setAllUsersSelected) {
-                        SmartLists.setAllUsersSelected(page, true);
-                        page._pendingAllUsers = false;
-                    } else if (checkboxes.length > 0 && page._pendingUserIds) {
-                        // Users already loaded, set immediately
-                        if (SmartLists.setSelectedUserIds) {
-                            SmartLists.setSelectedUserIds(page, page._pendingUserIds);
-                        }
-                        page._pendingUserIds = null; // Clear since we set it
-                    }
+                    // Playlists can have multiple users; selection was staged above
+                    SmartLists.applyPendingUserSelection(page);
                     // If checkboxes don't exist yet, loadUsers will set them when it finishes
-
-                    if (SmartLists.updatePublicCheckboxVisibility) {
-                        SmartLists.updatePublicCheckboxVisibility(page);
-                    }
                 }
 
                 // Clear existing rules and populate with cloned rules (applies to both playlists and collections)

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -798,7 +798,7 @@
             SmartLists.setAllUsersSelected(page, page._pendingAllUsers === true);
         }
         if (page._pendingAllUsers) {
-            page._pendingAllUsers = false;
+            delete page._pendingAllUsers; // Consumed - the checkbox now carries the state
         } else if (checkboxes.length > 0 && page._pendingUserIds) {
             // Users already loaded, set immediately
             if (SmartLists.setSelectedUserIds) {

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-multi-select.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-multi-select.js
@@ -305,6 +305,12 @@
      * @param {string} placeholderText - Optional placeholder text when nothing is selected
      */
     SmartLists.setSelectedItems = function (page, containerId, values, checkboxClass, placeholderText) {
+        // All Users mode owns the user multi-select: async late writers (deferred
+        // selection restores, current-user defaults) must not re-check user boxes
+        // or overwrite the "All users" display after an all-users populate
+        if (containerId === 'playlistUserMultiSelect' && SmartLists.isAllUsersSelected && SmartLists.isAllUsersSelected(page)) {
+            return;
+        }
         if (!values || !Array.isArray(values)) {
             values = [];
         }


### PR DESCRIPTION
## What
Fixes several admin-UI state-sync bugs around the "All Users" playlist checkbox that made the edit form misrepresent stored playlist state.

## Why
Reported via a user: playlists showed the All Users checkbox checked while stored as explicit user lists, so newly added Jellyfin users were never included until the playlist was manually re-saved. Investigation (with live browser tracing) surfaced a family of related state-sync and async-race bugs.

## Changes
- **Stale checkbox**: edit/clone populate now syncs the All Users checkbox unconditionally from the stored `AllUsers` flag, so a stale checked box from a previously viewed all-users playlist can't survive (previously it silently misrepresented — and on save converted — explicit-list playlists).
- **Snapshot leak**: for genuine all-users playlists, `_pendingUserIds` is no longer populated from the persisted expanded `UserPlaylists` snapshot, so the form shows "All users" instead of a stale user-name list.
- **Async writer races**: `setSelectedItems` ignores writes to the user multi-select while All Users is checked — late `loadUsers` current-user defaults and deferred selection restores can no longer overwrite the state after a subsequent populate.
- **Clear Form races**: `applyFormDefaults`/`applyFallbackDefaults` bail when the form is no longer blank (their async config fetch could clobber a subsequently populated edit form); `loadUsers` clears the browser-auto-selected owner option before defaulting, fixing Clear Form while editing selecting the first user alphabetically instead of the current user.
- **Collection mode**: switching to Collection always clears the hidden All Users checkbox; `clearForm` also drops `_pendingCollectionUserId`.
- **DRY**: the four pasted edit/clone staging blocks are extracted into shared `stagePendingUserSelection`/`applyPendingUserSelection` helpers; removed a redundant `updatePublicCheckboxVisibility` call.

Verified end-to-end against the local Jellyfin 12 dev container, including live reproduction of the race sequences via browser automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented delayed defaults from overwriting an already-edited or cloned playlist name.
  * Improved user selection behavior during edit/clone flows for both playlists and collections.
  * Cleared user selection state appropriately when switching list types to Collection.
  * Prevented stale “All Users” selections from being re-applied when user options load asynchronously.
  * Ensured collection user selection fields are reset and applied consistently across form updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

https://github.com/jyourstone/jellyfin-smartlists-plugin/issues/459