### PR TITLE
Add ListenBrainz external list provider for music playlists

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.SmartLists/Configuration/PluginConfiguration.cs
@@ -156,7 +156,7 @@ namespace Jellyfin.Plugin.SmartLists.Configuration
         /// Gets or sets the ListenBrainz user token for fetching external lists.
         /// Optional — only needed for private playlists. Find it at https://listenbrainz.org/settings/
         /// </summary>
-        public string ListenBrainzUserToken { get; set; } = string.Empty;
+        public string? ListenBrainzUserToken { get; set; } = null;
 
         // ===== Backup Settings =====
 

--- a/Jellyfin.Plugin.SmartLists/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.SmartLists/Configuration/PluginConfiguration.cs
@@ -152,6 +152,12 @@ namespace Jellyfin.Plugin.SmartLists.Configuration
         /// </summary>
         public string? TmdbApiKey { get; set; } = null;
 
+        /// <summary>
+        /// Gets or sets the ListenBrainz user token for fetching external lists.
+        /// Optional — only needed for private playlists. Find it at https://listenbrainz.org/settings/
+        /// </summary>
+        public string ListenBrainzUserToken { get; set; } = string.Empty;
+
         // ===== Backup Settings =====
 
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
@@ -1954,6 +1954,10 @@
             if (tmdbApiKeyEl) {
                 tmdbApiKeyEl.value = config.TmdbApiKey || '';
             }
+            var listenBrainzUserTokenEl = page.querySelector('#listenBrainzUserToken');
+            if (listenBrainzUserTokenEl) {
+                listenBrainzUserTokenEl.value = config.ListenBrainzUserToken || '';
+            }
 
             // Load backup settings
             var backupEnabledEl = page.querySelector('#backupEnabled');
@@ -2152,6 +2156,8 @@
             config.TraktClientId = traktClientIdInput ? (traktClientIdInput.value.trim() || null) : null;
             var tmdbApiKeyInput = page.querySelector('#tmdbApiKey');
             config.TmdbApiKey = tmdbApiKeyInput ? (tmdbApiKeyInput.value.trim() || null) : null;
+            var listenBrainzUserTokenInput = page.querySelector('#listenBrainzUserToken');
+            config.ListenBrainzUserToken = listenBrainzUserTokenInput ? (listenBrainzUserTokenInput.value.trim() || null) : null;
 
             // Save backup settings
             var backupEnabledCheckbox = page.querySelector('#backupEnabled');

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-rules.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-rules.js
@@ -1186,7 +1186,7 @@
             '</div>' +
             '<div class="rule-externallist-options" style="display: none; margin-bottom: 0.75em; padding: 0.5em; background: var(--jf-palette-background-paper); border: 1px solid var(--jf-palette-divider); border-radius: 4px;">' +
             '<div style="font-size: 0.85em; opacity: 0.8; display: flex; align-items: center;">' +
-            '<span>Enter an external list URL. Supported: MDBList, IMDb, Trakt, TMDB, Letterboxd.</span>' +
+            '<span>Enter an external list URL. Supported: MDBList, IMDb, Trakt, TMDB, Letterboxd, ListenBrainz. Music lists match by MusicBrainz tags, with title/artist fallback.</span>' +
             '<a href="https://jellyfin-smartlists-plugin.dinsten.se/user-guide/external-lists/" target="_blank" rel="noopener noreferrer" title="Documentation" style="margin-left: 0.5em; text-decoration: none; color: inherit; display: inline-flex; align-items: center;">' +
             '<span class="material-icons" aria-hidden="true" style="font-size: 1.1em; line-height: 0;">info_outline</span>' +
             '</a>' +

--- a/Jellyfin.Plugin.SmartLists/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config.html
@@ -916,6 +916,17 @@
                             </div>
                         </div>
 
+                        <div class="inputContainer" style="margin-bottom: 1em;">
+                            <label class="inputLabel" for="listenBrainzUserToken">ListenBrainz User Token</label>
+                            <input type="password" id="listenBrainzUserToken" class="emby-input"
+                                placeholder="Enter your ListenBrainz user token (optional)">
+                            <div class="fieldDescription">Optional - only needed to access private playlists. Find
+                                your token at
+                                <a href="https://listenbrainz.org/settings/" target="_blank"
+                                    rel="noopener noreferrer" style="color: inherit;">listenbrainz.org/settings</a>.
+                            </div>
+                        </div>
+
                         <h2 class="sectionTitle" style="margin-top: 2em; display: flex; align-items: center;">
                             Backup & Restore
                             <a href="https://jellyfin-smartlists-plugin.dinsten.se/user-guide/configuration/#backup-restore"

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
@@ -4308,6 +4308,28 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                 return matchingLists;
             }
 
+            // Music items match by MusicBrainz recording MBID with title/artist fallback
+            // instead of imdb/tmdb/tvdb provider IDs, so they bypass the hasAnyId check below.
+            if (GetExternalListItemKind(baseItem) == ExternalListItemKind.Music)
+            {
+                var recordingMbid = baseItem.GetProviderId("MusicBrainzRecording");
+                var artistNames = (baseItem as Audio)?.Artists;
+
+                foreach (var kvp in cache.ExternalListData)
+                {
+                    if (kvp.Value.TryGetMusicPosition(recordingMbid, baseItem.Name, artistNames, out var trackPosition))
+                    {
+                        matchingLists.Add(kvp.Key);
+                        // Cache the best (lowest) position across all matched external lists for sorting
+                        cache.ExternalListPositions.AddOrUpdate(baseItem.Id, trackPosition, (_, existing) => Math.Min(existing, trackPosition));
+                        logger?.LogDebug("Item '{ItemName}' matched external list: {Url} at position {Position}", baseItem.Name, kvp.Key, trackPosition);
+                    }
+                }
+
+                cache.ItemExternalLists[baseItem.Id] = matchingLists;
+                return matchingLists;
+            }
+
             // Get this item's provider IDs
             var imdbId = baseItem.GetProviderId(MetadataProvider.Imdb);
             var tmdbId = baseItem.GetProviderId(MetadataProvider.Tmdb);
@@ -4375,6 +4397,8 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                 Movie => ExternalListItemKind.Movie,
                 Episode => ExternalListItemKind.Episode,
                 Series => ExternalListItemKind.Show,
+                // AudioBook derives from Audio, so guard on the item kind to match plain music tracks only
+                Audio when baseItem.GetBaseItemKind() == BaseItemKind.Audio => ExternalListItemKind.Music,
                 _ => ExternalListItemKind.Unknown
             };
         }

--- a/Jellyfin.Plugin.SmartLists/ServiceRegistrator.cs
+++ b/Jellyfin.Plugin.SmartLists/ServiceRegistrator.cs
@@ -43,6 +43,7 @@ namespace Jellyfin.Plugin.SmartLists
             serviceCollection.AddSingleton<IExternalListProvider, TraktListProvider>();
             serviceCollection.AddSingleton<IExternalListProvider, TmdbListProvider>();
             serviceCollection.AddSingleton<IExternalListProvider, LetterboxdListProvider>();
+            serviceCollection.AddSingleton<IExternalListProvider, ListenBrainzListProvider>();
             serviceCollection.AddSingleton<ExternalListService>();
 
             // Register backup service

--- a/Jellyfin.Plugin.SmartLists/Services/ExternalList/IExternalListProvider.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/ExternalList/IExternalListProvider.cs
@@ -227,7 +227,9 @@ namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
 
             foreach (var artist in artistNames)
             {
-                if (string.IsNullOrEmpty(artist))
+                // Skip artists that normalize to empty (e.g. "!!!") — a "title|" key would
+                // cross-match unrelated artists sharing the same title.
+                if (MusicMatchKey.NormalizeArtist(artist).Length == 0)
                 {
                     continue;
                 }
@@ -263,7 +265,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
 
             foreach (var artist in artistNames)
             {
-                if (string.IsNullOrEmpty(artist))
+                // Mirror AddMusicTrack: artists that normalize to empty never have keys stored.
+                if (MusicMatchKey.NormalizeArtist(artist).Length == 0)
                 {
                     continue;
                 }

--- a/Jellyfin.Plugin.SmartLists/Services/ExternalList/IExternalListProvider.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/ExternalList/IExternalListProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Threading;
@@ -28,7 +29,12 @@ namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
         /// <summary>
         /// A TV episode item.
         /// </summary>
-        Episode
+        Episode,
+
+        /// <summary>
+        /// A music track (audio) item.
+        /// </summary>
+        Music
     }
 
     /// <summary>
@@ -112,6 +118,17 @@ namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
         public Dictionary<string, int> EpisodeTvdbIds { get; init; } = [];
 
         /// <summary>
+        /// Gets the lowercased MusicBrainz recording MBIDs mapped to their 0-based position in the list.
+        /// </summary>
+        public Dictionary<string, int> MusicRecordingIds { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Gets the normalized "title|artist" keys (see <see cref="MusicMatchKey.TitleArtistKey"/>)
+        /// mapped to their 0-based position in the list.
+        /// </summary>
+        public Dictionary<string, int> MusicTitleArtistIds { get; } = new(StringComparer.Ordinal);
+
+        /// <summary>
         /// Gets or sets the total number of items in the external list.
         /// </summary>
         public int TotalItems { get; set; }
@@ -187,6 +204,87 @@ namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
             }
 
             return TryGetPosition(UnknownImdbIds, UnknownTmdbIds, UnknownTvdbIds, imdbId, tmdbId, tvdbId, out position);
+        }
+
+        /// <summary>
+        /// Adds a music track to the recording-MBID and normalized title|artist buckets.
+        /// </summary>
+        /// <param name="recordingMbid">The MusicBrainz recording MBID, if available.</param>
+        /// <param name="title">The track title, if available.</param>
+        /// <param name="artistNames">The artist credit names, if available.</param>
+        /// <param name="position">The 0-based position in the external list.</param>
+        public void AddMusicTrack(string? recordingMbid, string? title, IEnumerable<string>? artistNames, int position)
+        {
+            if (!string.IsNullOrEmpty(recordingMbid))
+            {
+                AddKeepingLowestPosition(MusicRecordingIds, recordingMbid.ToLowerInvariant(), position);
+            }
+
+            if (artistNames == null || MusicMatchKey.NormalizeTitle(title).Length == 0)
+            {
+                return;
+            }
+
+            foreach (var artist in artistNames)
+            {
+                if (string.IsNullOrEmpty(artist))
+                {
+                    continue;
+                }
+
+                AddKeepingLowestPosition(MusicTitleArtistIds, MusicMatchKey.TitleArtistKey(title, artist), position);
+            }
+        }
+
+        /// <summary>
+        /// Tries to find the position for a music track by recording MBID first, then by every
+        /// normalized title|artist key. Returns the minimum position across all matches.
+        /// </summary>
+        /// <param name="recordingMbid">The MusicBrainz recording MBID, if available.</param>
+        /// <param name="title">The track title, if available.</param>
+        /// <param name="artistNames">The artist credit names, if available.</param>
+        /// <param name="position">The matched position, when found.</param>
+        /// <returns>True if the recording MBID or any title|artist key matched.</returns>
+        public bool TryGetMusicPosition(string? recordingMbid, string? title, IEnumerable<string>? artistNames, out int position)
+        {
+            var found = false;
+            position = -1;
+
+            if (!string.IsNullOrEmpty(recordingMbid) && MusicRecordingIds.TryGetValue(recordingMbid, out var recordingPosition))
+            {
+                position = recordingPosition;
+                found = true;
+            }
+
+            if (artistNames == null || MusicMatchKey.NormalizeTitle(title).Length == 0)
+            {
+                return found;
+            }
+
+            foreach (var artist in artistNames)
+            {
+                if (string.IsNullOrEmpty(artist))
+                {
+                    continue;
+                }
+
+                if (MusicTitleArtistIds.TryGetValue(MusicMatchKey.TitleArtistKey(title, artist), out var keyPosition) &&
+                    (!found || keyPosition < position))
+                {
+                    position = keyPosition;
+                    found = true;
+                }
+            }
+
+            return found;
+        }
+
+        private static void AddKeepingLowestPosition(Dictionary<string, int> ids, string key, int position)
+        {
+            if (!ids.TryAdd(key, position) && position < ids[key])
+            {
+                ids[key] = position;
+            }
         }
 
         private (Dictionary<string, int> ImdbIds, Dictionary<string, int> TmdbIds, Dictionary<string, int> TvdbIds) GetDictionaries(ExternalListItemKind kind)

--- a/Jellyfin.Plugin.SmartLists/Services/ExternalList/ListenBrainzListProvider.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/ExternalList/ListenBrainzListProvider.cs
@@ -1,0 +1,372 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
+{
+    /// <summary>
+    /// Fetches music tracks from the ListenBrainz API (JSPF playlists).
+    /// Supports static playlist URLs like https://listenbrainz.org/playlist/{mbid}
+    /// and recurring recommendation feed URLs like
+    /// https://listenbrainz.org/syndication-feed/user/{user}/recommendations?recommendation_type=weekly-jams,
+    /// which are re-resolved to the latest generated playlist on every refresh.
+    /// </summary>
+    public partial class ListenBrainzListProvider : IExternalListProvider
+    {
+        private const string ApiBaseUrl = "https://api.listenbrainz.org";
+        private const int CreatedForPageSize = 25;
+        private const int MaxRateLimitWaitSeconds = 10;
+
+        private const string InvalidUrlMessage =
+            "Invalid ListenBrainz URL. Paste either a playlist URL (https://listenbrainz.org/playlist/{mbid}) " +
+            "or a syndication feed URL from the ListenBrainz recommendations page " +
+            "(https://listenbrainz.org/syndication-feed/user/{user}/recommendations?recommendation_type=weekly-jams).";
+
+        private static readonly string UserAgent =
+            "JellyfinSmartLists/" + (typeof(ListenBrainzListProvider).Assembly.GetName().Version?.ToString() ?? "1.0")
+            + " (+https://github.com/jyourstone/jellyfin-smartlists-plugin)";
+
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ILogger<ListenBrainzListProvider> _logger;
+
+        public ListenBrainzListProvider(IHttpClientFactory httpClientFactory, ILogger<ListenBrainzListProvider> logger)
+        {
+            _httpClientFactory = httpClientFactory;
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        public bool CanHandle(string url)
+        {
+            return !string.IsNullOrWhiteSpace(url)
+                && Uri.TryCreate(url, UriKind.Absolute, out var uri)
+                && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)
+                && (uri.Host.Equals("listenbrainz.org", StringComparison.OrdinalIgnoreCase)
+                    || uri.Host.Equals("www.listenbrainz.org", StringComparison.OrdinalIgnoreCase)
+                    || uri.Host.Equals("api.listenbrainz.org", StringComparison.OrdinalIgnoreCase));
+        }
+
+        /// <inheritdoc />
+        public async Task<ExternalListResult> FetchListAsync(string url, CancellationToken cancellationToken, int maxItems = 0)
+        {
+            var result = new ExternalListResult();
+            var httpClient = _httpClientFactory.CreateClient("ListenBrainz");
+
+            var mbid = await ResolvePlaylistMbidAsync(httpClient, url, cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation("Fetching ListenBrainz playlist {Mbid} for {Url}", mbid, url);
+
+            var requestUrl = $"{ApiBaseUrl}/1/playlist/{mbid}?fetch_metadata=true";
+            using var response = await SendWithRetryAsync(httpClient, requestUrl, cancellationToken).ConfigureAwait(false);
+
+            if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden or HttpStatusCode.NotFound)
+            {
+                throw new InvalidOperationException(
+                    $"ListenBrainz returned {(int)response.StatusCode} for playlist {mbid}. " +
+                    "The playlist may be private — if so, configure a ListenBrainz user token in Settings > External Lists.");
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new HttpRequestException($"ListenBrainz API returned {response.StatusCode} for playlist {mbid}");
+            }
+
+            var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            var tracks = JsonSerializer.Deserialize<ListenBrainzPlaylistResponse>(json)?.Playlist?.Tracks ?? [];
+
+            int position = 0;
+            foreach (var track in tracks)
+            {
+                // Stop early if we have enough items
+                if (maxItems > 0 && position >= maxItems)
+                {
+                    break;
+                }
+
+                result.AddMusicTrack(GetRecordingMbid(track), track.Title, GetArtistNames(track), position);
+                position++;
+            }
+
+            result.TotalItems = position;
+            result.IsComplete = maxItems <= 0 || tracks.Length <= maxItems;
+            _logger.LogInformation(
+                "Fetched {Count} tracks from ListenBrainz playlist {Mbid} (recording MBIDs: {MbidCount}, title/artist keys: {KeyCount})",
+                position, mbid, result.MusicRecordingIds.Count, result.MusicTitleArtistIds.Count);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Resolves the URL to a playlist MBID: static playlist URLs carry the MBID directly,
+        /// syndication feed URLs are resolved to the latest generated playlist for the user.
+        /// </summary>
+        private async Task<string> ResolvePlaylistMbidAsync(HttpClient httpClient, string url, CancellationToken cancellationToken)
+        {
+            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            {
+                throw new InvalidOperationException(InvalidUrlMessage);
+            }
+
+            var staticMbid = TryParseStaticPlaylistMbid(uri);
+            if (staticMbid != null)
+            {
+                return staticMbid;
+            }
+
+            var feedMatch = SyndicationFeedPattern().Match(uri.AbsolutePath);
+            if (feedMatch.Success)
+            {
+                var user = Uri.UnescapeDataString(feedMatch.Groups[1].Value);
+                var type = GetQueryParameter(uri, "recommendation_type");
+                if (!string.IsNullOrWhiteSpace(type))
+                {
+                    return await ResolveCreatedForPlaylistMbidAsync(httpClient, user, type, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            throw new InvalidOperationException(InvalidUrlMessage);
+        }
+
+        /// <summary>
+        /// Resolves the latest generated playlist of the given type (e.g. "weekly-jams") for a user
+        /// via the created-for endpoint. Weekly playlists expire, so the MBID is re-resolved on every refresh.
+        /// </summary>
+        private async Task<string> ResolveCreatedForPlaylistMbidAsync(HttpClient httpClient, string user, string type, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Resolving latest '{Type}' playlist for ListenBrainz user {User}", type, user);
+
+            var requestUrl = $"{ApiBaseUrl}/1/user/{Uri.EscapeDataString(user)}/playlists/createdfor?count={CreatedForPageSize}";
+            using var response = await SendWithRetryAsync(httpClient, requestUrl, cancellationToken).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new HttpRequestException($"ListenBrainz API returned {response.StatusCode} for user '{user}' playlists");
+            }
+
+            var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            var playlists = JsonSerializer.Deserialize<ListenBrainzCreatedForResponse>(json)?.Playlists ?? [];
+
+            // Entries are newest-first; the first matching source_patch is the latest playlist of that type
+            foreach (var entry in playlists)
+            {
+                var playlist = entry.Playlist;
+                var sourcePatch = playlist?.Extension?.MusicBrainzPlaylist?.AdditionalMetadata?.AlgorithmMetadata?.SourcePatch;
+                if (!string.Equals(sourcePatch, type, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var mbid = GetIdentifierTailMbid(playlist!.Identifier);
+                if (mbid != null)
+                {
+                    return mbid;
+                }
+            }
+
+            throw new InvalidOperationException(
+                $"No '{type}' playlist found for user '{user}' on ListenBrainz — the list may not be generated yet.");
+        }
+
+        /// <summary>
+        /// Sends a GET request, retrying once on 429 after waiting for the advertised
+        /// rate-limit reset window (capped at <see cref="MaxRateLimitWaitSeconds"/> seconds).
+        /// </summary>
+        private async Task<HttpResponseMessage> SendWithRetryAsync(HttpClient httpClient, string requestUrl, CancellationToken cancellationToken)
+        {
+            var response = await SendAsync(httpClient, requestUrl, cancellationToken).ConfigureAwait(false);
+            if (response.StatusCode != HttpStatusCode.TooManyRequests)
+            {
+                return response;
+            }
+
+            var waitSeconds = MaxRateLimitWaitSeconds;
+            if (response.Headers.TryGetValues("X-RateLimit-Reset-In", out var resetValues)
+                && int.TryParse(string.Join("", resetValues), CultureInfo.InvariantCulture, out var resetIn)
+                && resetIn >= 0)
+            {
+                waitSeconds = Math.Min(resetIn, MaxRateLimitWaitSeconds);
+            }
+
+            response.Dispose();
+            _logger.LogWarning("ListenBrainz API rate limited, retrying in {WaitSeconds}s: {Url}", waitSeconds, requestUrl);
+            await Task.Delay(TimeSpan.FromSeconds(waitSeconds), cancellationToken).ConfigureAwait(false);
+
+            response = await SendAsync(httpClient, requestUrl, cancellationToken).ConfigureAwait(false);
+            if (response.StatusCode == HttpStatusCode.TooManyRequests)
+            {
+                response.Dispose();
+                throw new InvalidOperationException("ListenBrainz API rate limit exceeded — try again later.");
+            }
+
+            return response;
+        }
+
+        /// <summary>
+        /// Sends a GET request with the ListenBrainz headers. The optional user token
+        /// (Settings > External Lists) is sent as "Authorization: Token {token}" to allow private playlists.
+        /// </summary>
+        private static async Task<HttpResponseMessage> SendAsync(HttpClient httpClient, string requestUrl, CancellationToken cancellationToken)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            request.Headers.Add("User-Agent", UserAgent);
+
+            var token = Plugin.Instance?.Configuration?.ListenBrainzUserToken;
+            if (!string.IsNullOrWhiteSpace(token))
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Token", token);
+            }
+
+            return await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Parses a static playlist URL into its MBID:
+        /// https://listenbrainz.org/playlist/{mbid}, https://listenbrainz.org/playlist/?path={mbid}
+        /// or https://api.listenbrainz.org/1/playlist/{mbid}. Returns null when the URL is not a playlist URL.
+        /// </summary>
+        private static string? TryParseStaticPlaylistMbid(Uri uri)
+        {
+            var match = PlaylistPathPattern().Match(uri.AbsolutePath);
+            if (match.Success)
+            {
+                return match.Groups[1].Value.ToLowerInvariant();
+            }
+
+            // Query variant: https://listenbrainz.org/playlist/?path={mbid}
+            if (uri.AbsolutePath.TrimEnd('/').EndsWith("/playlist", StringComparison.OrdinalIgnoreCase))
+            {
+                var candidate = GetQueryParameter(uri, "path");
+                if (!string.IsNullOrEmpty(candidate) && IsMbid(candidate))
+                {
+                    return candidate.ToLowerInvariant();
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Extracts the recording MBID from the first track identifier containing "/recording/".
+        /// </summary>
+        private static string? GetRecordingMbid(ListenBrainzTrack track)
+        {
+            if (track.Identifier == null)
+            {
+                return null;
+            }
+
+            foreach (var identifier in track.Identifier)
+            {
+                if (string.IsNullOrEmpty(identifier) || !identifier.Contains("/recording/", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var mbid = GetIdentifierTailMbid(identifier);
+                if (mbid != null)
+                {
+                    return mbid;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the artist credit names for a track: the MusicBrainz extension artists when present,
+        /// otherwise the JSPF creator string as a single-element fallback.
+        /// </summary>
+        private static List<string> GetArtistNames(ListenBrainzTrack track)
+        {
+            var names = new List<string>();
+
+            var artists = track.Extension?.MusicBrainzTrack?.AdditionalMetadata?.Artists;
+            if (artists != null)
+            {
+                foreach (var artist in artists)
+                {
+                    if (!string.IsNullOrWhiteSpace(artist.ArtistCreditName))
+                    {
+                        names.Add(artist.ArtistCreditName);
+                    }
+                }
+            }
+
+            if (names.Count == 0 && !string.IsNullOrWhiteSpace(track.Creator))
+            {
+                names.Add(track.Creator);
+            }
+
+            return names;
+        }
+
+        /// <summary>
+        /// Extracts the MBID from the tail segment of an identifier URL
+        /// (e.g. https://listenbrainz.org/playlist/{mbid}). Returns null when the tail is not a UUID.
+        /// </summary>
+        private static string? GetIdentifierTailMbid(string? identifier)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                return null;
+            }
+
+            var tail = identifier.TrimEnd('/');
+            var slashIndex = tail.LastIndexOf('/');
+            if (slashIndex >= 0)
+            {
+                tail = tail[(slashIndex + 1)..];
+            }
+
+            return IsMbid(tail) ? tail.ToLowerInvariant() : null;
+        }
+
+        /// <summary>
+        /// Checks whether a value has the UUID shape of a MusicBrainz ID.
+        /// </summary>
+        private static bool IsMbid(string value)
+        {
+            return Guid.TryParseExact(value, "D", out _);
+        }
+
+        /// <summary>
+        /// Gets a query string parameter value from a URI, or null when absent.
+        /// </summary>
+        private static string? GetQueryParameter(Uri uri, string name)
+        {
+            foreach (var pair in uri.Query.TrimStart('?').Split('&', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var separatorIndex = pair.IndexOf('=', StringComparison.Ordinal);
+                var key = separatorIndex < 0 ? pair : pair[..separatorIndex];
+                if (string.Equals(Uri.UnescapeDataString(key), name, StringComparison.OrdinalIgnoreCase))
+                {
+                    return separatorIndex < 0 ? string.Empty : Uri.UnescapeDataString(pair[(separatorIndex + 1)..]);
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Matches playlist URL paths: /playlist/{mbid} (web) or /1/playlist/{mbid} (API host).
+        /// </summary>
+        [GeneratedRegex(@"^/(?:1/)?playlist/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/?$", RegexOptions.IgnoreCase)]
+        private static partial Regex PlaylistPathPattern();
+
+        /// <summary>
+        /// Matches syndication feed URL paths: /syndication-feed/user/{user}/recommendations
+        /// (the recommendation type is carried in the query string).
+        /// </summary>
+        [GeneratedRegex(@"^/syndication-feed/user/([^/?#]+)/recommendations/?$", RegexOptions.IgnoreCase)]
+        private static partial Regex SyndicationFeedPattern();
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Services/ExternalList/ListenBrainzModels.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/ExternalList/ListenBrainzModels.cs
@@ -1,0 +1,157 @@
+using System.Text.Json.Serialization;
+
+namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
+{
+    /// <summary>
+    /// Response wrapper for the ListenBrainz playlist endpoint (GET /1/playlist/{mbid}).
+    /// </summary>
+    public class ListenBrainzPlaylistResponse
+    {
+        [JsonPropertyName("playlist")]
+        public ListenBrainzPlaylist? Playlist { get; set; }
+    }
+
+    /// <summary>
+    /// Response wrapper for the ListenBrainz created-for endpoint
+    /// (GET /1/user/{user}/playlists/createdfor). Entries are newest-first
+    /// and always have an empty track array.
+    /// </summary>
+    public class ListenBrainzCreatedForResponse
+    {
+        [JsonPropertyName("playlists")]
+        public ListenBrainzPlaylistWrapper[]? Playlists { get; set; }
+    }
+
+    /// <summary>
+    /// Wrapper around a playlist entry in ListenBrainz list endpoints.
+    /// </summary>
+    public class ListenBrainzPlaylistWrapper
+    {
+        [JsonPropertyName("playlist")]
+        public ListenBrainzPlaylist? Playlist { get; set; }
+    }
+
+    /// <summary>
+    /// A JSPF playlist object from the ListenBrainz API.
+    /// </summary>
+    public class ListenBrainzPlaylist
+    {
+        /// <summary>
+        /// Gets or sets the playlist identifier URL: https://listenbrainz.org/playlist/{mbid}.
+        /// </summary>
+        [JsonPropertyName("identifier")]
+        public string? Identifier { get; set; }
+
+        [JsonPropertyName("title")]
+        public string? Title { get; set; }
+
+        [JsonPropertyName("track")]
+        public ListenBrainzTrack[]? Tracks { get; set; }
+
+        [JsonPropertyName("extension")]
+        public ListenBrainzPlaylistExtension? Extension { get; set; }
+    }
+
+    /// <summary>
+    /// The JSPF extension container on a playlist.
+    /// </summary>
+    public class ListenBrainzPlaylistExtension
+    {
+        [JsonPropertyName("https://musicbrainz.org/doc/jspf#playlist")]
+        public ListenBrainzPlaylistExtensionData? MusicBrainzPlaylist { get; set; }
+    }
+
+    /// <summary>
+    /// The MusicBrainz playlist extension payload.
+    /// </summary>
+    public class ListenBrainzPlaylistExtensionData
+    {
+        [JsonPropertyName("additional_metadata")]
+        public ListenBrainzPlaylistAdditionalMetadata? AdditionalMetadata { get; set; }
+    }
+
+    /// <summary>
+    /// Additional metadata on a playlist.
+    /// </summary>
+    public class ListenBrainzPlaylistAdditionalMetadata
+    {
+        [JsonPropertyName("algorithm_metadata")]
+        public ListenBrainzAlgorithmMetadata? AlgorithmMetadata { get; set; }
+    }
+
+    /// <summary>
+    /// Metadata about the algorithm that generated a playlist.
+    /// </summary>
+    public class ListenBrainzAlgorithmMetadata
+    {
+        /// <summary>
+        /// Gets or sets the machine-readable playlist type, e.g. "weekly-jams" or "weekly-exploration".
+        /// </summary>
+        [JsonPropertyName("source_patch")]
+        public string? SourcePatch { get; set; }
+    }
+
+    /// <summary>
+    /// A JSPF track from a ListenBrainz playlist.
+    /// </summary>
+    public class ListenBrainzTrack
+    {
+        /// <summary>
+        /// Gets or sets the identifier URLs; recording MBIDs appear as
+        /// https://musicbrainz.org/recording/{mbid} entries.
+        /// </summary>
+        [JsonPropertyName("identifier")]
+        public string[]? Identifier { get; set; }
+
+        [JsonPropertyName("title")]
+        public string? Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets the artist credit string.
+        /// </summary>
+        [JsonPropertyName("creator")]
+        public string? Creator { get; set; }
+
+        [JsonPropertyName("extension")]
+        public ListenBrainzTrackExtension? Extension { get; set; }
+    }
+
+    /// <summary>
+    /// The JSPF extension container on a track.
+    /// </summary>
+    public class ListenBrainzTrackExtension
+    {
+        [JsonPropertyName("https://musicbrainz.org/doc/jspf#track")]
+        public ListenBrainzTrackExtensionData? MusicBrainzTrack { get; set; }
+    }
+
+    /// <summary>
+    /// The MusicBrainz track extension payload.
+    /// </summary>
+    public class ListenBrainzTrackExtensionData
+    {
+        [JsonPropertyName("additional_metadata")]
+        public ListenBrainzTrackAdditionalMetadata? AdditionalMetadata { get; set; }
+    }
+
+    /// <summary>
+    /// Additional metadata on a track.
+    /// </summary>
+    public class ListenBrainzTrackAdditionalMetadata
+    {
+        [JsonPropertyName("artists")]
+        public ListenBrainzArtistCredit[]? Artists { get; set; }
+    }
+
+    /// <summary>
+    /// A single artist credit on a track.
+    /// </summary>
+    public class ListenBrainzArtistCredit
+    {
+        [JsonPropertyName("artist_mbid")]
+        public string? ArtistMbid { get; set; }
+
+        [JsonPropertyName("artist_credit_name")]
+        public string? ArtistCreditName { get; set; }
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Services/ExternalList/MusicMatchKey.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/ExternalList/MusicMatchKey.cs
@@ -64,9 +64,10 @@ namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
             // suffixes). Leading/mid groups stay — "(I Can't Get No) Satisfaction" keeps its prefix.
             if (stripTrailingGroups)
             {
-                while (TrailingGroupPattern().IsMatch(value))
+                string stripped;
+                while ((stripped = TrailingGroupPattern().Replace(value, string.Empty)) != value)
                 {
-                    value = TrailingGroupPattern().Replace(value, string.Empty);
+                    value = stripped;
                 }
             }
 

--- a/Jellyfin.Plugin.SmartLists/Services/ExternalList/MusicMatchKey.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/ExternalList/MusicMatchKey.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
+{
+    /// <summary>
+    /// Builds normalized title|artist match keys for music tracks. Shared by external-list
+    /// providers (list side) and the query engine (library-item side) so both sides produce
+    /// identical keys for fallback matching when no MusicBrainz recording MBID is available.
+    /// </summary>
+    public static partial class MusicMatchKey
+    {
+        /// <summary>
+        /// Builds the combined match key for a track title and a single artist name.
+        /// </summary>
+        /// <param name="title">The track title.</param>
+        /// <param name="artist">The artist credit name.</param>
+        /// <returns>The normalized "title|artist" key.</returns>
+        public static string TitleArtistKey(string? title, string? artist)
+        {
+            return NormalizeTitle(title) + "|" + NormalizeArtist(artist);
+        }
+
+        /// <summary>
+        /// Normalizes a track title for matching: lowercases, strips diacritics and
+        /// featured-artist segments, strips trailing parenthetical/bracket groups
+        /// (remaster/live suffixes), and keeps only letters, digits and spaces.
+        /// </summary>
+        /// <param name="s">The raw title.</param>
+        /// <returns>The normalized title, or an empty string when nothing remains.</returns>
+        public static string NormalizeTitle(string? s)
+        {
+            return Normalize(s, stripTrailingGroups: true);
+        }
+
+        /// <summary>
+        /// Normalizes an artist name for matching. Same pipeline as <see cref="NormalizeTitle"/>
+        /// but keeps trailing parenthetical/bracket groups (they can be part of the artist name).
+        /// </summary>
+        /// <param name="s">The raw artist name.</param>
+        /// <returns>The normalized artist name, or an empty string when nothing remains.</returns>
+        public static string NormalizeArtist(string? s)
+        {
+            return Normalize(s, stripTrailingGroups: false);
+        }
+
+        private static string Normalize(string? s, bool stripTrailingGroups)
+        {
+            if (string.IsNullOrWhiteSpace(s))
+            {
+                return string.Empty;
+            }
+
+            // Trim and lowercase (invariant), then decompose (NFKD) and drop combining marks
+            // so accented characters compare equal to their base characters.
+            var value = RemoveDiacritics(s.Trim().ToLowerInvariant());
+
+            // Remove featured-artist segments: "(feat. X)", "[ft X]" or "feat. X" to end of string.
+            value = FeatSegmentPattern().Replace(value, string.Empty);
+
+            // Titles only: repeatedly strip a trailing "(...)" or "[...]" group (remaster/live
+            // suffixes). Leading/mid groups stay — "(I Can't Get No) Satisfaction" keeps its prefix.
+            if (stripTrailingGroups)
+            {
+                while (TrailingGroupPattern().IsMatch(value))
+                {
+                    value = TrailingGroupPattern().Replace(value, string.Empty);
+                }
+            }
+
+            // "&" and "and" compare equal.
+            value = value.Replace("&", " and ", StringComparison.Ordinal);
+
+            // Keep only letters, digits and spaces; collapse whitespace runs to a single space; trim.
+            var builder = new StringBuilder(value.Length);
+            var pendingSpace = false;
+            foreach (var c in value)
+            {
+                if (char.IsLetterOrDigit(c))
+                {
+                    if (pendingSpace && builder.Length > 0)
+                    {
+                        builder.Append(' ');
+                    }
+
+                    pendingSpace = false;
+                    builder.Append(c);
+                }
+                else if (char.IsWhiteSpace(c))
+                {
+                    pendingSpace = true;
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        private static string RemoveDiacritics(string value)
+        {
+            var decomposed = value.Normalize(NormalizationForm.FormKD);
+            var builder = new StringBuilder(decomposed.Length);
+            foreach (var c in decomposed)
+            {
+                if (CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark)
+                {
+                    builder.Append(c);
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// Matches featured-artist segments in an already-lowercased string: a "(...)"/"[...]"
+        /// group starting with feat/ft/featuring (optional trailing dot), or the keyword to end of string.
+        /// </summary>
+        [GeneratedRegex(@"\(\s*(?:featuring|feat|ft)\b\.?[^)]*\)|\[\s*(?:featuring|feat|ft)\b\.?[^\]]*\]|\b(?:featuring|feat|ft)\b\.?\s.*$", RegexOptions.None)]
+        private static partial Regex FeatSegmentPattern();
+
+        /// <summary>
+        /// Matches a trailing "(...)" or "[...]" group, e.g. "(2011 remaster)" or "[live]".
+        /// </summary>
+        [GeneratedRegex(@"\s*(?:\([^()]*\)|\[[^\[\]]*\])\s*$", RegexOptions.None)]
+        private static partial Regex TrailingGroupPattern();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This plugin allows you to create dynamic playlists and collections based on a se
 ## ✨ Features
 
 - **Modern Web Interface** - A full-featured UI to create, manage and view status for smart playlists and collections
-- **External Lists** - Populate lists from [MDBList](https://mdblist.com), [IMDb](https://www.imdb.com), [Trakt](https://trakt.tv), and [TMDB](https://www.themoviedb.org) — trending charts, watchlists, top lists, and more
+- **External Lists** - Populate lists from [MDBList](https://mdblist.com), [IMDb](https://www.imdb.com), [Letterboxd](https://letterboxd.com), [Trakt](https://trakt.tv), [TMDB](https://www.themoviedb.org), and [ListenBrainz](https://listenbrainz.org) — trending charts, watchlists, top lists, music playlists, and more
 - **Flexible Rules** - Build simple or complex rules with an intuitive builder
 - **Automatic Updates** - Playlists and collections refresh automatically on library updates, playback status changes, or via scheduled tasks
 - **Refresh Status & Statistics** - Monitor ongoing refresh operations with real-time progress, view refresh history, and track statistics for all your lists

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   jellyfin:
-    image: jellyfin/jellyfin:12.0-rc2
+    image: jellyfin/jellyfin:12.0-rc3
     container_name: jellyfin
     user: 1000:1000
     environment:

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -30,12 +30,12 @@ SmartLists creates rule-based playlists and collections that refresh automatical
 - Refreshes lists automatically when library content or playback state changes
 - Supports movies, shows, episodes, music, photos, books, and more
 - Lets administrators and regular users manage lists through the Jellyfin web UI
-- Supports external sources such as IMDb, TMDB, Trakt, MDBList, and Letterboxd
+- Supports external sources such as IMDb, TMDB, Trakt, MDBList, Letterboxd, and ListenBrainz
 
 ## Features
 
 - **Modern Web Interface** - A full-featured UI to create, manage and view status for smart playlists and collections
-- **External Lists** - Populate lists from [MDBList](https://mdblist.com), [IMDb](https://www.imdb.com), [Trakt](https://trakt.tv), and [TMDB](https://www.themoviedb.org)
+- **External Lists** - Populate lists from [MDBList](https://mdblist.com), [IMDb](https://www.imdb.com), [Letterboxd](https://letterboxd.com), [Trakt](https://trakt.tv), [TMDB](https://www.themoviedb.org), and [ListenBrainz](https://listenbrainz.org)
 - **User Selection** - Choose which users should own a playlist or collection with an intuitive dropdown
 - **Flexible Rules** - Build simple or complex rules with an intuitive builder
 - **Automatic Updates** - Playlists and collections refresh automatically on library updates, playback status changes, or via scheduled tasks

--- a/docs/content/user-guide/external-lists.md
+++ b/docs/content/user-guide/external-lists.md
@@ -1,6 +1,6 @@
 # External Lists
 
-External Lists let you populate smart lists from external services like MDBList, IMDb, Letterboxd, Trakt, and TMDB. Use them to create collections based on trending lists, watchlists, top charts, and curated lists from these services.
+External Lists let you populate smart lists from external services like MDBList, IMDb, Letterboxd, Trakt, TMDB, and ListenBrainz. Use them to create collections based on trending lists, watchlists, top charts, curated lists, and music playlists from these services.
 
 ## How It Works
 
@@ -8,7 +8,7 @@ External Lists let you populate smart lists from external services like MDBList,
 2. Create a rule with the `External List` field, `equals` operator, and the list URL as the value
 3. On refresh, the plugin fetches the external list and matches items by provider IDs (IMDb, TMDB, TVDB) against your Jellyfin library
 
-Items are matched by comparing provider IDs between the external list and your library metadata. For episodes, the episode's own provider IDs are checked first. Parent series IDs are only used as a fallback when the external list entry represents a show/series, which lets show lists produce episode playlists without letting episode-level IDs match unrelated shows.
+Items are matched by comparing provider IDs between the external list and your library metadata. For episodes, the episode's own provider IDs are checked first. Parent series IDs are only used as a fallback when the external list entry represents a show/series, which lets show lists produce episode playlists without letting episode-level IDs match unrelated shows. Music lists (ListenBrainz) are matched by MusicBrainz recording IDs instead, with a title + artist fallback for tracks that lack MusicBrainz tags.
 
 ## Supported Providers
 
@@ -17,6 +17,7 @@ Items are matched by comparing provider IDs between the external list and your l
 | **MDBList** | Yes | IMDb, TMDB, TVDB |
 | **IMDb** | No | IMDb |
 | **Letterboxd** | No | TMDB |
+| **ListenBrainz** | No (optional user token) | MusicBrainz recording ID (title + artist fallback) |
 | **Trakt** | Yes (client ID) | IMDb, TMDB, TVDB |
 | **TMDB** | Yes | TMDB |
 
@@ -127,6 +128,44 @@ External List / equals / https://letterboxd.com/official/list/letterboxds-top-50
 
 !!! warning "Letterboxd is Slow for Large Lists"
     Letterboxd list pages do not include TMDB IDs directly. The plugin must fetch each film's individual page to resolve its TMDB ID. This means a 250-film list requires ~250 additional HTTP requests, which can take several minutes. Resolved IDs are cached in memory for faster subsequent refreshes (until Jellyfin restarts). To minimize fetch time, use **External List Order Ascending** sort with a **Max Items** limit — the plugin will only fetch the first N items instead of the entire list.
+
+---
+
+### ListenBrainz
+
+[ListenBrainz](https://listenbrainz.org) is an open music listening tracker from the MusicBrainz project. It hosts user-created playlists and generates personalized playlists like Weekly Jams, Weekly Exploration, and Daily Jams. ListenBrainz lists contain music tracks, so use them with the **Audio** media type.
+
+**Setup:**
+
+No API key required for public playlists. To access your private playlists, add a user token:
+
+1. Go to [listenbrainz.org/settings](https://listenbrainz.org/settings/)
+2. Copy your **User token**
+3. Enter it in the plugin **Settings** tab under **External Lists > ListenBrainz User Token**
+
+**Supported URLs:**
+
+| Type | URL format |
+|------|-----------|
+| Playlist | `https://listenbrainz.org/playlist/{id}` |
+| Syndication feed | `https://listenbrainz.org/syndication-feed/user/{user}/recommendations?recommendation_type={type}` |
+
+A **playlist URL** points to one specific playlist — its current contents are fetched on every refresh.
+
+A **syndication feed URL** points to a *type* of generated playlist (e.g., `weekly-jams`, `weekly-exploration`, `daily-jams`) rather than one specific playlist. On every refresh, the plugin looks up the latest generated playlist of that type for the user, so your smart list automatically follows each new edition — ideal for Weekly Jams, which ListenBrainz regenerates every week. You can copy the syndication feed URL from the feed icon on a generated playlist on your ListenBrainz **Created for you** page.
+
+**Examples:**
+
+```
+External List / equals / https://listenbrainz.org/playlist/07e984e3-1e63-44e3-b53c-7c3f9502cd28
+External List / equals / https://listenbrainz.org/syndication-feed/user/rob/recommendations?recommendation_type=weekly-jams
+```
+
+!!! note "How Music Matching Works"
+    Tracks are matched by MusicBrainz recording IDs, which Jellyfin reads from your music files' embedded tags (e.g., files tagged with [MusicBrainz Picard](https://picard.musicbrainz.org)). Tracks without a MusicBrainz recording ID fall back to title + artist matching, so untagged libraries work too — though tagged libraries will match more reliably.
+
+!!! note "Private Playlists"
+    Public playlists work without any configuration. To use your own private playlists, configure a ListenBrainz user token in the plugin settings (see Setup above).
 
 ---
 

--- a/docs/content/user-guide/fields-and-operators.md
+++ b/docs/content/user-guide/fields-and-operators.md
@@ -180,7 +180,7 @@ Filter by cast and crew members. Select "People" in the field dropdown, then cho
 | **Album** | Album name (music) |
 | **Artists** | Track-level artists (music) |
 | **Album Artists** | Album-level primary artists (music) |
-| **External List** | Match items from an external list (e.g., MDBList). [See details below.](#external-list) |
+| **External List** | Match items from an external list (MDBList, IMDb, Letterboxd, Trakt, TMDB, ListenBrainz). [See details below.](#external-list) |
 
 **Parent metadata options** for Tags, Studios, and Genres (shown when Episode or Audio media type is selected):
 
@@ -241,12 +241,14 @@ Filter items based on Jellyfin playlist membership.
 
 #### External List
 
-Filter items based on membership in an external list. Supports [MDBList](https://mdblist.com), [IMDb](https://www.imdb.com), [Trakt](https://trakt.tv), and [TMDB](https://www.themoviedb.org) — including user lists, watchlists, and charts/trending.
+Filter items based on membership in an external list. Supports [MDBList](https://mdblist.com), [IMDb](https://www.imdb.com), [Letterboxd](https://letterboxd.com), [Trakt](https://trakt.tv), [TMDB](https://www.themoviedb.org), and [ListenBrainz](https://listenbrainz.org) — including user lists, watchlists, charts/trending, and music playlists.
 
 | Provider | API key required | Matches by |
 |----------|-----------------|------------|
 | **MDBList** | Yes | IMDb, TMDB, TVDB |
 | **IMDb** | No | IMDb |
+| **Letterboxd** | No | TMDB |
+| **ListenBrainz** | No (optional user token) | MusicBrainz recording ID (title + artist fallback) |
 | **Trakt** | Yes (client ID) | IMDb, TMDB, TVDB |
 | **TMDB** | Yes | TMDB |
 


### PR DESCRIPTION
## What
Adds ListenBrainz as an external list provider, enabling smart music playlists sourced from ListenBrainz playlists (issue #461).

## Why
ListenBrainz offers free, public, token-less access to user playlists and generated recommendations (Weekly Jams, Weekly Exploration, etc.). Requested in #461 for music parity with the existing movie/TV providers (MDBList, IMDb, Trakt, TMDB, Letterboxd).

## Changes
- **New `ListenBrainzListProvider`** — two URL modes:
  - Static playlist URLs (`listenbrainz.org/playlist/{mbid}`, `?path={mbid}` variant, api-host URLs)
  - Syndication-feed URLs (`/syndication-feed/user/{user}/recommendations?recommendation_type=weekly-jams`) — re-resolves the latest edition via the `createdfor` API on every refresh, since weekly playlists get a new MBID each week and expire after ~2 weeks
  - Friendly errors for unsupported URLs and private playlists; identifying User-Agent; single 429 retry honoring `X-RateLimit-Reset-In`
- **Music matching** — new `Music` kind + MusicBrainz recording-MBID and normalized title|artist buckets in `ExternalListResult`; `MusicMatchKey` normalizer (NFKD, feat/ft stripping, trailing-parenthetical stripping for remaster/live suffixes); `Factory` matches Audio items by `MusicBrainzRecording` provider ID first, title+artist fallback for untagged libraries. Movie/Show/Episode matching unchanged.
- **Config** — optional `ListenBrainzUserToken` (admin page) for private playlists; external-list help text updated
- **Docs** — ListenBrainz section in external-lists guide + provider enumerations updated in README, docs index, fields-and-operators (also added missing Letterboxd mentions)
- **Dev** — Jellyfin dev container bumped to 12.0-rc3

## Testing
- Both ABIs build clean (net9.0/10.11, net10.0/12.x, warnings-as-errors)
- Live-verified end-to-end against Jellyfin 12.0-rc3: 5-track test library — 4 matched via recording MBID, 1 via title+artist fallback, positions preserved for External List Order sorting; static-URL and feed-URL modes both verified against the live ListenBrainz API

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZT8BWVs1DwSgPWa6MimD4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added ListenBrainz as a new external list source, supporting both playlist URLs and recommendation feed URLs.
  - Added an optional ListenBrainz user token setting to enable access to private playlists.
  - Improved music list matching using MusicBrainz recording IDs, with a title + artist fallback when tags are missing.
- **Documentation**
  - Updated the user guide and field/operator documentation to include ListenBrainz setup, supported URL types, refresh behavior, and matching rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->