### PR TITLE
Add list templates: one-click starting points on the Create tab

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
@@ -86,6 +86,10 @@
                 SmartLists.reinitializeExistingRules(page);
             }
 
+            if (SmartLists.initTemplatePicker) {
+                SmartLists.initTemplatePicker(page);
+            }
+
             // Enable form submission
             const editState = SmartLists.getPageEditState(page);
             const submitBtn = page.querySelector('#submitBtn');
@@ -1132,6 +1136,12 @@
                 const button = target.closest('.clone-playlist-btn');
                 if (SmartLists.clonePlaylist) {
                     SmartLists.clonePlaylist(page, button.getAttribute('data-playlist-id'), button.getAttribute('data-playlist-name'));
+                }
+            }
+            if (target.closest('#useTemplateBtn')) {
+                const templateSelect = page.querySelector('#templateSelect');
+                if (templateSelect && templateSelect.value && SmartLists.useTemplate) {
+                    SmartLists.useTemplate(page, templateSelect.value);
                 }
             }
             if (target.closest('.refresh-playlist-btn')) {

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -1121,6 +1121,12 @@
             if (editIndicator) {
                 editIndicator.style.display = 'flex';
             }
+            // Templates create new lists - hide the picker while editing so
+            // "Use" can't silently abandon the in-progress edit
+            const templatePickerEdit = page.querySelector('#templatePickerContainer');
+            if (templatePickerEdit) {
+                templatePickerEdit.style.display = 'none';
+            }
             const submitBtn = page.querySelector('#submitBtn');
             if (submitBtn) {
                 const currentListType = SmartLists.getElementValue(page, '#listType', 'Playlist');
@@ -1146,6 +1152,11 @@
             const createTabButton = page.querySelector('a[data-tab="create"]');
             if (createTabButton) {
                 createTabButton.textContent = 'Create List';
+            }
+            // Restore the template picker hidden by a previous edit session
+            const templatePicker = page.querySelector('#templatePickerContainer');
+            if (templatePicker) {
+                templatePicker.style.display = '';
             }
             // Drop image rows and pending image ops from an abandoned edit
             // session so they can't be applied to the newly created list

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -328,7 +328,7 @@
             // rules with empty values, so an unfilled template rule would otherwise
             // create a much broader list than the user expects.
             if (page._templatePlaceholderPending) {
-                const ruleValueInputs = page.querySelectorAll('#rules-container .rule-value-input');
+                const ruleValueInputs = page.querySelectorAll('#rules-container .rule-value-input, #bumper-rules-container .rule-value-input');
                 let firstEmptyInput = null;
                 for (let i = 0; i < ruleValueInputs.length; i++) {
                     if (!ruleValueInputs[i].value) {
@@ -934,6 +934,10 @@
         const listType = playlist.Type || 'Playlist';
         const isCollection = listType === 'Collection';
 
+        // Any repopulation invalidates a pending template placeholder hint
+        // (useTemplate re-sets the flag after calling this)
+        page._templatePlaceholderPending = false;
+
         if (editMode && playlist.CreatedByUserId) {
             // Store CreatedByUserId to preserve it during updates
             page._editingPlaylistCreatedByUserId = playlist.CreatedByUserId;
@@ -1106,6 +1110,21 @@
             const createTabButton = page.querySelector('a[data-tab="create"]');
             if (createTabButton) {
                 createTabButton.textContent = 'Edit List';
+            }
+        } else {
+            // Reset any stale edit-mode UI (e.g. a template applied, or a list
+            // cloned, while the form was in edit mode)
+            const editIndicator = page.querySelector('#edit-mode-indicator');
+            if (editIndicator) {
+                editIndicator.style.display = 'none';
+            }
+            const submitBtn = page.querySelector('#submitBtn');
+            if (submitBtn) {
+                submitBtn.textContent = 'Create List';
+            }
+            const createTabButton = page.querySelector('a[data-tab="create"]');
+            if (createTabButton) {
+                createTabButton.textContent = 'Create List';
             }
         }
 

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -324,6 +324,26 @@
                 return;
             }
 
+            // Guard for template placeholders: collectRulesFromForm silently drops
+            // rules with empty values, so an unfilled template rule would otherwise
+            // create a much broader list than the user expects.
+            if (page._templatePlaceholderPending) {
+                const ruleValueInputs = page.querySelectorAll('#rules-container .rule-value-input');
+                let firstEmptyInput = null;
+                for (let i = 0; i < ruleValueInputs.length; i++) {
+                    if (!ruleValueInputs[i].value) {
+                        firstEmptyInput = ruleValueInputs[i];
+                        break;
+                    }
+                }
+                if (firstEmptyInput) {
+                    SmartLists.showNotification('This template needs a value - fill in the empty rule value first.');
+                    firstEmptyInput.focus();
+                    return;
+                }
+                page._templatePlaceholderPending = false;
+            }
+
             // Collect rules from form using helper function
             const expressionSets = SmartLists.collectRulesFromForm(page);
 
@@ -822,6 +842,21 @@
         delete page._pendingUserIds;
         delete page._pendingCollectionUserId;
         delete page._metadataTagsWasManaged;
+        page._templatePlaceholderPending = false;
+
+        // Reset the template picker so a cleared form doesn't keep a stale selection
+        const templateSelect = page.querySelector('#templateSelect');
+        if (templateSelect) {
+            templateSelect.value = '';
+            const templateDescription = page.querySelector('#templateDescription');
+            if (templateDescription) {
+                templateDescription.style.display = 'none';
+            }
+            const useTemplateBtn = page.querySelector('#useTemplateBtn');
+            if (useTemplateBtn) {
+                useTemplateBtn.disabled = true;
+            }
+        }
 
         SmartLists.setElementValue(page, '#playlistName', '');
         if (SmartLists.setAllUsersSelected) {

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -328,14 +328,7 @@
             // rules with empty values, so an unfilled template rule would otherwise
             // create a much broader list than the user expects.
             if (page._templatePlaceholderPending) {
-                const ruleValueInputs = page.querySelectorAll('#rules-container .rule-value-input, #bumper-rules-container .rule-value-input');
-                let firstEmptyInput = null;
-                for (let i = 0; i < ruleValueInputs.length; i++) {
-                    if (!ruleValueInputs[i].value) {
-                        firstEmptyInput = ruleValueInputs[i];
-                        break;
-                    }
-                }
+                const firstEmptyInput = SmartLists.findFirstEmptyRuleValueInput(page);
                 if (firstEmptyInput) {
                     SmartLists.showNotification('This template needs a value - fill in the empty rule value first.');
                     firstEmptyInput.focus();
@@ -845,17 +838,8 @@
         page._templatePlaceholderPending = false;
 
         // Reset the template picker so a cleared form doesn't keep a stale selection
-        const templateSelect = page.querySelector('#templateSelect');
-        if (templateSelect) {
-            templateSelect.value = '';
-            const templateDescription = page.querySelector('#templateDescription');
-            if (templateDescription) {
-                templateDescription.style.display = 'none';
-            }
-            const useTemplateBtn = page.querySelector('#useTemplateBtn');
-            if (useTemplateBtn) {
-                useTemplateBtn.disabled = true;
-            }
+        if (SmartLists.resetTemplatePicker) {
+            SmartLists.resetTemplatePicker(page);
         }
 
         SmartLists.setElementValue(page, '#playlistName', '');
@@ -926,6 +910,20 @@
         }
     };
 
+    // Shared by the createPlaylist placeholder guard and useTemplate's focus
+    // step: first VISIBLE empty rule value input (rules + bumper rules).
+    // Hidden inputs (collapsed bumper section, tag-editor internals) are
+    // skipped - an invisible empty value must not block saving or take focus.
+    SmartLists.findFirstEmptyRuleValueInput = function (page) {
+        const inputs = page.querySelectorAll('#rules-container .rule-value-input, #bumper-rules-container .rule-value-input');
+        for (let i = 0; i < inputs.length; i++) {
+            if (!inputs[i].value && inputs[i].offsetParent !== null) {
+                return inputs[i];
+            }
+        }
+        return null;
+    };
+
     // Shared DTO -> create-form population engine used by edit, clone, and
     // template flows. opts: { editMode, playlistId, name }.
     SmartLists.populateFormFromDto = function (page, playlist, opts) {
@@ -944,8 +942,17 @@
         }
 
         // Extract userIds BEFORE calling handleListTypeChange (which triggers loadUsers)
-        // This ensures pendingUserIds is set before loadUsers checks for it
-        SmartLists.stagePendingUserSelection(page, playlist, isCollection);
+        // This ensures pendingUserIds is set before loadUsers checks for it.
+        // Template dtos carry no user fields: leave the current owner selection
+        // alone instead of staging an empty one (which would wipe it).
+        const hasUserInfo = playlist.AllUsers !== undefined || playlist.UserPlaylists !== undefined || playlist.UserId !== undefined;
+        if (hasUserInfo) {
+            SmartLists.stagePendingUserSelection(page, playlist, isCollection);
+        } else {
+            delete page._pendingAllUsers;
+            delete page._pendingUserIds;
+            delete page._pendingCollectionUserId;
+        }
 
         // Set playlist name FIRST (before switchToTab) to prevent populateFormDefaults from being called
         // switchToTab checks if name is empty and calls populateFormDefaults if so, which would regenerate checkboxes
@@ -965,6 +972,10 @@
 
         // Trigger type change handler to show/hide fields
         SmartLists.handleListTypeChange(page);
+
+        // handleListTypeChange clears the flag when it regenerates the media
+        // type checkboxes - re-assert it for the rest of the population
+        page._skipMediaTypeChangeHandlers = true;
 
         // Only set public for playlists
         if (!isCollection) {
@@ -1022,17 +1033,20 @@
         }
         SmartLists.loadRandomGroupSelectionIntoUI(page, playlist);
 
-        // Set the list owner (for both playlists and collections)
-        if (isCollection) {
-            // Collections always have single user
-            const userIdString = playlist.UserId ? String(playlist.UserId) : null;
-            if (userIdString) {
-                SmartLists.setUserIdValueWithRetry(page, userIdString);
+        // Set the list owner (for both playlists and collections); skipped when
+        // the dto carries no user info (templates) so the existing selection stays
+        if (hasUserInfo) {
+            if (isCollection) {
+                // Collections always have single user
+                const userIdString = playlist.UserId ? String(playlist.UserId) : null;
+                if (userIdString) {
+                    SmartLists.setUserIdValueWithRetry(page, userIdString);
+                }
+            } else {
+                // Playlists can have multiple users; selection was staged above
+                SmartLists.applyPendingUserSelection(page);
+                // If checkboxes don't exist yet, loadUsers will set them when it finishes
             }
-        } else {
-            // Playlists can have multiple users; selection was staged above
-            SmartLists.applyPendingUserSelection(page);
-            // If checkboxes don't exist yet, loadUsers will set them when it finishes
         }
 
         // Clear existing rules (applies to both playlists and collections)
@@ -1051,8 +1065,15 @@
             playlist.ExpressionSets.forEach(function (expressionSet, groupIndex) {
                 const logicGroup = groupIndex === 0 ? SmartLists.createInitialLogicGroup(page) : SmartLists.addNewLogicGroup(page);
 
-                // Store similarity comparison fields on page for populateRuleRow to access
-                page._editingPlaylistSimilarityFields = playlist.SimilarityComparisonFields;
+                // Store similarity comparison fields on the mode-specific page key
+                // so cloneRule's freshly staged _cloningPlaylistSimilarityFields is
+                // not shadowed in clone/template flows (populateRuleRow reads the
+                // editing key first, config-rules.js)
+                if (editMode) {
+                    page._editingPlaylistSimilarityFields = playlist.SimilarityComparisonFields;
+                } else {
+                    page._cloningPlaylistSimilarityFields = playlist.SimilarityComparisonFields;
+                }
 
                 // Populate rules and per-group MaxItems into this logic group
                 SmartLists.populateLogicGroupExpressions(page, logicGroup, expressionSet);
@@ -1120,11 +1141,16 @@
             }
             const submitBtn = page.querySelector('#submitBtn');
             if (submitBtn) {
-                submitBtn.textContent = 'Create List';
+                submitBtn.textContent = 'Create ' + listType;
             }
             const createTabButton = page.querySelector('a[data-tab="create"]');
             if (createTabButton) {
                 createTabButton.textContent = 'Create List';
+            }
+            // Drop image rows and pending image ops from an abandoned edit
+            // session so they can't be applied to the newly created list
+            if (SmartLists.initCustomImagesContainer) {
+                SmartLists.initCustomImagesContainer(page);
             }
         }
 

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -891,6 +891,212 @@
         }
     };
 
+    // Shared DTO -> create-form population engine used by edit, clone, and
+    // template flows. opts: { editMode, playlistId, name }.
+    SmartLists.populateFormFromDto = function (page, playlist, opts) {
+        opts = opts || {};
+        const editMode = opts.editMode === true;
+        const listType = playlist.Type || 'Playlist';
+        const isCollection = listType === 'Collection';
+
+        if (editMode && playlist.CreatedByUserId) {
+            // Store CreatedByUserId to preserve it during updates
+            page._editingPlaylistCreatedByUserId = playlist.CreatedByUserId;
+        }
+
+        // Extract userIds BEFORE calling handleListTypeChange (which triggers loadUsers)
+        // This ensures pendingUserIds is set before loadUsers checks for it
+        SmartLists.stagePendingUserSelection(page, playlist, isCollection);
+
+        // Set playlist name FIRST (before switchToTab) to prevent populateFormDefaults from being called
+        // switchToTab checks if name is empty and calls populateFormDefaults if so, which would regenerate checkboxes
+        SmartLists.setElementValue(page, '#playlistName', opts.name !== undefined ? opts.name : (playlist.Name || ''));
+
+        // Switch to Create tab
+        SmartLists.switchToTab(page, 'create');
+
+        // Clear any existing edit state (edit mode is set after population below)
+        SmartLists.setPageEditState(page, false, null);
+
+        // Set list type
+        SmartLists.setElementValue(page, '#listType', listType);
+
+        // Set flag to prevent media type change handlers from interfering during population
+        page._skipMediaTypeChangeHandlers = true;
+
+        // Trigger type change handler to show/hide fields
+        SmartLists.handleListTypeChange(page);
+
+        // Only set public for playlists
+        if (!isCollection) {
+            SmartLists.setElementChecked(page, '#playlistIsPublic', playlist.Public || false);
+        }
+
+        SmartLists.setElementChecked(page, '#playlistIsEnabled', playlist.Enabled !== false); // Default to true for backward compatibility
+        SmartLists.setElementChecked(page, '#playlistIncludeExtras', playlist.IncludeExtras || false);
+        SmartLists.setElementChecked(page, '#playlistHideWhenEmpty', playlist.HideWhenEmpty || false);
+
+        // Handle AutoRefresh with backward compatibility
+        const autoRefreshValue = playlist.AutoRefresh !== undefined ? playlist.AutoRefresh : 'Never';
+        const autoRefreshElement = page.querySelector('#autoRefreshMode');
+        if (autoRefreshElement) {
+            autoRefreshElement.value = autoRefreshValue;
+        }
+
+        // Handle schedule settings with backward compatibility
+        SmartLists.loadSchedulesIntoUI(page, playlist);
+
+        // Handle visibility schedule settings
+        SmartLists.loadVisibilitySchedulesIntoUI(page, playlist);
+
+        SmartLists.loadRandomGroupSelectionIntoUI(page, playlist);
+
+        // Handle MaxItems with backward compatibility
+        // Default to 0 (unlimited) for lists that didn't have this setting
+        const maxItemsValue = (playlist.MaxItems !== undefined && playlist.MaxItems !== null) ? playlist.MaxItems : 0;
+        const maxItemsElement = page.querySelector('#playlistMaxItems');
+        if (maxItemsElement) {
+            maxItemsElement.value = maxItemsValue;
+        } else {
+            console.warn('Max Items element not found when trying to populate form');
+        }
+
+        // Handle MaxPlayTimeMinutes with backward compatibility
+        const maxPlayTimeMinutesValue = (playlist.MaxPlayTimeMinutes !== undefined && playlist.MaxPlayTimeMinutes !== null) ? playlist.MaxPlayTimeMinutes : 0;
+        const maxPlayTimeMinutesElement = page.querySelector('#playlistMaxPlayTimeMinutes');
+        if (maxPlayTimeMinutesElement) {
+            maxPlayTimeMinutesElement.value = maxPlayTimeMinutesValue;
+        } else {
+            console.warn('Max Playtime Minutes element not found when trying to populate form');
+        }
+
+        // Set media types
+        if (playlist.MediaTypes && playlist.MediaTypes.length > 0) {
+            SmartLists.setSelectedItems(page, 'mediaTypesMultiSelect', playlist.MediaTypes, 'media-type-multi-select-checkbox', 'Select media types...');
+        } else {
+            SmartLists.setSelectedItems(page, 'mediaTypesMultiSelect', [], 'media-type-multi-select-checkbox', 'Select media types...');
+        }
+
+        // Update Include Extras visibility based on loaded media types
+        if (SmartLists.updateIncludeExtrasVisibility) {
+            SmartLists.updateIncludeExtrasVisibility(page);
+        }
+        SmartLists.loadRandomGroupSelectionIntoUI(page, playlist);
+
+        // Set the list owner (for both playlists and collections)
+        if (isCollection) {
+            // Collections always have single user
+            const userIdString = playlist.UserId ? String(playlist.UserId) : null;
+            if (userIdString) {
+                SmartLists.setUserIdValueWithRetry(page, userIdString);
+            }
+        } else {
+            // Playlists can have multiple users; selection was staged above
+            SmartLists.applyPendingUserSelection(page);
+            // If checkboxes don't exist yet, loadUsers will set them when it finishes
+        }
+
+        // Clear existing rules (applies to both playlists and collections)
+        const rulesContainer = page.querySelector('#rules-container');
+        if (rulesContainer) {
+            rulesContainer.innerHTML = '';
+        }
+
+        // Clear stale similarity-field context from any previous population
+        page._editingPlaylistSimilarityFields = null;
+        page._cloningPlaylistSimilarityFields = null;
+
+        // Populate logic groups and rules
+        if (playlist.ExpressionSets && playlist.ExpressionSets.length > 0 &&
+            playlist.ExpressionSets.some(function (es) { return es.Expressions && es.Expressions.length > 0; })) {
+            playlist.ExpressionSets.forEach(function (expressionSet, groupIndex) {
+                const logicGroup = groupIndex === 0 ? SmartLists.createInitialLogicGroup(page) : SmartLists.addNewLogicGroup(page);
+
+                // Store similarity comparison fields on page for populateRuleRow to access
+                page._editingPlaylistSimilarityFields = playlist.SimilarityComparisonFields;
+
+                // Populate rules and per-group MaxItems into this logic group
+                SmartLists.populateLogicGroupExpressions(page, logicGroup, expressionSet);
+            });
+        } else {
+            // No rules exist - create an initial logic group with a placeholder rule
+            SmartLists.createInitialLogicGroup(page);
+        }
+
+        // Clear and populate bumper rules
+        SmartLists.populateBumperConfigIntoForm(page, playlist);
+
+        // Set sort options AFTER rules are populated so hasSimilarToRuleInForm() can detect them
+        SmartLists.loadSortOptionsIntoUI(page, playlist);
+        // Update sort options visibility based on populated rules
+        SmartLists.updateAllSortOptionsVisibility(page);
+
+        // Update field selects first, then per-field options visibility based on selected media types
+        SmartLists.updateAllFieldSelects(page);
+        SmartLists.updateAllTagsOptionsVisibility(page);
+        SmartLists.updateAllStudiosOptionsVisibility(page);
+        SmartLists.updateAllGenresOptionsVisibility(page);
+        SmartLists.updateAllAudioLanguagesOptionsVisibility(page);
+        SmartLists.updateAllCollectionsOptionsVisibility(page);
+        SmartLists.updateAllNextUnwatchedOptionsVisibility(page);
+
+        // Update button visibility
+        SmartLists.updateRuleButtonVisibility(page);
+
+        // Clear flag to re-enable change event handlers
+        page._skipMediaTypeChangeHandlers = false;
+
+        // Clear any pending media type update timers just in case
+        if (page._mediaTypeUpdateTimer) {
+            clearTimeout(page._mediaTypeUpdateTimer);
+            page._mediaTypeUpdateTimer = null;
+        }
+
+        if (editMode) {
+            // Set edit mode state
+            SmartLists.setPageEditState(page, true, opts.playlistId);
+
+            // Update UI to show edit mode
+            const editIndicator = page.querySelector('#edit-mode-indicator');
+            if (editIndicator) {
+                editIndicator.style.display = 'flex';
+            }
+            const submitBtn = page.querySelector('#submitBtn');
+            if (submitBtn) {
+                const currentListType = SmartLists.getElementValue(page, '#listType', 'Playlist');
+                submitBtn.textContent = 'Update ' + currentListType;
+            }
+
+            // Update tab button text
+            const createTabButton = page.querySelector('a[data-tab="create"]');
+            if (createTabButton) {
+                createTabButton.textContent = 'Edit List';
+            }
+        }
+
+        // Populate metadata fields
+        SmartLists.setElementValue(page, '#metadataSortTitle', playlist.SortTitle || '');
+        SmartLists.setElementValue(page, '#metadataOverview', playlist.Overview || '');
+        SmartLists.setElementValue(page, '#metadataFavorite', playlist.Favorite === true ? 'true' : (playlist.Favorite === false ? 'false' : ''));
+        page._metadataTagsWasManaged = playlist.Tags !== undefined && playlist.Tags !== null;
+        if (SmartLists.initMetadataTagsInput) {
+            SmartLists.initMetadataTagsInput(page, playlist.Tags || []);
+        }
+
+        if (editMode) {
+            // Load existing images for this list, then re-sync the
+            // Advanced fold so an images-only list still expands.
+            if (SmartLists.loadExistingImages) {
+                SmartLists.loadExistingImages(page, opts.playlistId).then(function () {
+                    SmartLists.syncAdvancedSection(page, playlist);
+                });
+            }
+        }
+
+        // Chips + auto-expand from the populated config (images re-sync above in edit mode)
+        SmartLists.syncAdvancedSection(page, playlist);
+    };
+
     SmartLists.editPlaylist = function (page, playlistId) {
         const apiClient = SmartLists.getApiClient();
         Dashboard.showLoadingMsg();
@@ -916,190 +1122,7 @@
             }
 
             try {
-                // Store CreatedByUserId to preserve it during updates
-                if (playlist.CreatedByUserId) {
-                    page._editingPlaylistCreatedByUserId = playlist.CreatedByUserId;
-                }
-
-                // Determine list type
-                const listType = playlist.Type || 'Playlist';
-                const isCollection = listType === 'Collection';
-
-                // Extract userIds BEFORE calling handleListTypeChange (which triggers loadUsers)
-                // This ensures pendingUserIds is set before loadUsers checks for it
-                SmartLists.stagePendingUserSelection(page, playlist, isCollection);
-
-                // Set list type
-                SmartLists.setElementValue(page, '#listType', listType);
-
-                // Trigger type change handler to show/hide fields
-                SmartLists.handleListTypeChange(page);
-
-                // Populate form with playlist data using helper functions
-                SmartLists.setElementValue(page, '#playlistName', playlist.Name || '');
-
-                // Only set public for playlists
-                if (!isCollection) {
-                    SmartLists.setElementChecked(page, '#playlistIsPublic', playlist.Public || false);
-                }
-
-                SmartLists.setElementChecked(page, '#playlistIsEnabled', playlist.Enabled !== false); // Default to true for backward compatibility
-                SmartLists.setElementChecked(page, '#playlistIncludeExtras', playlist.IncludeExtras || false);
-                SmartLists.setElementChecked(page, '#playlistHideWhenEmpty', playlist.HideWhenEmpty || false);
-
-                // Handle AutoRefresh with backward compatibility
-                const autoRefreshValue = playlist.AutoRefresh !== undefined ? playlist.AutoRefresh : 'Never';
-                const autoRefreshElement = page.querySelector('#autoRefreshMode');
-                if (autoRefreshElement) {
-                    autoRefreshElement.value = autoRefreshValue;
-                }
-
-                // Handle schedule settings with backward compatibility
-                SmartLists.loadSchedulesIntoUI(page, playlist);
-
-                // Handle visibility schedule settings
-                SmartLists.loadVisibilitySchedulesIntoUI(page, playlist);
-
-                SmartLists.loadRandomGroupSelectionIntoUI(page, playlist);
-
-                // Handle MaxItems with backward compatibility for existing playlists
-                // Default to 0 (unlimited) for old playlists that didn't have this setting
-                const maxItemsValue = (playlist.MaxItems !== undefined && playlist.MaxItems !== null) ? playlist.MaxItems : 0;
-                const maxItemsElement = page.querySelector('#playlistMaxItems');
-                if (maxItemsElement) {
-                    maxItemsElement.value = maxItemsValue;
-                } else {
-                    console.warn('Max Items element not found when trying to populate edit form');
-                }
-
-                // Handle MaxPlayTimeMinutes with backward compatibility for existing playlists
-                // Default to 0 (unlimited) for old playlists that didn't have this setting
-                const maxPlayTimeMinutesValue = (playlist.MaxPlayTimeMinutes !== undefined && playlist.MaxPlayTimeMinutes !== null) ? playlist.MaxPlayTimeMinutes : 0;
-                const maxPlayTimeMinutesElement = page.querySelector('#playlistMaxPlayTimeMinutes');
-                if (maxPlayTimeMinutesElement) {
-                    maxPlayTimeMinutesElement.value = maxPlayTimeMinutesValue;
-                } else {
-                    console.warn('Max Playtime Minutes element not found when trying to populate edit form');
-                }
-
-                // Set media types
-                // Set flag to skip change event handlers while we programmatically set checkbox states
-                page._skipMediaTypeChangeHandlers = true;
-
-                if (playlist.MediaTypes && playlist.MediaTypes.length > 0) {
-                    SmartLists.setSelectedItems(page, 'mediaTypesMultiSelect', playlist.MediaTypes, 'media-type-multi-select-checkbox', 'Select media types...');
-                } else {
-                    SmartLists.setSelectedItems(page, 'mediaTypesMultiSelect', [], 'media-type-multi-select-checkbox', 'Select media types...');
-                }
-
-                // Clear flag to re-enable change event handlers
-                page._skipMediaTypeChangeHandlers = false;
-
-                // Update Include Extras visibility based on loaded media types
-                if (SmartLists.updateIncludeExtrasVisibility) {
-                    SmartLists.updateIncludeExtrasVisibility(page);
-                }
-                SmartLists.loadRandomGroupSelectionIntoUI(page, playlist);
-
-                // Set the list owner (for both playlists and collections)
-                // isCollection is already declared above on line 425
-                if (isCollection) {
-                    // Collections always have single user
-                    const userIdString = playlist.UserId ? String(playlist.UserId) : null;
-                    if (userIdString) {
-                        SmartLists.setUserIdValueWithRetry(page, userIdString);
-                    }
-                } else {
-                    // Playlists can have multiple users; selection was staged above
-                    SmartLists.applyPendingUserSelection(page);
-                    // If checkboxes don't exist yet, loadUsers will set them when it finishes
-                }
-
-                // Clear existing rules (applies to both playlists and collections)
-                const rulesContainer = page.querySelector('#rules-container');
-                rulesContainer.innerHTML = '';
-
-                // Populate logic groups and rules
-                if (playlist.ExpressionSets && playlist.ExpressionSets.length > 0 &&
-                    playlist.ExpressionSets.some(function (es) { return es.Expressions && es.Expressions.length > 0; })) {
-                    playlist.ExpressionSets.forEach(function (expressionSet, groupIndex) {
-                        const logicGroup = groupIndex === 0 ? SmartLists.createInitialLogicGroup(page) : SmartLists.addNewLogicGroup(page);
-
-                        // Store similarity comparison fields on page for populateRuleRow to access
-                        page._editingPlaylistSimilarityFields = playlist.SimilarityComparisonFields;
-
-                        // Populate rules and per-group MaxItems into this logic group
-                        SmartLists.populateLogicGroupExpressions(page, logicGroup, expressionSet);
-                    });
-                } else {
-                    // No rules exist - create an initial logic group with a placeholder rule
-                    // This matches the behavior when creating a new playlist
-                    SmartLists.createInitialLogicGroup(page);
-                }
-
-                // Clear and populate bumper rules
-                SmartLists.populateBumperConfigIntoForm(page, playlist);
-
-                // Set sort options AFTER rules are populated so hasSimilarToRuleInForm() can detect them
-                SmartLists.loadSortOptionsIntoUI(page, playlist);
-                // Update sort options visibility based on populated rules
-                SmartLists.updateAllSortOptionsVisibility(page);
-
-                // Update field selects first, then per-field options visibility based on selected media types
-                SmartLists.updateAllFieldSelects(page);
-                SmartLists.updateAllTagsOptionsVisibility(page);
-                SmartLists.updateAllStudiosOptionsVisibility(page);
-                SmartLists.updateAllGenresOptionsVisibility(page);
-                SmartLists.updateAllAudioLanguagesOptionsVisibility(page);
-                SmartLists.updateAllCollectionsOptionsVisibility(page);
-                SmartLists.updateAllNextUnwatchedOptionsVisibility(page);
-
-                // Update button visibility
-                SmartLists.updateRuleButtonVisibility(page);
-
-                // Set edit mode state
-                SmartLists.setPageEditState(page, true, playlistId);
-
-                // Update UI to show edit mode
-                const editIndicator = page.querySelector('#edit-mode-indicator');
-                if (editIndicator) {
-                    editIndicator.style.display = 'flex';
-                }
-                const submitBtn = page.querySelector('#submitBtn');
-                if (submitBtn) {
-                    const currentListType = SmartLists.getElementValue(page, '#listType', 'Playlist');
-                    submitBtn.textContent = 'Update ' + currentListType;
-                }
-
-                // Update tab button text
-                const createTabButton = page.querySelector('a[data-tab="create"]');
-                if (createTabButton) {
-                    createTabButton.textContent = 'Edit List';
-                }
-
-                // Switch to Create tab to show edit form
-                SmartLists.switchToTab(page, 'create');
-
-                // Populate metadata fields
-                SmartLists.setElementValue(page, '#metadataSortTitle', playlist.SortTitle || '');
-                SmartLists.setElementValue(page, '#metadataOverview', playlist.Overview || '');
-                SmartLists.setElementValue(page, '#metadataFavorite', playlist.Favorite === true ? 'true' : (playlist.Favorite === false ? 'false' : ''));
-                page._metadataTagsWasManaged = playlist.Tags !== undefined && playlist.Tags !== null;
-                if (SmartLists.initMetadataTagsInput) {
-                    SmartLists.initMetadataTagsInput(page, playlist.Tags || []);
-                }
-
-                // Load existing images for this playlist, then re-sync the
-                // Advanced fold so an images-only list still expands.
-                if (SmartLists.loadExistingImages) {
-                    SmartLists.loadExistingImages(page, playlistId).then(function () {
-                        SmartLists.syncAdvancedSection(page, playlist);
-                    });
-                }
-
-                // Chips + auto-expand from the loaded list (images re-sync above)
-                SmartLists.syncAdvancedSection(page, playlist);
-
+                SmartLists.populateFormFromDto(page, playlist, { editMode: true, playlistId: playlistId });
             } catch (formError) {
                 console.error('Error populating form for edit:', formError);
                 SmartLists.showNotification('Error loading playlist data for editing: ' + formError.message);
@@ -1136,167 +1159,10 @@
             }
 
             try {
-                // Determine list type
-                const listType = playlist.Type || 'Playlist';
-                const isCollection = listType === 'Collection';
-
-                // Extract userIds BEFORE calling handleListTypeChange (which triggers loadUsers)
-                // This ensures pendingUserIds is set before loadUsers checks for it
-                SmartLists.stagePendingUserSelection(page, playlist, isCollection);
-
-                // Set playlist name FIRST (before switchToTab) to prevent populateFormDefaults from being called
-                // switchToTab checks if name is empty and calls populateFormDefaults if so, which would regenerate checkboxes
-                SmartLists.setElementValue(page, '#playlistName', (playlist.Name || '') + ' (Copy)');
-
-                // Switch to Create tab
-                SmartLists.switchToTab(page, 'create');
-
-                // Clear any existing edit state
-                SmartLists.setPageEditState(page, false, null);
-
-                // Set list type
-                SmartLists.setElementValue(page, '#listType', listType);
-
-                // Set flag to prevent media type change handlers from interfering during cloning setup
-                page._skipMediaTypeChangeHandlers = true;
-
-                // Trigger type change handler to show/hide fields
-                SmartLists.handleListTypeChange(page);
-
-                // Only set public for playlists
-                if (!isCollection) {
-                    SmartLists.setElementChecked(page, '#playlistIsPublic', playlist.Public || false);
-                }
-
-                SmartLists.setElementChecked(page, '#playlistIsEnabled', playlist.Enabled !== false);
-                SmartLists.setElementChecked(page, '#playlistIncludeExtras', playlist.IncludeExtras || false);
-                SmartLists.setElementChecked(page, '#playlistHideWhenEmpty', playlist.HideWhenEmpty || false);
-
-                // Handle AutoRefresh
-                const autoRefreshValue = playlist.AutoRefresh !== undefined ? playlist.AutoRefresh : 'Never';
-                const autoRefreshElement = page.querySelector('#autoRefreshMode');
-                if (autoRefreshElement) {
-                    autoRefreshElement.value = autoRefreshValue;
-                }
-
-                // Handle schedule settings with backward compatibility (same as editPlaylist)
-                SmartLists.loadSchedulesIntoUI(page, playlist);
-
-                // Handle visibility schedule settings (same as editPlaylist)
-                SmartLists.loadVisibilitySchedulesIntoUI(page, playlist);
-
-                SmartLists.loadRandomGroupSelectionIntoUI(page, playlist);
-
-                // Handle MaxItems
-                const maxItemsValue = (playlist.MaxItems !== undefined && playlist.MaxItems !== null) ? playlist.MaxItems : 0;
-                const maxItemsElement = page.querySelector('#playlistMaxItems');
-                if (maxItemsElement) {
-                    maxItemsElement.value = maxItemsValue;
-                }
-
-                // Handle MaxPlayTimeMinutes
-                const maxPlayTimeMinutesValue = (playlist.MaxPlayTimeMinutes !== undefined && playlist.MaxPlayTimeMinutes !== null) ? playlist.MaxPlayTimeMinutes : 0;
-                const maxPlayTimeMinutesElement = page.querySelector('#playlistMaxPlayTimeMinutes');
-                if (maxPlayTimeMinutesElement) {
-                    maxPlayTimeMinutesElement.value = maxPlayTimeMinutesValue;
-                }
-
-                // Store media types to set later (after all updates are complete)
-                const clonedMediaTypes = playlist.MediaTypes && playlist.MediaTypes.length > 0 ? playlist.MediaTypes : [];
-
-                // Set media types BEFORE populating rules so that rule population can check selected media types
-                // Flag was already set at the beginning of clone process to prevent interference
-                // Set the media types from the cloned playlist
-                SmartLists.setSelectedItems(page, 'mediaTypesMultiSelect', clonedMediaTypes, 'media-type-multi-select-checkbox', 'Select media types...');
-
-                // Update Include Extras visibility based on cloned media types
-                if (SmartLists.updateIncludeExtrasVisibility) {
-                    SmartLists.updateIncludeExtrasVisibility(page);
-                }
-                SmartLists.loadRandomGroupSelectionIntoUI(page, playlist);
-
-                // Set the list owner (for both playlists and collections)
-                // isCollection is already declared above on line 650
-                if (isCollection) {
-                    // Collections always have single user
-                    const userIdString = playlist.UserId ? String(playlist.UserId) : null;
-                    if (userIdString) {
-                        SmartLists.setUserIdValueWithRetry(page, userIdString);
-                    }
-                } else {
-                    // Playlists can have multiple users; selection was staged above
-                    SmartLists.applyPendingUserSelection(page);
-                    // If checkboxes don't exist yet, loadUsers will set them when it finishes
-                }
-
-                // Clear existing rules and populate with cloned rules (applies to both playlists and collections)
-                const rulesContainer = page.querySelector('#rules-container');
-                if (rulesContainer) {
-                    rulesContainer.innerHTML = '';
-                }
-
-                // Populate rules from cloned playlist
-                if (playlist.ExpressionSets && playlist.ExpressionSets.length > 0) {
-                    playlist.ExpressionSets.forEach(function (expressionSet, setIndex) {
-                        const logicGroup = setIndex === 0 ? SmartLists.createInitialLogicGroup(page) : SmartLists.addNewLogicGroup(page);
-
-                        // Store similarity comparison fields on page for populateRuleRow to access
-                        page._cloningPlaylistSimilarityFields = playlist.SimilarityComparisonFields;
-
-                        // Populate rules and per-group MaxItems into this logic group
-                        SmartLists.populateLogicGroupExpressions(page, logicGroup, expressionSet);
-                    });
-                } else {
-                    // If no rules, create initial empty group
-                    SmartLists.createInitialLogicGroup(page);
-                }
-
-                // Clear and populate bumper rules
-                SmartLists.populateBumperConfigIntoForm(page, playlist);
-
-                // Update button visibility
-                SmartLists.updateRuleButtonVisibility(page);
-
-                // Update field selects first, then per-field options visibility based on selected media types
-                SmartLists.updateAllFieldSelects(page);
-                SmartLists.updateAllTagsOptionsVisibility(page);
-                SmartLists.updateAllStudiosOptionsVisibility(page);
-                SmartLists.updateAllGenresOptionsVisibility(page);
-                SmartLists.updateAllAudioLanguagesOptionsVisibility(page);
-                SmartLists.updateAllCollectionsOptionsVisibility(page);
-                SmartLists.updateAllNextUnwatchedOptionsVisibility(page);
-
-                // Set sort options AFTER rules are populated so hasSimilarToRuleInForm() can detect them
-                SmartLists.loadSortOptionsIntoUI(page, playlist);
-                // Update sort options visibility based on populated rules
-                SmartLists.updateAllSortOptionsVisibility(page);
-
-
-
-                // Clear flag to re-enable change event handlers
-                page._skipMediaTypeChangeHandlers = false;
-
-                // Clear any pending media type update timers just in case
-                if (page._mediaTypeUpdateTimer) {
-                    clearTimeout(page._mediaTypeUpdateTimer);
-                    page._mediaTypeUpdateTimer = null;
-                }
-
-                // Populate metadata fields
-                SmartLists.setElementValue(page, '#metadataSortTitle', playlist.SortTitle || '');
-                SmartLists.setElementValue(page, '#metadataOverview', playlist.Overview || '');
-                SmartLists.setElementValue(page, '#metadataFavorite', playlist.Favorite === true ? 'true' : (playlist.Favorite === false ? 'false' : ''));
-                page._metadataTagsWasManaged = playlist.Tags !== undefined && playlist.Tags !== null;
-                if (SmartLists.initMetadataTagsInput) {
-                    SmartLists.initMetadataTagsInput(page, playlist.Tags || []);
-                }
-
-                // Chips + auto-expand for cloned advanced config
-                SmartLists.syncAdvancedSection(page, playlist);
+                SmartLists.populateFormFromDto(page, playlist, { name: (playlist.Name || '') + ' (Copy)' });
 
                 // Show success message
                 SmartLists.showNotification('List "' + playlistName + '" cloned successfully! You can now modify and create the new list.', 'success');
-
             } catch (formError) {
                 console.error('Error populating form for clone:', formError);
                 SmartLists.showNotification('Error loading list data for cloning: ' + formError.message);

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-multi-select.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-multi-select.js
@@ -261,19 +261,14 @@
             options.appendChild(option);
         });
 
-        // Restore previously selected values after recreating checkboxes
+        // Restore previously selected values after recreating checkboxes.
+        // Synchronous on purpose: a deferred (setTimeout) restore raced any
+        // explicit setSelectedItems that ran right after the rebuild (e.g.
+        // edit/clone/template population after handleListTypeChange) and
+        // reverted it - and loadUsers' empty-selection fallback must see the
+        // restored checkboxes to know not to apply the current-user default.
         if (currentlySelected && currentlySelected.length > 0) {
-            // Use setTimeout to ensure checkboxes are fully rendered. Guard with a
-            // selection generation so an explicit setSelectedItems call that lands
-            // between scheduling and firing (e.g. edit/clone/template population
-            // right after handleListTypeChange) is not reverted by this restore.
-            const generationAtSchedule = options._selectionGeneration || 0;
-            setTimeout(function () {
-                if ((options._selectionGeneration || 0) !== generationAtSchedule) {
-                    return;
-                }
-                SmartLists.setSelectedItems(page, containerId, currentlySelected, checkboxClass, undefined);
-            }, 0);
+            SmartLists.setSelectedItems(page, containerId, currentlySelected, checkboxClass, undefined);
         }
     };
 
@@ -328,9 +323,6 @@
             console.warn('SmartLists.setSelectedItems: Options container not found for', containerId);
             return;
         }
-
-        // Invalidate any pending deferred selection restore (see loadItemsIntoMultiSelect)
-        options._selectionGeneration = (options._selectionGeneration || 0) + 1;
 
         const selector = checkboxClass ? '.' + checkboxClass : 'input[type="checkbox"]';
         const checkboxes = options.querySelectorAll(selector);

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-multi-select.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-multi-select.js
@@ -263,8 +263,15 @@
 
         // Restore previously selected values after recreating checkboxes
         if (currentlySelected && currentlySelected.length > 0) {
-            // Use setTimeout to ensure checkboxes are fully rendered
+            // Use setTimeout to ensure checkboxes are fully rendered. Guard with a
+            // selection generation so an explicit setSelectedItems call that lands
+            // between scheduling and firing (e.g. edit/clone/template population
+            // right after handleListTypeChange) is not reverted by this restore.
+            const generationAtSchedule = options._selectionGeneration || 0;
             setTimeout(function () {
+                if ((options._selectionGeneration || 0) !== generationAtSchedule) {
+                    return;
+                }
                 SmartLists.setSelectedItems(page, containerId, currentlySelected, checkboxClass, undefined);
             }, 0);
         }
@@ -321,6 +328,9 @@
             console.warn('SmartLists.setSelectedItems: Options container not found for', containerId);
             return;
         }
+
+        // Invalidate any pending deferred selection restore (see loadItemsIntoMultiSelect)
+        options._selectionGeneration = (options._selectionGeneration || 0) + 1;
 
         const selector = checkboxClass ? '.' + checkboxClass : 'input[type="checkbox"]';
         const checkboxes = options.querySelectorAll(selector);

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-templates.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-templates.js
@@ -1,0 +1,229 @@
+// Template catalog for the "Start from a template" picker on the Create tab.
+// Each dto is a partial SmartListDto containing only definition fields —
+// never instance fields (Id, FileName, Jellyfin IDs, dates, stats, images).
+// Rule MemberName/Operator/TargetValue strings and sort names must match the
+// backend vocabulary (FieldRegistry.cs / OrderFactory) — dev/validate-templates.js
+// checks the catalog against config-core.js.
+(function (SmartLists) {
+    'use strict';
+
+    SmartLists.TEMPLATES = [
+        {
+            id: 'tv-channel',
+            name: 'TV Channel',
+            category: 'TV',
+            description: 'Interleaves unwatched episodes from all your shows like a TV channel: one episode per series, round-robin, in order.',
+            adminOnly: false,
+            inputHint: null,
+            dto: {
+                Type: 'Playlist',
+                MediaTypes: ['Episode'],
+                ExpressionSets: [{
+                    Expressions: [
+                        { MemberName: 'PlaybackStatus', Operator: 'Equal', TargetValue: 'Unplayed' }
+                    ]
+                }],
+                Order: { SortOptions: [{ SortBy: 'Round Robin', SortOrder: 'Ascending', GroupByField: 'SeriesName' }] },
+                AutoRefresh: 'OnLibraryChanges'
+            }
+        },
+        {
+            id: 'franchise-tv-channel',
+            name: 'Franchise TV Channel',
+            category: 'TV',
+            description: 'Rotates through your collections (franchises) in broadcast order, resuming the least recently watched one. Crossover episodes that aired within 3 days stay together.',
+            adminOnly: false,
+            inputHint: null,
+            dto: {
+                Type: 'Playlist',
+                MediaTypes: ['Episode'],
+                ExpressionSets: [{
+                    Expressions: [
+                        { MemberName: 'PlaybackStatus', Operator: 'Equal', TargetValue: 'Unplayed' }
+                    ]
+                }],
+                Order: {
+                    SortOptions: [{
+                        SortBy: 'Least Recently Watched Round Robin',
+                        SortOrder: 'Ascending',
+                        GroupByField: 'Collections',
+                        WithinGroupOrder: 'AirDate',
+                        AirBlockWindowDays: 3
+                    }]
+                },
+                AutoRefresh: 'OnAllChanges'
+            }
+        },
+        {
+            id: 'continue-watching',
+            name: 'Continue Watching',
+            category: 'TV',
+            description: 'The next unwatched episode of every show you are in the middle of, with the show you have not touched longest surfacing first. Updates itself as you watch.',
+            adminOnly: false,
+            inputHint: null,
+            dto: {
+                Type: 'Playlist',
+                MediaTypes: ['Episode'],
+                ExpressionSets: [{
+                    Expressions: [
+                        { MemberName: 'NextUnwatched', Operator: 'Equal', TargetValue: 'true' }
+                    ]
+                }],
+                Order: { SortOptions: [{ SortBy: 'Least Recently Watched Round Robin', SortOrder: 'Ascending', GroupByField: 'SeriesName' }] },
+                AutoRefresh: 'OnAllChanges'
+            }
+        },
+        {
+            id: 'saturday-cartoons',
+            name: 'Saturday Morning Cartoons',
+            category: 'TV',
+            description: 'Animated episodes with bumper clips woven in every 2 episodes, visible only on weekend mornings. Tag your bumper videos and enter that tag in the bumper rule.',
+            adminOnly: false,
+            inputHint: 'Enter the tag of your bumper videos in the empty bumper rule value (tag some short videos first).',
+            dto: {
+                Type: 'Playlist',
+                MediaTypes: ['Episode'],
+                ExpressionSets: [{
+                    Expressions: [
+                        { MemberName: 'Genres', Operator: 'Contains', TargetValue: 'Animation' },
+                        { MemberName: 'PlaybackStatus', Operator: 'Equal', TargetValue: 'Unplayed' }
+                    ]
+                }],
+                Order: { SortOptions: [{ SortBy: 'Round Robin', SortOrder: 'Ascending', GroupByField: 'SeriesName' }] },
+                Bumpers: {
+                    ExpressionSets: [{
+                        Expressions: [
+                            { MemberName: 'Tags', Operator: 'Contains', TargetValue: '' }
+                        ]
+                    }],
+                    MediaTypes: ['Video'],
+                    BumperOrder: 'Random',
+                    Interval: 2
+                },
+                VisibilitySchedules: [
+                    { Action: 'Enable', Trigger: 'Weekly', DayOfWeek: 6, Time: '06:00:00' },
+                    { Action: 'Disable', Trigger: 'Weekly', DayOfWeek: 0, Time: '12:00:00' }
+                ]
+            }
+        },
+        {
+            id: 'because-you-watched',
+            name: 'Because You Watched…',
+            category: 'Movies',
+            description: 'Movies similar to a title you pick, best matches first. Compares genres, tags, actors and directors.',
+            adminOnly: false,
+            inputHint: 'Type the title to find similar movies for in the empty rule value.',
+            dto: {
+                Type: 'Playlist',
+                MediaTypes: ['Movie'],
+                ExpressionSets: [{
+                    Expressions: [
+                        { MemberName: 'SimilarTo', Operator: 'Equal', TargetValue: '' }
+                    ]
+                }],
+                SimilarityComparisonFields: ['Genre', 'Tags', 'Actors', 'Directors'],
+                Order: { SortOptions: [{ SortBy: 'Similarity', SortOrder: 'Descending' }] },
+                MaxItems: 25
+            }
+        },
+        {
+            id: 'balanced-mix',
+            name: 'Balanced Genre Mix',
+            category: 'Movies',
+            description: 'Up to 15 movies each of Action, Comedy and Drama, kept in that block order. Change the genres to taste — each rule block has its own item limit.',
+            adminOnly: false,
+            inputHint: null,
+            dto: {
+                Type: 'Playlist',
+                MediaTypes: ['Movie'],
+                ExpressionSets: [
+                    { Expressions: [{ MemberName: 'Genres', Operator: 'Contains', TargetValue: 'Action' }], MaxItems: 15 },
+                    { Expressions: [{ MemberName: 'Genres', Operator: 'Contains', TargetValue: 'Comedy' }], MaxItems: 15 },
+                    { Expressions: [{ MemberName: 'Genres', Operator: 'Contains', TargetValue: 'Drama' }], MaxItems: 15 }
+                ],
+                Order: { SortOptions: [{ SortBy: 'Rule Block Order', SortOrder: 'Ascending' }] }
+            }
+        },
+        {
+            id: 'fresh-and-unseen',
+            name: 'Fresh & Unseen',
+            category: 'Movies',
+            description: 'Movies added in the last 30 days that you have not watched yet, newest first. Kept current automatically.',
+            adminOnly: false,
+            inputHint: null,
+            dto: {
+                Type: 'Playlist',
+                MediaTypes: ['Movie'],
+                ExpressionSets: [{
+                    Expressions: [
+                        { MemberName: 'DateCreated', Operator: 'NewerThan', TargetValue: '30:days' },
+                        { MemberName: 'PlaybackStatus', Operator: 'Equal', TargetValue: 'Unplayed' }
+                    ]
+                }],
+                Order: { SortOptions: [{ SortBy: 'DateCreated', SortOrder: 'Descending' }] },
+                AutoRefresh: 'OnAllChanges'
+            }
+        },
+        {
+            id: 'trakt-trending',
+            name: 'Trending Now (Trakt)',
+            category: 'Movies',
+            description: 'A collection of the movies trending on Trakt right now, refreshed daily. Requires a Trakt Client ID in the plugin settings (admin, Settings tab). Hidden while empty.',
+            adminOnly: false,
+            inputHint: null,
+            dto: {
+                Type: 'Collection',
+                MediaTypes: ['Movie'],
+                ExpressionSets: [{
+                    Expressions: [
+                        { MemberName: 'ExternalList', Operator: 'Equal', TargetValue: 'https://trakt.tv/movies/trending' }
+                    ]
+                }],
+                Order: { SortOptions: [{ SortBy: 'External List Order', SortOrder: 'Ascending' }] },
+                Schedules: [{ Trigger: 'Daily', Time: '06:00:00' }],
+                HideWhenEmpty: true,
+                MaxItems: 50
+            }
+        },
+        {
+            id: 'weekly-jams',
+            name: 'Weekly Jams (ListenBrainz)',
+            category: 'Music',
+            description: 'Your personalized ListenBrainz Weekly Jams as a playlist, in list order, refreshed weekly. No API key needed — just your ListenBrainz username in the feed URL.',
+            adminOnly: false,
+            inputHint: 'Paste your feed URL in the empty rule value: https://listenbrainz.org/syndication-feed/user/YOUR_USERNAME/recommendations?recommendation_type=weekly-jams',
+            dto: {
+                Type: 'Playlist',
+                MediaTypes: ['Audio'],
+                ExpressionSets: [{
+                    Expressions: [
+                        { MemberName: 'ExternalList', Operator: 'Equal', TargetValue: '' }
+                    ]
+                }],
+                Order: { SortOptions: [{ SortBy: 'External List Order', SortOrder: 'Ascending' }] },
+                Schedules: [{ Trigger: 'Weekly', DayOfWeek: 1, Time: '08:00:00' }]
+            }
+        },
+        {
+            id: 'album-roulette',
+            name: 'Album Roulette',
+            category: 'Music',
+            description: 'A few random complete albums (at least 5 tracks each), tracks in album order, capped at 3 hours. Re-roll by refreshing the list.',
+            adminOnly: false,
+            inputHint: null,
+            dto: {
+                Type: 'Playlist',
+                MediaTypes: ['Audio'],
+                ExpressionSets: [],
+                RandomGroupSelection: { Enabled: true, GroupBy: 'Album', MinimumItems: 5 },
+                Order: {
+                    SortOptions: [
+                        { SortBy: 'AlbumName', SortOrder: 'Ascending' },
+                        { SortBy: 'TrackNumber', SortOrder: 'Ascending' }
+                    ]
+                },
+                MaxPlayTimeMinutes: 180
+            }
+        }
+    ];
+})(window.SmartLists = window.SmartLists || {});

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-templates.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-templates.js
@@ -314,7 +314,7 @@
         if (template.inputHint) {
             SmartLists.showNotification(template.inputHint);
             // Focus the first empty rule value so the user sees what to fill in
-            const inputs = page.querySelectorAll('#rules-container .rule-value-input');
+            const inputs = page.querySelectorAll('#rules-container .rule-value-input, #bumper-rules-container .rule-value-input');
             for (let i = 0; i < inputs.length; i++) {
                 if (!inputs[i].value) {
                     inputs[i].focus();

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-templates.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-templates.js
@@ -226,4 +226,103 @@
             }
         }
     ];
+
+    function visibleTemplates(page) {
+        const isUserPage = SmartLists.isUserPage(page);
+        const caps = SmartLists.userCapabilities || {};
+        return SmartLists.TEMPLATES.filter(function (t) {
+            if (isUserPage && t.adminOnly) {
+                return false;
+            }
+            // Hide collection templates from users who cannot create collections
+            if (isUserPage && t.dto.Type === 'Collection' && !caps.CanCreateCollections) {
+                return false;
+            }
+            return true;
+        });
+    }
+
+    function findTemplate(templateId) {
+        for (let i = 0; i < SmartLists.TEMPLATES.length; i++) {
+            if (SmartLists.TEMPLATES[i].id === templateId) {
+                return SmartLists.TEMPLATES[i];
+            }
+        }
+        return null;
+    }
+
+    SmartLists.initTemplatePicker = function (page) {
+        const select = page.querySelector('#templateSelect');
+        if (!select) {
+            return;
+        }
+
+        const templates = visibleTemplates(page);
+        let html = '<option value="">Select a template...</option>';
+        let currentCategory = null;
+        templates.forEach(function (t) {
+            if (t.category !== currentCategory) {
+                if (currentCategory !== null) {
+                    html += '</optgroup>';
+                }
+                html += '<optgroup label="' + SmartLists.escapeHtml(t.category) + '">';
+                currentCategory = t.category;
+            }
+            html += '<option value="' + SmartLists.escapeHtml(t.id) + '">' + SmartLists.escapeHtml(t.name) + '</option>';
+        });
+        if (currentCategory !== null) {
+            html += '</optgroup>';
+        }
+        select.innerHTML = html;
+
+        if (!select._templatePickerBound) {
+            select._templatePickerBound = true;
+            select.addEventListener('change', function () {
+                const template = findTemplate(select.value);
+                const descriptionDiv = page.querySelector('#templateDescription');
+                const useBtn = page.querySelector('#useTemplateBtn');
+                if (descriptionDiv) {
+                    descriptionDiv.textContent = template ? template.description : '';
+                    descriptionDiv.style.display = template ? 'block' : 'none';
+                }
+                if (useBtn) {
+                    useBtn.disabled = !template;
+                }
+            });
+        }
+    };
+
+    SmartLists.useTemplate = function (page, templateId) {
+        const template = findTemplate(templateId);
+        if (!template) {
+            return;
+        }
+
+        // Deep-copy so form population can never mutate the catalog
+        const dto = JSON.parse(JSON.stringify(template.dto));
+
+        try {
+            SmartLists.populateFormFromDto(page, dto, { name: template.name });
+        } catch (formError) {
+            console.error('Error applying template:', formError);
+            SmartLists.showNotification('Error applying template: ' + formError.message);
+            return;
+        }
+
+        page._templatePlaceholderPending = !!template.inputHint;
+
+        if (template.inputHint) {
+            SmartLists.showNotification(template.inputHint);
+            // Focus the first empty rule value so the user sees what to fill in
+            const inputs = page.querySelectorAll('#rules-container .rule-value-input');
+            for (let i = 0; i < inputs.length; i++) {
+                if (!inputs[i].value) {
+                    inputs[i].focus();
+                    break;
+                }
+            }
+        } else {
+            SmartLists.showNotification('Template applied - review the settings and click Create.', 'success');
+        }
+    };
 })(window.SmartLists = window.SmartLists || {});

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-templates.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-templates.js
@@ -312,7 +312,7 @@
         page._templatePlaceholderPending = !!template.inputHint;
 
         if (template.inputHint) {
-            SmartLists.showNotification(template.inputHint);
+            SmartLists.showNotification(template.inputHint, 'info');
             // Focus the first empty rule value so the user sees what to fill in
             const inputs = page.querySelectorAll('#rules-container .rule-value-input, #bumper-rules-container .rule-value-input');
             for (let i = 0; i < inputs.length; i++) {

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-templates.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-templates.js
@@ -253,9 +253,14 @@
         return null;
     }
 
-    // Clear selection, description, and Use-button state. Called from
+    // Clear selection, description, and Use-button state, and re-show the
+    // picker (populateFormFromDto hides it in edit mode). Called from
     // initTemplatePicker after rebuilding the options and from clearForm.
     SmartLists.resetTemplatePicker = function (page) {
+        const container = page.querySelector('#templatePickerContainer');
+        if (container) {
+            container.style.display = '';
+        }
         const select = page.querySelector('#templateSelect');
         if (select) {
             select.value = '';

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-templates.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-templates.js
@@ -102,6 +102,8 @@
                 },
                 VisibilitySchedules: [
                     { Action: 'Enable', Trigger: 'Weekly', DayOfWeek: 6, Time: '06:00:00' },
+                    { Action: 'Disable', Trigger: 'Weekly', DayOfWeek: 6, Time: '12:00:00' },
+                    { Action: 'Enable', Trigger: 'Weekly', DayOfWeek: 0, Time: '06:00:00' },
                     { Action: 'Disable', Trigger: 'Weekly', DayOfWeek: 0, Time: '12:00:00' }
                 ]
             }
@@ -251,6 +253,24 @@
         return null;
     }
 
+    // Clear selection, description, and Use-button state. Called from
+    // initTemplatePicker after rebuilding the options and from clearForm.
+    SmartLists.resetTemplatePicker = function (page) {
+        const select = page.querySelector('#templateSelect');
+        if (select) {
+            select.value = '';
+        }
+        const descriptionDiv = page.querySelector('#templateDescription');
+        if (descriptionDiv) {
+            descriptionDiv.textContent = '';
+            descriptionDiv.style.display = 'none';
+        }
+        const useBtn = page.querySelector('#useTemplateBtn');
+        if (useBtn) {
+            useBtn.disabled = true;
+        }
+    };
+
     SmartLists.initTemplatePicker = function (page) {
         const select = page.querySelector('#templateSelect');
         if (!select) {
@@ -274,6 +294,11 @@
             html += '</optgroup>';
         }
         select.innerHTML = html;
+
+        // Rebuilding options silently resets the value to '' without a change
+        // event - sync the description and Use button so an SPA page revisit
+        // doesn't keep a stale description and an enabled Use button
+        SmartLists.resetTemplatePicker(page);
 
         if (!select._templatePickerBound) {
             select._templatePickerBound = true;
@@ -306,6 +331,9 @@
         } catch (formError) {
             console.error('Error applying template:', formError);
             SmartLists.showNotification('Error applying template: ' + formError.message);
+            // Re-arm the guard: a partial population may have left the
+            // template's empty placeholder rule in the form
+            page._templatePlaceholderPending = !!template.inputHint;
             return;
         }
 
@@ -313,13 +341,17 @@
 
         if (template.inputHint) {
             SmartLists.showNotification(template.inputHint, 'info');
+            // Notifications auto-dismiss - keep the hint (which may contain a
+            // URL pattern to copy) readable in the picker description too
+            const descriptionDiv = page.querySelector('#templateDescription');
+            if (descriptionDiv) {
+                descriptionDiv.textContent = template.description + ' — ' + template.inputHint;
+                descriptionDiv.style.display = 'block';
+            }
             // Focus the first empty rule value so the user sees what to fill in
-            const inputs = page.querySelectorAll('#rules-container .rule-value-input, #bumper-rules-container .rule-value-input');
-            for (let i = 0; i < inputs.length; i++) {
-                if (!inputs[i].value) {
-                    inputs[i].focus();
-                    break;
-                }
+            const emptyInput = SmartLists.findFirstEmptyRuleValueInput(page);
+            if (emptyInput) {
+                emptyInput.focus();
             }
         } else {
             SmartLists.showNotification('Template applied - review the settings and click Create.', 'success');

--- a/Jellyfin.Plugin.SmartLists/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config.html
@@ -1258,6 +1258,8 @@
         <script src="configurationpage?name=config-rules.js"></script>
         <!-- List CRUD operations -->
         <script src="configurationpage?name=config-lists.js"></script>
+        <!-- Template catalog and picker -->
+        <script src="configurationpage?name=config-templates.js"></script>
         <!-- Filtering and search -->
         <script src="configurationpage?name=config-filters.js"></script>
         <!-- Bulk actions -->

--- a/Jellyfin.Plugin.SmartLists/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config.html
@@ -51,7 +51,15 @@
                             <button type="button" id="cancelEditBtn" class="emby-button raised">Cancel Edit</button>
                         </div>
                         <div class="inputContainer" id="templatePickerContainer" style="margin-bottom: 1em;">
-                            <label class="inputLabel" for="templateSelect">Start from a template (optional)</label>
+                            <label class="inputLabel" for="templateSelect" style="display: flex; align-items: center;">
+                                Start from a template (optional)
+                                <a href="https://jellyfin-smartlists-plugin.dinsten.se/user-guide/configuration/#start-from-a-template"
+                                    target="_blank" rel="noopener noreferrer" title="Documentation"
+                                    style="margin-left: 0.5em; text-decoration: none; color: inherit; display: inline-flex; align-items: center;">
+                                    <span class="material-icons" aria-hidden="true"
+                                        style="font-size: 1.1em; line-height: 0;">info_outline</span>
+                                </a>
+                            </label>
                             <div style="display: flex; gap: 0.5em; align-items: center;">
                                 <select is="emby-select" id="templateSelect" class="emby-select" style="flex: 1;">
                                 </select>

--- a/Jellyfin.Plugin.SmartLists/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config.html
@@ -50,6 +50,15 @@
                             <span style="color: var(--jf-palette-Alert-warningColor); font-weight: 500;">✏️ Editing Mode - Modifying existing list</span>
                             <button type="button" id="cancelEditBtn" class="emby-button raised">Cancel Edit</button>
                         </div>
+                        <div class="inputContainer" id="templatePickerContainer" style="margin-bottom: 1em;">
+                            <label class="inputLabel" for="templateSelect">Start from a template (optional)</label>
+                            <div style="display: flex; gap: 0.5em; align-items: center;">
+                                <select is="emby-select" id="templateSelect" class="emby-select" style="flex: 1;">
+                                </select>
+                                <button type="button" id="useTemplateBtn" class="emby-button raised" disabled>Use</button>
+                            </div>
+                            <div id="templateDescription" class="fieldDescription" style="display: none; margin-top: 0.4em;"></div>
+                        </div>
                         <div class="inputContainer" style="margin-bottom: 1em;">
                             <label class="inputLabel" for="listType" style="display: flex; align-items: center;">
                                 List Type

--- a/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
@@ -35,7 +35,15 @@
                             <button type="button" id="cancelEditBtn" class="emby-button raised">Cancel Edit</button>
                         </div>
                         <div class="inputContainer" id="templatePickerContainer" style="margin-bottom: 1em;">
-                            <label class="inputLabel" for="templateSelect">Start from a template (optional)</label>
+                            <label class="inputLabel" for="templateSelect" style="display: flex; align-items: center;">
+                                Start from a template (optional)
+                                <a href="https://jellyfin-smartlists-plugin.dinsten.se/user-guide/configuration/#start-from-a-template"
+                                    target="_blank" rel="noopener noreferrer" title="Documentation"
+                                    style="margin-left: 0.5em; text-decoration: none; color: inherit; display: inline-flex; align-items: center;">
+                                    <span class="material-icons" aria-hidden="true"
+                                        style="font-size: 1.1em; line-height: 0;">info_outline</span>
+                                </a>
+                            </label>
                             <div style="display: flex; gap: 0.5em; align-items: center;">
                                 <select is="emby-select" id="templateSelect" class="emby-select" style="flex: 1;">
                                 </select>

--- a/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
@@ -34,6 +34,15 @@
                             <span style="color: var(--jf-palette-Alert-warningColor); font-weight: 500;">✏️ Editing Mode - Modifying existing list</span>
                             <button type="button" id="cancelEditBtn" class="emby-button raised">Cancel Edit</button>
                         </div>
+                        <div class="inputContainer" id="templatePickerContainer" style="margin-bottom: 1em;">
+                            <label class="inputLabel" for="templateSelect">Start from a template (optional)</label>
+                            <div style="display: flex; gap: 0.5em; align-items: center;">
+                                <select is="emby-select" id="templateSelect" class="emby-select" style="flex: 1;">
+                                </select>
+                                <button type="button" id="useTemplateBtn" class="emby-button raised" disabled>Use</button>
+                            </div>
+                            <div id="templateDescription" class="fieldDescription" style="display: none; margin-top: 0.4em;"></div>
+                        </div>
                         <!-- List Type - shown/hidden based on user permissions -->
                         <div class="inputContainer" id="listTypeContainer" style="margin-bottom: 1em;">
                             <label class="inputLabel" for="listType" style="display: flex; align-items: center;">

--- a/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
@@ -633,6 +633,8 @@
         <script src="configurationpage?name=config-rules.js"></script>
         <!-- List CRUD operations -->
         <script src="configurationpage?name=config-lists.js"></script>
+        <!-- Template catalog and picker -->
+        <script src="configurationpage?name=config-templates.js"></script>
         <!-- Filtering and search -->
         <script src="configurationpage?name=config-filters.js"></script>
         <!-- Bulk actions and playlist card interactions -->

--- a/Jellyfin.Plugin.SmartLists/Jellyfin.Plugin.SmartLists.csproj
+++ b/Jellyfin.Plugin.SmartLists/Jellyfin.Plugin.SmartLists.csproj
@@ -46,6 +46,8 @@
     <EmbeddedResource Include="Configuration\config-rules.js" />
     <!-- Playlist CRUD operations -->
     <EmbeddedResource Include="Configuration\config-lists.js" />
+    <!-- Template catalog and picker -->
+    <EmbeddedResource Include="Configuration\config-templates.js" />
     <!-- Filtering and search -->
     <EmbeddedResource Include="Configuration\config-filters.js" />
     <!-- Bulk actions -->

--- a/Jellyfin.Plugin.SmartLists/Plugin.cs
+++ b/Jellyfin.Plugin.SmartLists/Plugin.cs
@@ -146,6 +146,12 @@ namespace Jellyfin.Plugin.SmartLists
                     Name = "config-lists.js",
                     EmbeddedResourcePath = GetType().Namespace + ".Configuration.config-lists.js",
                 },
+                // Template catalog and picker
+                new PluginPageInfo
+                {
+                    Name = "config-templates.js",
+                    EmbeddedResourcePath = GetType().Namespace + ".Configuration.config-templates.js",
+                },
                 // Filtering and search
                 new PluginPageInfo
                 {

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This plugin allows you to create dynamic playlists and collections based on a se
 - **Refresh Status & Statistics** - Monitor ongoing refresh operations with real-time progress, view refresh history, and track statistics for all your lists
 - **Media Types** - Works with all Jellyfin media types
 - **End User Config Page** - Let regular users manage their own smart lists from the home screen (requires [Plugin Pages](https://github.com/IAmParadox27/jellyfin-plugin-pages) and [File Transformation](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) plugins)
+- **Templates** - Start from built-in templates - TV channel round-robin, Continue Watching, external-list imports, album roulette, and more
 - **And more** - [View the documentation](https://jellyfin-smartlists-plugin.dinsten.se) to see all features
 
 ## 🚀 Quick Start

--- a/dev/validate-templates.js
+++ b/dev/validate-templates.js
@@ -7,6 +7,8 @@ const vm = require('vm');
 
 const cfgDir = path.join(__dirname, '..', 'Jellyfin.Plugin.SmartLists', 'Configuration');
 const coreSrc = fs.readFileSync(path.join(cfgDir, 'config-core.js'), 'utf8');
+// rulesSrc is intentionally never executed in the vm - it is only text-searched
+// (indexOf) for quoted field names; running it would need far heavier DOM stubs
 const rulesSrc = fs.readFileSync(path.join(cfgDir, 'config-rules.js'), 'utf8');
 const templatesSrc = fs.readFileSync(path.join(cfgDir, 'config-templates.js'), 'utf8');
 

--- a/dev/validate-templates.js
+++ b/dev/validate-templates.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+// Validates the template catalog (config-templates.js) against the frontend
+// vocabulary in config-core.js. Run: node dev/validate-templates.js
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const cfgDir = path.join(__dirname, '..', 'Jellyfin.Plugin.SmartLists', 'Configuration');
+const coreSrc = fs.readFileSync(path.join(cfgDir, 'config-core.js'), 'utf8');
+const rulesSrc = fs.readFileSync(path.join(cfgDir, 'config-rules.js'), 'utf8');
+const templatesSrc = fs.readFileSync(path.join(cfgDir, 'config-templates.js'), 'utf8');
+
+const stubEl = { classList: { contains: function () { return false; } } };
+const sandbox = {
+    window: {},
+    document: {
+        querySelector: function () { return null; },
+        querySelectorAll: function () { return []; },
+        addEventListener: function () {},
+        createElement: function () { return stubEl; }
+    },
+    console: console,
+    setTimeout: setTimeout,
+    clearTimeout: clearTimeout
+};
+sandbox.window.SmartLists = {};
+vm.createContext(sandbox);
+vm.runInContext(coreSrc, sandbox, { filename: 'config-core.js' });
+vm.runInContext(templatesSrc, sandbox, { filename: 'config-templates.js' });
+
+const SL = sandbox.window.SmartLists;
+const errors = [];
+function check(cond, msg) { if (!cond) { errors.push(msg); } }
+
+check(Array.isArray(SL.TEMPLATES) && SL.TEMPLATES.length > 0, 'SmartLists.TEMPLATES missing or empty');
+
+const sortValues = (SL.SORT_OPTIONS || []).map(function (o) { return typeof o === 'string' ? o : o.value; });
+const groupFields = (SL.ROUND_ROBIN_GROUP_FIELDS || []).map(function (o) { return typeof o === 'string' ? o : o.value; });
+const OPERATORS = ['Equal', 'NotEqual', 'Contains', 'NotContains', 'IsIn', 'IsNotIn', 'MatchRegex',
+    'GreaterThan', 'LessThan', 'GreaterThanOrEqual', 'LessThanOrEqual',
+    'After', 'Before', 'NewerThan', 'OlderThan', 'Weekday'];
+const MEDIA_TYPES = ['Episode', 'Series', 'Season', 'Movie', 'Audio', 'MusicAlbum', 'MusicVideo', 'Video', 'Photo', 'Book', 'AudioBook'];
+const AUTO_REFRESH = ['Never', 'OnLibraryChanges', 'OnAllChanges'];
+const TRIGGERS = ['None', 'Daily', 'Weekly', 'Monthly', 'Interval', 'Yearly'];
+const seenIds = {};
+
+(SL.TEMPLATES || []).forEach(function (t) {
+    const p = 'template "' + t.id + '": ';
+    check(t.id && t.name && t.category && t.description, p + 'id/name/category/description required');
+    check(!seenIds[t.id], p + 'duplicate id');
+    seenIds[t.id] = true;
+    check(t.dto && typeof t.dto === 'object', p + 'dto required');
+    if (!t.dto) { return; }
+    const dto = t.dto;
+    check(dto.Type === 'Playlist' || dto.Type === 'Collection', p + 'Type must be Playlist|Collection');
+    check(Array.isArray(dto.MediaTypes) && dto.MediaTypes.length > 0, p + 'MediaTypes required');
+    (dto.MediaTypes || []).forEach(function (m) {
+        check(MEDIA_TYPES.indexOf(m) !== -1, p + 'unknown MediaType ' + m);
+    });
+    check(Array.isArray(dto.ExpressionSets), p + 'ExpressionSets must be an array');
+    ['Id', 'FileName', 'JellyfinPlaylistId', 'JellyfinCollectionId', 'DateCreated', 'LastRefreshed',
+        'ItemCount', 'TotalRuntimeMinutes', 'CustomImages', 'UserPlaylists', 'UserId', 'CreatedByUserId'
+    ].forEach(function (k) {
+        check(!(k in dto), p + 'instance field ' + k + ' must not be in a template dto');
+    });
+    function checkExpressionSets(sets, where) {
+        (sets || []).forEach(function (set) {
+            check(Array.isArray(set.Expressions), p + where + ' set missing Expressions array');
+            (set.Expressions || []).forEach(function (e) {
+                check(typeof e.MemberName === 'string' && e.MemberName.length > 0, p + where + ' rule missing MemberName');
+                check(OPERATORS.indexOf(e.Operator) !== -1, p + where + ' unknown Operator ' + e.Operator);
+                check(typeof e.TargetValue === 'string', p + where + ' TargetValue must be a string');
+                // Every valid field name appears as a quoted string in the frontend sources
+                const quoted = "'" + e.MemberName + "'";
+                check(coreSrc.indexOf(quoted) !== -1 || rulesSrc.indexOf(quoted) !== -1,
+                    p + where + ' MemberName not found in config-core.js/config-rules.js: ' + e.MemberName);
+            });
+        });
+    }
+    checkExpressionSets(dto.ExpressionSets, 'rule');
+    if (dto.Bumpers) {
+        checkExpressionSets(dto.Bumpers.ExpressionSets, 'bumper');
+        check(['Random', 'Name', 'ReleaseDate'].indexOf(dto.Bumpers.BumperOrder) !== -1, p + 'bad BumperOrder');
+        check(dto.Bumpers.Interval >= 1, p + 'bumper Interval must be >= 1');
+        check(dto.Type === 'Playlist', p + 'Bumpers are playlist-only');
+    }
+    ((dto.Order || {}).SortOptions || []).forEach(function (s) {
+        check(sortValues.indexOf(s.SortBy) !== -1, p + 'unknown SortBy ' + s.SortBy);
+        check(s.SortOrder === 'Ascending' || s.SortOrder === 'Descending', p + 'bad SortOrder for ' + s.SortBy);
+        if (s.GroupByField) {
+            check(groupFields.indexOf(s.GroupByField) !== -1, p + 'unknown GroupByField ' + s.GroupByField);
+        }
+        if (s.WithinGroupOrder) {
+            check(s.WithinGroupOrder === 'AirDate', p + 'WithinGroupOrder must be AirDate');
+        }
+        if (s.AirBlockWindowDays !== undefined) {
+            check(s.GroupByField === 'Collections' && s.WithinGroupOrder === 'AirDate',
+                p + 'AirBlockWindowDays needs GroupByField Collections + WithinGroupOrder AirDate');
+            check(s.AirBlockWindowDays >= 0 && s.AirBlockWindowDays <= 30, p + 'AirBlockWindowDays out of range');
+        }
+    });
+    if (dto.AutoRefresh !== undefined) {
+        check(AUTO_REFRESH.indexOf(dto.AutoRefresh) !== -1, p + 'bad AutoRefresh ' + dto.AutoRefresh);
+    }
+    (dto.Schedules || []).concat(dto.VisibilitySchedules || []).forEach(function (s) {
+        check(TRIGGERS.indexOf(s.Trigger) !== -1, p + 'bad schedule Trigger ' + s.Trigger);
+        if (s.Time !== undefined) {
+            check(/^\d{2}:\d{2}:00$/.test(s.Time), p + 'schedule Time must be HH:MM:00, got ' + s.Time);
+        }
+        if (s.DayOfWeek !== undefined) {
+            check(typeof s.DayOfWeek === 'number' && s.DayOfWeek >= 0 && s.DayOfWeek <= 6, p + 'DayOfWeek must be integer 0-6');
+        }
+    });
+    (dto.VisibilitySchedules || []).forEach(function (s) {
+        check(s.Action === 'Enable' || s.Action === 'Disable', p + 'visibility schedule needs Action Enable|Disable');
+    });
+    if (dto.RandomGroupSelection) {
+        check(['Artists', 'AlbumArtists', 'Album', 'SeriesName', 'Genres', 'Studios', 'Tags'].indexOf(dto.RandomGroupSelection.GroupBy) !== -1,
+            p + 'bad RandomGroupSelection.GroupBy');
+    }
+    if (t.inputHint) {
+        // Placeholder templates must actually contain an empty value to fill
+        const allSets = (dto.ExpressionSets || []).concat(dto.Bumpers ? dto.Bumpers.ExpressionSets : []);
+        const hasEmpty = allSets.some(function (set) {
+            return (set.Expressions || []).some(function (e) { return e.TargetValue === ''; });
+        });
+        check(hasEmpty, p + 'inputHint set but no empty TargetValue');
+    }
+});
+
+if (errors.length) {
+    console.error('TEMPLATE VALIDATION FAILED (' + errors.length + '):');
+    errors.forEach(function (e) { console.error('  - ' + e); });
+    process.exit(1);
+}
+console.log('All ' + SL.TEMPLATES.length + ' templates valid.');

--- a/docs/content/getting-started/quick-start.md
+++ b/docs/content/getting-started/quick-start.md
@@ -30,6 +30,11 @@ SmartLists can be accessed in two ways depending on your user permissions:
 
 ## Creating Your First List
 
+!!! tip "Shortcut: start from a template"
+    The quickest first list: pick a built-in template from **Start from a template**
+    at the top of the Create tab and click **Use** — the form is filled in for you,
+    ready to review and create. The steps below build the same thing by hand.
+
 1. **Access SmartLists**: Use one of the methods above
 2. **Navigate to Create List Tab**: Click on the "Create List" tab
 3. **Configure Your List**:

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -42,6 +42,7 @@ SmartLists creates rule-based playlists and collections that refresh automatical
 - **Refresh Status & Statistics** - Monitor ongoing refresh operations with real-time progress, view refresh history, and track statistics for all your lists
 - **Media Types** - Works with all Jellyfin media types
 - **End User Config Page** - Let regular users manage their own smart lists from the home screen (requires [Plugin Pages](https://github.com/IAmParadox27/jellyfin-plugin-pages) and [File Transformation](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) plugins)
+- **Templates** - Start from built-in templates - TV channel round-robin, Continue Watching, external-list imports, album roulette, and more
 
 ## Screenshots
 

--- a/docs/content/user-guide/configuration.md
+++ b/docs/content/user-guide/configuration.md
@@ -166,6 +166,19 @@ The web interface is organized into tabs. The available tabs and features depend
 
 This is where you build new playlists and collections:
 
+#### Start from a Template
+
+At the top of the Create tab you can pick one of the built-in templates — ready-made
+configurations like **TV Channel** (round-robin episode interleaving), **Continue
+Watching**, **Weekly Jams (ListenBrainz)**, or **Album Roulette**. Selecting a
+template and clicking **Use** fills the whole create form with a working setup.
+Nothing is created yet: review the settings, adjust them to taste, and click
+**Create** as usual.
+
+Some templates need one value from you (for example a title for *Because You
+Watched…* or your ListenBrainz feed URL for *Weekly Jams*) — a notification tells
+you which rule to fill in, and the form won't save until you do.
+
 !!! note "More options"
     Fields beyond List Type, Name, Media Types (with its Include Extras option), Rules,
     Sort Options, and Users live in a collapsed **More options** section on the create/edit form. The collapsed

--- a/docs/content/user-guide/configuration.md
+++ b/docs/content/user-guide/configuration.md
@@ -179,6 +179,10 @@ Some templates need one value from you (for example a title for *Because You
 Watched…* or your ListenBrainz feed URL for *Weekly Jams*) — a notification tells
 you which rule to fill in, and the form won't save until you do.
 
+On the [user configuration page](user-selection.md), collection templates (such
+as *Trending Now (Trakt)*) are only shown to users who are allowed to create
+collections, so regular users may see fewer templates than an administrator.
+
 !!! note "More options"
     Fields beyond List Type, Name, Media Types (with its Include Extras option), Rules,
     Sort Options, and Users live in a collapsed **More options** section on the create/edit form. The collapsed

--- a/docs/superpowers/plans/2026-07-22-list-templates.md
+++ b/docs/superpowers/plans/2026-07-22-list-templates.md
@@ -501,6 +501,8 @@ git commit -m "refactor: extract shared populateFormFromDto from edit/clone dupl
                 },
                 VisibilitySchedules: [
                     { Action: 'Enable', Trigger: 'Weekly', DayOfWeek: 6, Time: '06:00:00' },
+                    { Action: 'Disable', Trigger: 'Weekly', DayOfWeek: 6, Time: '12:00:00' },
+                    { Action: 'Enable', Trigger: 'Weekly', DayOfWeek: 0, Time: '06:00:00' },
                     { Action: 'Disable', Trigger: 'Weekly', DayOfWeek: 0, Time: '12:00:00' }
                 ]
             }
@@ -1144,7 +1146,7 @@ Use the project's `/verify` skill flow. CRITICAL (from prior-session incident): 
 2. Select **TV Channel** → Use → form fills: type Playlist, name "TV Channel", media type Episode, one rule PlaybackStatus = Unplayed, sort Round Robin grouped by Series Name, auto-refresh On library changes; success notification shown; More-options fold state consistent (auto-expands only when the template sets advanced chips — e.g. schedules/bumpers templates).
 3. Click Create → list is created and materializes (Manage tab shows it; Jellyfin playlist appears).
 4. Select **Because You Watched…** → Use → notification with the hint; SimilarTo rule value empty and focused; click Create without filling → blocked with notification + focus; fill a title → Create succeeds.
-5. Select **Saturday Morning Cartoons** → Use → bumper section populated (interval 2, Random), bumper Tags rule empty; Create blocked by the existing bumper-incomplete message until filled; visibility schedules present (Enable Sat 06:00, Disable Sun 12:00) and Advanced fold auto-expanded.
+5. Select **Saturday Morning Cartoons** → Use → bumper section populated (interval 2, Random), bumper Tags rule empty; Create blocked by the existing bumper-incomplete message until filled; visibility schedules present (all four transitions: Enable Sat 06:00, Disable Sat 12:00, Enable Sun 06:00, Disable Sun 12:00) and Advanced fold auto-expanded.
 6. **Franchise TV Channel** → Use → sort shows Least Recently Watched Round Robin, group by Collections, within-group Air Date, air-block window 3.
 7. **Album Roulette** → Use → no rules (single empty rule row), Random Group Selection enabled/Album/min 5, two sorts (Album Name, Track Number), max playtime 180 — creating works (empty rule row is allowed for non-placeholder templates).
 8. Regression: edit an existing list → form populates correctly, Update works; clone an existing list → " (Copy)" name, create works; cancel edit resets.

--- a/docs/superpowers/plans/2026-07-22-list-templates.md
+++ b/docs/superpowers/plans/2026-07-22-list-templates.md
@@ -1,0 +1,1169 @@
+# List Templates Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A "Start from a template" picker on the Create tab (admin + user pages) that prefills the create form from a curated catalog of 10 smart-list templates.
+
+**Architecture:** Frontend-only. A new `config-templates.js` holds the catalog and picker logic. The population engine is a shared `populateFormFromDto(page, dto, opts)` extracted from the existing near-duplicate `editPlaylist`/`clonePlaylist` functions in `config-lists.js`. No backend changes — the prefilled form is the draft; the existing POST path validates and creates.
+
+**Tech Stack:** Vanilla ES5-style JS (IIFE modules over shared `window.SmartLists` namespace), Jellyfin plugin embedded resources, C# only for resource registration.
+
+**Spec:** `docs/superpowers/specs/2026-07-22-list-templates-design.md`
+
+## Global Constraints
+
+- No ES6 template literals in config-*.js — string concatenation only. No arrow functions — match existing `function () {}` style.
+- Never `is="emby-input"`; `is="emby-select"` / `is="emby-checkbox"` are fine. Text inputs use `class="emby-input"`.
+- User messages via `SmartLists.showNotification(message[, 'success'])`, never `Dashboard.alert()`.
+- New JS file registered in FOUR places: `.csproj` `<EmbeddedResource>`, `Plugin.cs` `GetPages()`, `<script>` tag in `config.html` AND in `user-playlists.html`.
+- Required inputs must never live inside `#advanced-options-body`. The picker is optional and sits above List Type — outside the fold.
+- Build treats all warnings as errors (`AnalysisMode=Recommended`), multi-targets net9.0 + net10.0. Build check: `dotnet build Jellyfin.Plugin.SmartLists/Jellyfin.Plugin.SmartLists.csproj -c Release`.
+- JS syntax check: `node --check <file>` on every changed JS file.
+- No test suite exists. Verification = builds + `node --check` + `dev/validate-templates.js` (added by this plan) + end-to-end against the local dev Jellyfin container (Task 5).
+- Work on branch `feature/list-templates` (already created, spec committed).
+- All file paths below are relative to the repo root (worktree `.claude/worktrees/collection-group-by-round-robin`).
+
+## Load-Bearing Facts (verified against the codebase)
+
+- `editPlaylist` (config-lists.js:894-1112) and `clonePlaylist` (config-lists.js:1114-1309) are ~400 lines of near-duplicate DTO→form population. Differences (complete list):
+  1. edit stashes `page._editingPlaylistCreatedByUserId` (920-922); clone doesn't (createPlaylist then assigns fresh, config-lists.js:486-491).
+  2. clone sets `#playlistName` to `Name + ' (Copy)'` BEFORE `switchToTab` (1149-1152) to stop `populateFormDefaults` from firing (switchToTab populates defaults when NOT editMode AND `#playlistName` empty — config-init.js:828-839); edit sets name mid-flow (939) and calls switchToTab LATE (1081).
+  3. clone clears edit state early (`setPageEditState(page, false, null)`, 1155); edit sets `setPageEditState(page, true, playlistId)` late (1061) plus edit-only UI: `#edit-mode-indicator` display flex (1064-1067), submitBtn text `'Update ' + listType` (1068-1072), create-tab button text `'Edit List'` (1075-1078).
+  4. clone holds `page._skipMediaTypeChangeHandlers = true` from before `handleListTypeChange` (1161) to near the end (1277) and clears `page._mediaTypeUpdateTimer` (1280-1283); edit only wraps the `setSelectedItems` call (987-996).
+  5. rules guard: edit requires `ExpressionSets.some(es => es.Expressions && es.Expressions.length > 0)` (1023-1024); clone only checks `length > 0` (1239). Use edit's (stricter, falls back to an initial empty group).
+  6. similarity fields page key: edit `_editingPlaylistSimilarityFields` (1029), clone `_cloningPlaylistSimilarityFields` (1244); `populateRuleRow` reads `page._editingPlaylistSimilarityFields || page._cloningPlaylistSimilarityFields` (config-rules.js:3071). The shared helper uses `_editingPlaylistSimilarityFields` and clears both first.
+  7. images: edit calls `loadExistingImages(page, playlistId).then(re-sync syncAdvancedSection)` plus an immediate `syncAdvancedSection` (1094-1101); clone never loads images and calls `syncAdvancedSection` once (1295).
+  8. post-population update ordering differs slightly (edit: sorts → sort-visibility → field selects → per-field visibilities → rule buttons; clone: rule buttons → field selects → visibilities → sorts). Both work; the helper uses edit's order.
+  9. edit `console.warn`s on missing MaxItems/MaxPlayTime elements; clone is silent. Helper keeps the warns.
+  10. Both call `loadRandomGroupSelectionIntoUI` twice (963+1002 / 1188+1216) — existing quirk, keep it.
+- Population is synchronous (rule rows built from cached `SmartLists.availableFields`, loaded at page init by `loadAndPopulateFields`, config-core.js:426-446). Async edges (people-subfield setTimeout, `loadUsersForRule` promises) are internal to `populateRuleRow` and need no handling.
+- **Empty rule values do NOT block save.** `collectRulesFromForm` silently skips a rule when MemberName/Operator/TargetValue is empty (config-rules.js:2802); `createPlaylist` never checks ExpressionSets non-empty (config-lists.js:297-530); server-side `ValidateStringValue` accepts empty (InputValidator.cs:126-131). Placeholder templates therefore need an explicit client-side guard (Task 3). Exception: empty BUMPER rule values already block via `bumperResult.valid` (config-lists.js:417-420).
+- `syncAdvancedSection(page, playlist)` (config-lists.js:716-759) computes chips + auto-expands the More-options fold FROM THE PASSED OBJECT, and is only ever called explicitly — template flow must call it with the template dto.
+- Page context: `SmartLists.isUserPage(page)` (config-core.js), user page sets `window.SmartLists.IS_USER_PAGE = true` in an inline script before config-core.js loads (user-playlists.html:510-513). User capabilities live in `window.SmartLists.userCapabilities` (loaded via `Plugins/SmartLists/User/Capabilities`, user-playlists.html:516-534) — check the exact property name for collection permission there (expected `CanCreateCollections`) before using it in Task 3.
+- ExternalList rule field IS available on the user page (same `SharedFieldDefinitions.GetAvailableFields()` payload from both fields endpoints; no user-page filtering in config-rules.js).
+- `https://trakt.tv/movies/trending` is an explicitly supported provider URL (TraktListProvider.cs:17, chart regex :252) but needs the admin-configured Trakt Client ID to fetch.
+- Delegated click handler pattern: single `page.addEventListener('click', ...)` in `setupEventListeners` (config-init.js:984-1316); add new button handling inside it via `target.closest(...)`.
+- DTO value vocabulary used by the catalog (exact strings): see Task 2 catalog code — SortBy values from config-core.js:65-91; `GroupByField` ∈ 'SeriesName'|'Collections'|'AlbumName'|'Artist'|'Genres'|'Studios'; `WithinGroupOrder` only 'AirDate'; directionless sorts still carry `SortOrder: 'Ascending'`; relative dates `'30:days'`; booleans `'true'`/`'false'`; PlaybackStatus 'Played'|'InProgress'|'Unplayed'; schedule Time `'HH:MM:00'`, DayOfWeek integer 0=Sunday; RandomGroupSelection GroupBy 'Album' for whole albums.
+
+## File Structure
+
+- Modify `Jellyfin.Plugin.SmartLists/Configuration/config-lists.js` — Task 1 (extract `populateFormFromDto`, rewrite edit/clone as wrappers), Task 3 (placeholder guard in `createPlaylist`, flag reset in `clearForm`).
+- Create `Jellyfin.Plugin.SmartLists/Configuration/config-templates.js` — Task 2 (catalog) + Task 3 (`initTemplatePicker`, `useTemplate`).
+- Create `dev/validate-templates.js` — Task 2 (dev-only catalog validator, not shipped).
+- Modify `Jellyfin.Plugin.SmartLists/Jellyfin.Plugin.SmartLists.csproj`, `Jellyfin.Plugin.SmartLists/Plugin.cs` — Task 2 (registration).
+- Modify `Jellyfin.Plugin.SmartLists/Configuration/config.html`, `user-playlists.html` — Task 2 (script tag), Task 3 (picker markup).
+- Modify `Jellyfin.Plugin.SmartLists/Configuration/config-init.js` — Task 3 (picker init + Use-button click wiring).
+- Modify `docs/content/user-guide/configuration.md`, `docs/content/getting-started/quick-start.md`, `docs/content/index.md`, `README.md` — Task 4.
+
+---
+
+### Task 1: Extract shared `populateFormFromDto` (pure refactor)
+
+**Files:**
+- Modify: `Jellyfin.Plugin.SmartLists/Configuration/config-lists.js:894-1309`
+
+**Interfaces:**
+- Consumes: existing `SmartLists.*` population helpers (stagePendingUserSelection, setElementValue/Checked, handleListTypeChange, loadSchedulesIntoUI, loadVisibilitySchedulesIntoUI, loadRandomGroupSelectionIntoUI, setSelectedItems, setUserIdValueWithRetry, applyPendingUserSelection, createInitialLogicGroup, addNewLogicGroup, populateLogicGroupExpressions, populateBumperConfigIntoForm, loadSortOptionsIntoUI, updateAll*Visibility, updateAllFieldSelects, updateRuleButtonVisibility, setPageEditState, switchToTab, initMetadataTagsInput, loadExistingImages, syncAdvancedSection).
+- Produces: `SmartLists.populateFormFromDto(page, playlist, opts)` where `opts = { editMode?: boolean, playlistId?: string|null, name?: string }`. Behavior: populates the whole create form from a SmartListDto-shaped object; `opts.name` overrides `playlist.Name`; `editMode: true` additionally stashes CreatedByUserId, sets edit state/indicator/submit text/tab text and loads images. Throws on population errors (callers catch). Task 3 calls it with `{ name: template.name }`.
+
+- [ ] **Step 1: Replace `editPlaylist` and `clonePlaylist` bodies with the shared helper + thin wrappers**
+
+In `config-lists.js`, replace the entire block from line 894 (`SmartLists.editPlaylist = function (page, playlistId) {`) through line 1309 (end of `clonePlaylist`, the line before `SmartLists.cancelEdit = ...`) with:
+
+```js
+    // Shared DTO -> create-form population engine used by edit, clone, and
+    // template flows. opts: { editMode, playlistId, name }.
+    SmartLists.populateFormFromDto = function (page, playlist, opts) {
+        opts = opts || {};
+        const editMode = opts.editMode === true;
+        const listType = playlist.Type || 'Playlist';
+        const isCollection = listType === 'Collection';
+
+        if (editMode && playlist.CreatedByUserId) {
+            // Store CreatedByUserId to preserve it during updates
+            page._editingPlaylistCreatedByUserId = playlist.CreatedByUserId;
+        }
+
+        // Extract userIds BEFORE calling handleListTypeChange (which triggers loadUsers)
+        // This ensures pendingUserIds is set before loadUsers checks for it
+        SmartLists.stagePendingUserSelection(page, playlist, isCollection);
+
+        // Set playlist name FIRST (before switchToTab) to prevent populateFormDefaults from being called
+        // switchToTab checks if name is empty and calls populateFormDefaults if so, which would regenerate checkboxes
+        SmartLists.setElementValue(page, '#playlistName', opts.name !== undefined ? opts.name : (playlist.Name || ''));
+
+        // Switch to Create tab
+        SmartLists.switchToTab(page, 'create');
+
+        // Clear any existing edit state (edit mode is set after population below)
+        SmartLists.setPageEditState(page, false, null);
+
+        // Set list type
+        SmartLists.setElementValue(page, '#listType', listType);
+
+        // Set flag to prevent media type change handlers from interfering during population
+        page._skipMediaTypeChangeHandlers = true;
+
+        // Trigger type change handler to show/hide fields
+        SmartLists.handleListTypeChange(page);
+
+        // Only set public for playlists
+        if (!isCollection) {
+            SmartLists.setElementChecked(page, '#playlistIsPublic', playlist.Public || false);
+        }
+
+        SmartLists.setElementChecked(page, '#playlistIsEnabled', playlist.Enabled !== false); // Default to true for backward compatibility
+        SmartLists.setElementChecked(page, '#playlistIncludeExtras', playlist.IncludeExtras || false);
+        SmartLists.setElementChecked(page, '#playlistHideWhenEmpty', playlist.HideWhenEmpty || false);
+
+        // Handle AutoRefresh with backward compatibility
+        const autoRefreshValue = playlist.AutoRefresh !== undefined ? playlist.AutoRefresh : 'Never';
+        const autoRefreshElement = page.querySelector('#autoRefreshMode');
+        if (autoRefreshElement) {
+            autoRefreshElement.value = autoRefreshValue;
+        }
+
+        // Handle schedule settings with backward compatibility
+        SmartLists.loadSchedulesIntoUI(page, playlist);
+
+        // Handle visibility schedule settings
+        SmartLists.loadVisibilitySchedulesIntoUI(page, playlist);
+
+        SmartLists.loadRandomGroupSelectionIntoUI(page, playlist);
+
+        // Handle MaxItems with backward compatibility
+        // Default to 0 (unlimited) for lists that didn't have this setting
+        const maxItemsValue = (playlist.MaxItems !== undefined && playlist.MaxItems !== null) ? playlist.MaxItems : 0;
+        const maxItemsElement = page.querySelector('#playlistMaxItems');
+        if (maxItemsElement) {
+            maxItemsElement.value = maxItemsValue;
+        } else {
+            console.warn('Max Items element not found when trying to populate form');
+        }
+
+        // Handle MaxPlayTimeMinutes with backward compatibility
+        const maxPlayTimeMinutesValue = (playlist.MaxPlayTimeMinutes !== undefined && playlist.MaxPlayTimeMinutes !== null) ? playlist.MaxPlayTimeMinutes : 0;
+        const maxPlayTimeMinutesElement = page.querySelector('#playlistMaxPlayTimeMinutes');
+        if (maxPlayTimeMinutesElement) {
+            maxPlayTimeMinutesElement.value = maxPlayTimeMinutesValue;
+        } else {
+            console.warn('Max Playtime Minutes element not found when trying to populate form');
+        }
+
+        // Set media types
+        if (playlist.MediaTypes && playlist.MediaTypes.length > 0) {
+            SmartLists.setSelectedItems(page, 'mediaTypesMultiSelect', playlist.MediaTypes, 'media-type-multi-select-checkbox', 'Select media types...');
+        } else {
+            SmartLists.setSelectedItems(page, 'mediaTypesMultiSelect', [], 'media-type-multi-select-checkbox', 'Select media types...');
+        }
+
+        // Update Include Extras visibility based on loaded media types
+        if (SmartLists.updateIncludeExtrasVisibility) {
+            SmartLists.updateIncludeExtrasVisibility(page);
+        }
+        SmartLists.loadRandomGroupSelectionIntoUI(page, playlist);
+
+        // Set the list owner (for both playlists and collections)
+        if (isCollection) {
+            // Collections always have single user
+            const userIdString = playlist.UserId ? String(playlist.UserId) : null;
+            if (userIdString) {
+                SmartLists.setUserIdValueWithRetry(page, userIdString);
+            }
+        } else {
+            // Playlists can have multiple users; selection was staged above
+            SmartLists.applyPendingUserSelection(page);
+            // If checkboxes don't exist yet, loadUsers will set them when it finishes
+        }
+
+        // Clear existing rules (applies to both playlists and collections)
+        const rulesContainer = page.querySelector('#rules-container');
+        if (rulesContainer) {
+            rulesContainer.innerHTML = '';
+        }
+
+        // Clear stale similarity-field context from any previous population
+        page._editingPlaylistSimilarityFields = null;
+        page._cloningPlaylistSimilarityFields = null;
+
+        // Populate logic groups and rules
+        if (playlist.ExpressionSets && playlist.ExpressionSets.length > 0 &&
+            playlist.ExpressionSets.some(function (es) { return es.Expressions && es.Expressions.length > 0; })) {
+            playlist.ExpressionSets.forEach(function (expressionSet, groupIndex) {
+                const logicGroup = groupIndex === 0 ? SmartLists.createInitialLogicGroup(page) : SmartLists.addNewLogicGroup(page);
+
+                // Store similarity comparison fields on page for populateRuleRow to access
+                page._editingPlaylistSimilarityFields = playlist.SimilarityComparisonFields;
+
+                // Populate rules and per-group MaxItems into this logic group
+                SmartLists.populateLogicGroupExpressions(page, logicGroup, expressionSet);
+            });
+        } else {
+            // No rules exist - create an initial logic group with a placeholder rule
+            SmartLists.createInitialLogicGroup(page);
+        }
+
+        // Clear and populate bumper rules
+        SmartLists.populateBumperConfigIntoForm(page, playlist);
+
+        // Set sort options AFTER rules are populated so hasSimilarToRuleInForm() can detect them
+        SmartLists.loadSortOptionsIntoUI(page, playlist);
+        // Update sort options visibility based on populated rules
+        SmartLists.updateAllSortOptionsVisibility(page);
+
+        // Update field selects first, then per-field options visibility based on selected media types
+        SmartLists.updateAllFieldSelects(page);
+        SmartLists.updateAllTagsOptionsVisibility(page);
+        SmartLists.updateAllStudiosOptionsVisibility(page);
+        SmartLists.updateAllGenresOptionsVisibility(page);
+        SmartLists.updateAllAudioLanguagesOptionsVisibility(page);
+        SmartLists.updateAllCollectionsOptionsVisibility(page);
+        SmartLists.updateAllNextUnwatchedOptionsVisibility(page);
+
+        // Update button visibility
+        SmartLists.updateRuleButtonVisibility(page);
+
+        // Clear flag to re-enable change event handlers
+        page._skipMediaTypeChangeHandlers = false;
+
+        // Clear any pending media type update timers just in case
+        if (page._mediaTypeUpdateTimer) {
+            clearTimeout(page._mediaTypeUpdateTimer);
+            page._mediaTypeUpdateTimer = null;
+        }
+
+        if (editMode) {
+            // Set edit mode state
+            SmartLists.setPageEditState(page, true, opts.playlistId);
+
+            // Update UI to show edit mode
+            const editIndicator = page.querySelector('#edit-mode-indicator');
+            if (editIndicator) {
+                editIndicator.style.display = 'flex';
+            }
+            const submitBtn = page.querySelector('#submitBtn');
+            if (submitBtn) {
+                const currentListType = SmartLists.getElementValue(page, '#listType', 'Playlist');
+                submitBtn.textContent = 'Update ' + currentListType;
+            }
+
+            // Update tab button text
+            const createTabButton = page.querySelector('a[data-tab="create"]');
+            if (createTabButton) {
+                createTabButton.textContent = 'Edit List';
+            }
+        }
+
+        // Populate metadata fields
+        SmartLists.setElementValue(page, '#metadataSortTitle', playlist.SortTitle || '');
+        SmartLists.setElementValue(page, '#metadataOverview', playlist.Overview || '');
+        SmartLists.setElementValue(page, '#metadataFavorite', playlist.Favorite === true ? 'true' : (playlist.Favorite === false ? 'false' : ''));
+        page._metadataTagsWasManaged = playlist.Tags !== undefined && playlist.Tags !== null;
+        if (SmartLists.initMetadataTagsInput) {
+            SmartLists.initMetadataTagsInput(page, playlist.Tags || []);
+        }
+
+        if (editMode) {
+            // Load existing images for this list, then re-sync the
+            // Advanced fold so an images-only list still expands.
+            if (SmartLists.loadExistingImages) {
+                SmartLists.loadExistingImages(page, opts.playlistId).then(function () {
+                    SmartLists.syncAdvancedSection(page, playlist);
+                });
+            }
+        }
+
+        // Chips + auto-expand from the populated config (images re-sync above in edit mode)
+        SmartLists.syncAdvancedSection(page, playlist);
+    };
+
+    SmartLists.editPlaylist = function (page, playlistId) {
+        const apiClient = SmartLists.getApiClient();
+        Dashboard.showLoadingMsg();
+
+        // Always scroll to top when entering edit mode (auto for instant behavior)
+        window.scrollTo({ top: 0, behavior: 'auto' });
+
+        apiClient.ajax({
+            type: 'GET',
+            url: apiClient.getUrl(SmartLists.ENDPOINTS.base + '/' + playlistId),
+            contentType: 'application/json'
+        }).then(function (response) {
+            if (!response.ok) {
+                throw new Error('HTTP ' + response.status + ': ' + response.statusText);
+            }
+            return response.json();
+        }).then(function (playlist) {
+            Dashboard.hideLoadingMsg();
+
+            if (!playlist) {
+                SmartLists.showNotification('No playlist data received from server.');
+                return;
+            }
+
+            try {
+                SmartLists.populateFormFromDto(page, playlist, { editMode: true, playlistId: playlistId });
+            } catch (formError) {
+                console.error('Error populating form for edit:', formError);
+                SmartLists.showNotification('Error loading playlist data for editing: ' + formError.message);
+            }
+        }).catch(function (err) {
+            Dashboard.hideLoadingMsg();
+            console.error('Error loading playlist for edit:', err);
+            SmartLists.handleApiError(err, 'Failed to load playlist for editing');
+        });
+    };
+
+    SmartLists.clonePlaylist = function (page, playlistId, playlistName) {
+        const apiClient = SmartLists.getApiClient();
+        Dashboard.showLoadingMsg();
+
+        // Always scroll to top when entering clone mode (auto for instant behavior)
+        window.scrollTo({ top: 0, behavior: 'auto' });
+
+        apiClient.ajax({
+            type: 'GET',
+            url: apiClient.getUrl(SmartLists.ENDPOINTS.base + '/' + playlistId),
+            contentType: 'application/json'
+        }).then(function (response) {
+            if (!response.ok) {
+                throw new Error('HTTP ' + response.status + ': ' + response.statusText);
+            }
+            return response.json();
+        }).then(function (playlist) {
+            Dashboard.hideLoadingMsg();
+
+            if (!playlist) {
+                SmartLists.showNotification('No playlist data received from server.');
+                return;
+            }
+
+            try {
+                SmartLists.populateFormFromDto(page, playlist, { name: (playlist.Name || '') + ' (Copy)' });
+
+                // Show success message
+                SmartLists.showNotification('List "' + playlistName + '" cloned successfully! You can now modify and create the new list.', 'success');
+            } catch (formError) {
+                console.error('Error populating form for clone:', formError);
+                SmartLists.showNotification('Error loading list data for cloning: ' + formError.message);
+            }
+        }).catch(function (err) {
+            Dashboard.hideLoadingMsg();
+            console.error('Error loading list for clone:', err);
+            SmartLists.handleApiError(err, 'Failed to load list for cloning');
+        });
+    };
+```
+
+Known intentional unifications (all no-op or strictly-safer):
+- Edit mode now sets the name before switching tabs and clears edit state before re-setting it — safe because the name is always non-empty for an existing list, so `populateFormDefaults` never fires.
+- Edit mode now gets clone's wider `_skipMediaTypeChangeHandlers` scope and the `_mediaTypeUpdateTimer` clear — strictly more defensive.
+- Clone now gets edit's stricter empty-ExpressionSets guard and the missing-element `console.warn`s.
+- Clone keeps NOT hiding `#edit-mode-indicator` / resetting submit text (matches today's behavior; `cancelEdit`/`clearForm` own that).
+
+- [ ] **Step 2: Syntax check**
+
+Run: `node --check Jellyfin.Plugin.SmartLists/Configuration/config-lists.js`
+Expected: no output, exit 0.
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build Jellyfin.Plugin.SmartLists/Jellyfin.Plugin.SmartLists.csproj -c Release`
+Expected: `Build succeeded. 0 Warning(s). 0 Error(s).` for both TFMs.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+git commit -m "refactor: extract shared populateFormFromDto from edit/clone duplication"
+```
+
+---
+
+### Task 2: Template catalog + registration + validator
+
+**Files:**
+- Create: `Jellyfin.Plugin.SmartLists/Configuration/config-templates.js`
+- Create: `dev/validate-templates.js`
+- Modify: `Jellyfin.Plugin.SmartLists/Jellyfin.Plugin.SmartLists.csproj` (after the config-lists.js entry, ~line 48)
+- Modify: `Jellyfin.Plugin.SmartLists/Plugin.cs` (GetPages, after the config-lists.js entry, ~line 148)
+- Modify: `Jellyfin.Plugin.SmartLists/Configuration/config.html` (script list, after config-lists.js at ~line 1260)
+- Modify: `Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html` (script list, after config-lists.js at ~line 635)
+
+**Interfaces:**
+- Consumes: nothing (data module; IIFE over `window.SmartLists`).
+- Produces: `SmartLists.TEMPLATES` — array of `{ id, name, category, description, adminOnly, inputHint, dto }`. `dto` is a partial SmartListDto (always has `Type`, `MediaTypes`, `ExpressionSets`, `Order`). Task 3 reads this array.
+
+- [ ] **Step 1: Create `config-templates.js` with the full catalog**
+
+```js
+// Template catalog for the "Start from a template" picker on the Create tab.
+// Each dto is a partial SmartListDto containing only definition fields —
+// never instance fields (Id, FileName, Jellyfin IDs, dates, stats, images).
+// Rule MemberName/Operator/TargetValue strings and sort names must match the
+// backend vocabulary (FieldRegistry.cs / OrderFactory) — dev/validate-templates.js
+// checks the catalog against config-core.js.
+(function (SmartLists) {
+    'use strict';
+
+    SmartLists.TEMPLATES = [
+        {
+            id: 'tv-channel',
+            name: 'TV Channel',
+            category: 'TV',
+            description: 'Interleaves unwatched episodes from all your shows like a TV channel: one episode per series, round-robin, in order.',
+            adminOnly: false,
+            inputHint: null,
+            dto: {
+                Type: 'Playlist',
+                MediaTypes: ['Episode'],
+                ExpressionSets: [{
+                    Expressions: [
+                        { MemberName: 'PlaybackStatus', Operator: 'Equal', TargetValue: 'Unplayed' }
+                    ]
+                }],
+                Order: { SortOptions: [{ SortBy: 'Round Robin', SortOrder: 'Ascending', GroupByField: 'SeriesName' }] },
+                AutoRefresh: 'OnLibraryChanges'
+            }
+        },
+        {
+            id: 'franchise-tv-channel',
+            name: 'Franchise TV Channel',
+            category: 'TV',
+            description: 'Rotates through your collections (franchises) in broadcast order, resuming the least recently watched one. Crossover episodes that aired within 3 days stay together.',
+            adminOnly: false,
+            inputHint: null,
+            dto: {
+                Type: 'Playlist',
+                MediaTypes: ['Episode'],
+                ExpressionSets: [{
+                    Expressions: [
+                        { MemberName: 'PlaybackStatus', Operator: 'Equal', TargetValue: 'Unplayed' }
+                    ]
+                }],
+                Order: {
+                    SortOptions: [{
+                        SortBy: 'Least Recently Watched Round Robin',
+                        SortOrder: 'Ascending',
+                        GroupByField: 'Collections',
+                        WithinGroupOrder: 'AirDate',
+                        AirBlockWindowDays: 3
+                    }]
+                },
+                AutoRefresh: 'OnAllChanges'
+            }
+        },
+        {
+            id: 'continue-watching',
+            name: 'Continue Watching',
+            category: 'TV',
+            description: 'The next unwatched episode of every show you are in the middle of, with the show you have not touched longest surfacing first. Updates itself as you watch.',
+            adminOnly: false,
+            inputHint: null,
+            dto: {
+                Type: 'Playlist',
+                MediaTypes: ['Episode'],
+                ExpressionSets: [{
+                    Expressions: [
+                        { MemberName: 'NextUnwatched', Operator: 'Equal', TargetValue: 'true' }
+                    ]
+                }],
+                Order: { SortOptions: [{ SortBy: 'Least Recently Watched Round Robin', SortOrder: 'Ascending', GroupByField: 'SeriesName' }] },
+                AutoRefresh: 'OnAllChanges'
+            }
+        },
+        {
+            id: 'saturday-cartoons',
+            name: 'Saturday Morning Cartoons',
+            category: 'TV',
+            description: 'Animated episodes with bumper clips woven in every 2 episodes, visible only on weekend mornings. Tag your bumper videos and enter that tag in the bumper rule.',
+            adminOnly: false,
+            inputHint: 'Enter the tag of your bumper videos in the empty bumper rule value (tag some short videos first).',
+            dto: {
+                Type: 'Playlist',
+                MediaTypes: ['Episode'],
+                ExpressionSets: [{
+                    Expressions: [
+                        { MemberName: 'Genres', Operator: 'Contains', TargetValue: 'Animation' },
+                        { MemberName: 'PlaybackStatus', Operator: 'Equal', TargetValue: 'Unplayed' }
+                    ]
+                }],
+                Order: { SortOptions: [{ SortBy: 'Round Robin', SortOrder: 'Ascending', GroupByField: 'SeriesName' }] },
+                Bumpers: {
+                    ExpressionSets: [{
+                        Expressions: [
+                            { MemberName: 'Tags', Operator: 'Contains', TargetValue: '' }
+                        ]
+                    }],
+                    MediaTypes: ['Video'],
+                    BumperOrder: 'Random',
+                    Interval: 2
+                },
+                VisibilitySchedules: [
+                    { Action: 'Enable', Trigger: 'Weekly', DayOfWeek: 6, Time: '06:00:00' },
+                    { Action: 'Disable', Trigger: 'Weekly', DayOfWeek: 0, Time: '12:00:00' }
+                ]
+            }
+        },
+        {
+            id: 'because-you-watched',
+            name: 'Because You Watched…',
+            category: 'Movies',
+            description: 'Movies similar to a title you pick, best matches first. Compares genres, tags, actors and directors.',
+            adminOnly: false,
+            inputHint: 'Type the title to find similar movies for in the empty rule value.',
+            dto: {
+                Type: 'Playlist',
+                MediaTypes: ['Movie'],
+                ExpressionSets: [{
+                    Expressions: [
+                        { MemberName: 'SimilarTo', Operator: 'Equal', TargetValue: '' }
+                    ]
+                }],
+                SimilarityComparisonFields: ['Genre', 'Tags', 'Actors', 'Directors'],
+                Order: { SortOptions: [{ SortBy: 'Similarity', SortOrder: 'Descending' }] },
+                MaxItems: 25
+            }
+        },
+        {
+            id: 'balanced-mix',
+            name: 'Balanced Genre Mix',
+            category: 'Movies',
+            description: 'Up to 15 movies each of Action, Comedy and Drama, kept in that block order. Change the genres to taste — each rule block has its own item limit.',
+            adminOnly: false,
+            inputHint: null,
+            dto: {
+                Type: 'Playlist',
+                MediaTypes: ['Movie'],
+                ExpressionSets: [
+                    { Expressions: [{ MemberName: 'Genres', Operator: 'Contains', TargetValue: 'Action' }], MaxItems: 15 },
+                    { Expressions: [{ MemberName: 'Genres', Operator: 'Contains', TargetValue: 'Comedy' }], MaxItems: 15 },
+                    { Expressions: [{ MemberName: 'Genres', Operator: 'Contains', TargetValue: 'Drama' }], MaxItems: 15 }
+                ],
+                Order: { SortOptions: [{ SortBy: 'Rule Block Order', SortOrder: 'Ascending' }] }
+            }
+        },
+        {
+            id: 'fresh-and-unseen',
+            name: 'Fresh & Unseen',
+            category: 'Movies',
+            description: 'Movies added in the last 30 days that you have not watched yet, newest first. Kept current automatically.',
+            adminOnly: false,
+            inputHint: null,
+            dto: {
+                Type: 'Playlist',
+                MediaTypes: ['Movie'],
+                ExpressionSets: [{
+                    Expressions: [
+                        { MemberName: 'DateCreated', Operator: 'NewerThan', TargetValue: '30:days' },
+                        { MemberName: 'PlaybackStatus', Operator: 'Equal', TargetValue: 'Unplayed' }
+                    ]
+                }],
+                Order: { SortOptions: [{ SortBy: 'DateCreated', SortOrder: 'Descending' }] },
+                AutoRefresh: 'OnAllChanges'
+            }
+        },
+        {
+            id: 'trakt-trending',
+            name: 'Trending Now (Trakt)',
+            category: 'Movies',
+            description: 'A collection of the movies trending on Trakt right now, refreshed daily. Requires a Trakt Client ID in the plugin settings (admin, Settings tab). Hidden while empty.',
+            adminOnly: false,
+            inputHint: null,
+            dto: {
+                Type: 'Collection',
+                MediaTypes: ['Movie'],
+                ExpressionSets: [{
+                    Expressions: [
+                        { MemberName: 'ExternalList', Operator: 'Equal', TargetValue: 'https://trakt.tv/movies/trending' }
+                    ]
+                }],
+                Order: { SortOptions: [{ SortBy: 'External List Order', SortOrder: 'Ascending' }] },
+                Schedules: [{ Trigger: 'Daily', Time: '06:00:00' }],
+                HideWhenEmpty: true,
+                MaxItems: 50
+            }
+        },
+        {
+            id: 'weekly-jams',
+            name: 'Weekly Jams (ListenBrainz)',
+            category: 'Music',
+            description: 'Your personalized ListenBrainz Weekly Jams as a playlist, in list order, refreshed weekly. No API key needed — just your ListenBrainz username in the feed URL.',
+            adminOnly: false,
+            inputHint: 'Paste your feed URL in the empty rule value: https://listenbrainz.org/syndication-feed/user/YOUR_USERNAME/recommendations?recommendation_type=weekly-jams',
+            dto: {
+                Type: 'Playlist',
+                MediaTypes: ['Audio'],
+                ExpressionSets: [{
+                    Expressions: [
+                        { MemberName: 'ExternalList', Operator: 'Equal', TargetValue: '' }
+                    ]
+                }],
+                Order: { SortOptions: [{ SortBy: 'External List Order', SortOrder: 'Ascending' }] },
+                Schedules: [{ Trigger: 'Weekly', DayOfWeek: 1, Time: '08:00:00' }]
+            }
+        },
+        {
+            id: 'album-roulette',
+            name: 'Album Roulette',
+            category: 'Music',
+            description: 'A few random complete albums (at least 5 tracks each), tracks in album order, capped at 3 hours. Re-roll by refreshing the list.',
+            adminOnly: false,
+            inputHint: null,
+            dto: {
+                Type: 'Playlist',
+                MediaTypes: ['Audio'],
+                ExpressionSets: [],
+                RandomGroupSelection: { Enabled: true, GroupBy: 'Album', MinimumItems: 5 },
+                Order: {
+                    SortOptions: [
+                        { SortBy: 'AlbumName', SortOrder: 'Ascending' },
+                        { SortBy: 'TrackNumber', SortOrder: 'Ascending' }
+                    ]
+                },
+                MaxPlayTimeMinutes: 180
+            }
+        }
+    ];
+})(window.SmartLists = window.SmartLists || {});
+```
+
+- [ ] **Step 2: Register in `.csproj`**
+
+In `Jellyfin.Plugin.SmartLists/Jellyfin.Plugin.SmartLists.csproj`, after the `config-lists.js` entry (lines 47-48):
+
+```xml
+    <!-- Template catalog and picker -->
+    <EmbeddedResource Include="Configuration\config-templates.js" />
+```
+
+- [ ] **Step 3: Register in `Plugin.cs`**
+
+In `GetPages()` (Plugin.cs:74-180), after the `config-lists.js` PluginPageInfo entry (~line 148):
+
+```csharp
+                // Template catalog and picker
+                new PluginPageInfo
+                {
+                    Name = "config-templates.js",
+                    EmbeddedResourcePath = GetType().Namespace + ".Configuration.config-templates.js",
+                },
+```
+
+- [ ] **Step 4: Add script tags in both HTML pages**
+
+`config.html` after the config-lists.js script line (~1260):
+
+```html
+        <!-- Template catalog and picker -->
+        <script src="configurationpage?name=config-templates.js"></script>
+```
+
+`user-playlists.html` after the config-lists.js script line (~635): same two lines.
+
+- [ ] **Step 5: Create `dev/validate-templates.js`**
+
+Dev-only guard against typos in the canned DTOs. Loads config-core.js and config-templates.js in a Node vm with browser stubs, then checks every template's vocabulary against the live `SmartLists` constants plus the file sources.
+
+```js
+#!/usr/bin/env node
+// Validates the template catalog (config-templates.js) against the frontend
+// vocabulary in config-core.js. Run: node dev/validate-templates.js
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const cfgDir = path.join(__dirname, '..', 'Jellyfin.Plugin.SmartLists', 'Configuration');
+const coreSrc = fs.readFileSync(path.join(cfgDir, 'config-core.js'), 'utf8');
+const rulesSrc = fs.readFileSync(path.join(cfgDir, 'config-rules.js'), 'utf8');
+const templatesSrc = fs.readFileSync(path.join(cfgDir, 'config-templates.js'), 'utf8');
+
+const stubEl = { classList: { contains: function () { return false; } } };
+const sandbox = {
+    window: {},
+    document: {
+        querySelector: function () { return null; },
+        querySelectorAll: function () { return []; },
+        addEventListener: function () {},
+        createElement: function () { return stubEl; }
+    },
+    console: console,
+    setTimeout: setTimeout,
+    clearTimeout: clearTimeout
+};
+sandbox.window.SmartLists = {};
+vm.createContext(sandbox);
+vm.runInContext(coreSrc, sandbox, { filename: 'config-core.js' });
+vm.runInContext(templatesSrc, sandbox, { filename: 'config-templates.js' });
+
+const SL = sandbox.window.SmartLists;
+const errors = [];
+function check(cond, msg) { if (!cond) { errors.push(msg); } }
+
+check(Array.isArray(SL.TEMPLATES) && SL.TEMPLATES.length > 0, 'SmartLists.TEMPLATES missing or empty');
+
+const sortValues = (SL.SORT_OPTIONS || []).map(function (o) { return typeof o === 'string' ? o : o.value; });
+const groupFields = (SL.ROUND_ROBIN_GROUP_FIELDS || []).map(function (o) { return typeof o === 'string' ? o : o.value; });
+const OPERATORS = ['Equal', 'NotEqual', 'Contains', 'NotContains', 'IsIn', 'IsNotIn', 'MatchRegex',
+    'GreaterThan', 'LessThan', 'GreaterThanOrEqual', 'LessThanOrEqual',
+    'After', 'Before', 'NewerThan', 'OlderThan', 'Weekday'];
+const MEDIA_TYPES = ['Episode', 'Series', 'Season', 'Movie', 'Audio', 'MusicAlbum', 'MusicVideo', 'Video', 'Photo', 'Book', 'AudioBook'];
+const AUTO_REFRESH = ['Never', 'OnLibraryChanges', 'OnAllChanges'];
+const TRIGGERS = ['None', 'Daily', 'Weekly', 'Monthly', 'Interval', 'Yearly'];
+const seenIds = {};
+
+(SL.TEMPLATES || []).forEach(function (t) {
+    const p = 'template "' + t.id + '": ';
+    check(t.id && t.name && t.category && t.description, p + 'id/name/category/description required');
+    check(!seenIds[t.id], p + 'duplicate id');
+    seenIds[t.id] = true;
+    check(t.dto && typeof t.dto === 'object', p + 'dto required');
+    if (!t.dto) { return; }
+    const dto = t.dto;
+    check(dto.Type === 'Playlist' || dto.Type === 'Collection', p + 'Type must be Playlist|Collection');
+    check(Array.isArray(dto.MediaTypes) && dto.MediaTypes.length > 0, p + 'MediaTypes required');
+    (dto.MediaTypes || []).forEach(function (m) {
+        check(MEDIA_TYPES.indexOf(m) !== -1, p + 'unknown MediaType ' + m);
+    });
+    check(Array.isArray(dto.ExpressionSets), p + 'ExpressionSets must be an array');
+    ['Id', 'FileName', 'JellyfinPlaylistId', 'JellyfinCollectionId', 'DateCreated', 'LastRefreshed',
+        'ItemCount', 'TotalRuntimeMinutes', 'CustomImages', 'UserPlaylists', 'UserId', 'CreatedByUserId'
+    ].forEach(function (k) {
+        check(!(k in dto), p + 'instance field ' + k + ' must not be in a template dto');
+    });
+    function checkExpressionSets(sets, where) {
+        (sets || []).forEach(function (set) {
+            check(Array.isArray(set.Expressions), p + where + ' set missing Expressions array');
+            (set.Expressions || []).forEach(function (e) {
+                check(typeof e.MemberName === 'string' && e.MemberName.length > 0, p + where + ' rule missing MemberName');
+                check(OPERATORS.indexOf(e.Operator) !== -1, p + where + ' unknown Operator ' + e.Operator);
+                check(typeof e.TargetValue === 'string', p + where + ' TargetValue must be a string');
+                // Every valid field name appears as a quoted string in the frontend sources
+                const quoted = "'" + e.MemberName + "'";
+                check(coreSrc.indexOf(quoted) !== -1 || rulesSrc.indexOf(quoted) !== -1,
+                    p + where + ' MemberName not found in config-core.js/config-rules.js: ' + e.MemberName);
+            });
+        });
+    }
+    checkExpressionSets(dto.ExpressionSets, 'rule');
+    if (dto.Bumpers) {
+        checkExpressionSets(dto.Bumpers.ExpressionSets, 'bumper');
+        check(['Random', 'Name', 'ReleaseDate'].indexOf(dto.Bumpers.BumperOrder) !== -1, p + 'bad BumperOrder');
+        check(dto.Bumpers.Interval >= 1, p + 'bumper Interval must be >= 1');
+        check(dto.Type === 'Playlist', p + 'Bumpers are playlist-only');
+    }
+    ((dto.Order || {}).SortOptions || []).forEach(function (s) {
+        check(sortValues.indexOf(s.SortBy) !== -1, p + 'unknown SortBy ' + s.SortBy);
+        check(s.SortOrder === 'Ascending' || s.SortOrder === 'Descending', p + 'bad SortOrder for ' + s.SortBy);
+        if (s.GroupByField) {
+            check(groupFields.indexOf(s.GroupByField) !== -1, p + 'unknown GroupByField ' + s.GroupByField);
+        }
+        if (s.WithinGroupOrder) {
+            check(s.WithinGroupOrder === 'AirDate', p + 'WithinGroupOrder must be AirDate');
+        }
+        if (s.AirBlockWindowDays !== undefined) {
+            check(s.GroupByField === 'Collections' && s.WithinGroupOrder === 'AirDate',
+                p + 'AirBlockWindowDays needs GroupByField Collections + WithinGroupOrder AirDate');
+            check(s.AirBlockWindowDays >= 0 && s.AirBlockWindowDays <= 30, p + 'AirBlockWindowDays out of range');
+        }
+    });
+    if (dto.AutoRefresh !== undefined) {
+        check(AUTO_REFRESH.indexOf(dto.AutoRefresh) !== -1, p + 'bad AutoRefresh ' + dto.AutoRefresh);
+    }
+    (dto.Schedules || []).concat(dto.VisibilitySchedules || []).forEach(function (s) {
+        check(TRIGGERS.indexOf(s.Trigger) !== -1, p + 'bad schedule Trigger ' + s.Trigger);
+        if (s.Time !== undefined) {
+            check(/^\d{2}:\d{2}:00$/.test(s.Time), p + 'schedule Time must be HH:MM:00, got ' + s.Time);
+        }
+        if (s.DayOfWeek !== undefined) {
+            check(typeof s.DayOfWeek === 'number' && s.DayOfWeek >= 0 && s.DayOfWeek <= 6, p + 'DayOfWeek must be integer 0-6');
+        }
+    });
+    (dto.VisibilitySchedules || []).forEach(function (s) {
+        check(s.Action === 'Enable' || s.Action === 'Disable', p + 'visibility schedule needs Action Enable|Disable');
+    });
+    if (dto.RandomGroupSelection) {
+        check(['Artists', 'AlbumArtists', 'Album', 'SeriesName', 'Genres', 'Studios', 'Tags'].indexOf(dto.RandomGroupSelection.GroupBy) !== -1,
+            p + 'bad RandomGroupSelection.GroupBy');
+    }
+    if (t.inputHint) {
+        // Placeholder templates must actually contain an empty value to fill
+        const allSets = (dto.ExpressionSets || []).concat(dto.Bumpers ? dto.Bumpers.ExpressionSets : []);
+        const hasEmpty = allSets.some(function (set) {
+            return (set.Expressions || []).some(function (e) { return e.TargetValue === ''; });
+        });
+        check(hasEmpty, p + 'inputHint set but no empty TargetValue');
+    }
+});
+
+if (errors.length) {
+    console.error('TEMPLATE VALIDATION FAILED (' + errors.length + '):');
+    errors.forEach(function (e) { console.error('  - ' + e); });
+    process.exit(1);
+}
+console.log('All ' + SL.TEMPLATES.length + ' templates valid.');
+```
+
+Note: if `vm.runInContext(coreSrc, ...)` throws because config-core.js touches a browser API the stub lacks, extend the `sandbox.document`/`sandbox.window` stubs (no-op functions) until it loads — do NOT weaken the assertions.
+
+- [ ] **Step 6: Run validator + syntax checks**
+
+Run: `node dev/validate-templates.js`
+Expected: `All 10 templates valid.`
+Run: `node --check Jellyfin.Plugin.SmartLists/Configuration/config-templates.js`
+Expected: exit 0.
+
+- [ ] **Step 7: Build (verifies csproj/Plugin.cs registration compiles)**
+
+Run: `dotnet build Jellyfin.Plugin.SmartLists/Jellyfin.Plugin.SmartLists.csproj -c Release`
+Expected: 0 warnings, 0 errors, both TFMs.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Jellyfin.Plugin.SmartLists/Configuration/config-templates.js dev/validate-templates.js \
+  Jellyfin.Plugin.SmartLists/Jellyfin.Plugin.SmartLists.csproj Jellyfin.Plugin.SmartLists/Plugin.cs \
+  Jellyfin.Plugin.SmartLists/Configuration/config.html Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
+git commit -m "feat: add template catalog with dev validator and resource registration"
+```
+
+---
+
+### Task 3: Picker UI + apply flow + placeholder guard
+
+**Files:**
+- Modify: `Jellyfin.Plugin.SmartLists/Configuration/config.html` (~line 52, after `#edit-mode-indicator` closes, before the List Type `inputContainer`)
+- Modify: `Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html` (~line 36, same position)
+- Modify: `Jellyfin.Plugin.SmartLists/Configuration/config-templates.js` (add picker logic below the catalog, inside the same IIFE)
+- Modify: `Jellyfin.Plugin.SmartLists/Configuration/config-init.js` (init call + Use-button click wiring)
+- Modify: `Jellyfin.Plugin.SmartLists/Configuration/config-lists.js` (placeholder guard in `createPlaylist`, flag reset in `clearForm`)
+
+**Interfaces:**
+- Consumes: `SmartLists.TEMPLATES` (Task 2), `SmartLists.populateFormFromDto(page, dto, opts)` (Task 1), `SmartLists.isUserPage(page)`, `SmartLists.escapeHtml` (config-core.js — verify exact helper name near config-core.js:214, it may be `escapeHtml` or similar; use whatever the escaper there is called), `SmartLists.showNotification`, `SmartLists.syncAdvancedSection`.
+- Produces: `SmartLists.initTemplatePicker(page)` (idempotent; populates `#templateSelect`, binds change handler) and `SmartLists.useTemplate(page, templateId)`. Page flag `page._templatePlaceholderPending` consumed by `createPlaylist`.
+
+- [ ] **Step 1: Add picker markup to `config.html`**
+
+Between the closing `</div>` of `#edit-mode-indicator` (line 52) and the List Type `inputContainer` (line 53):
+
+```html
+                        <div class="inputContainer" id="templatePickerContainer" style="margin-bottom: 1em;">
+                            <label class="inputLabel" for="templateSelect">Start from a template (optional)</label>
+                            <div style="display: flex; gap: 0.5em; align-items: center;">
+                                <select is="emby-select" id="templateSelect" class="emby-select" style="flex: 1;">
+                                </select>
+                                <button type="button" id="useTemplateBtn" class="emby-button raised" disabled>Use</button>
+                            </div>
+                            <div id="templateDescription" class="fieldDescription" style="display: none; margin-top: 0.4em;"></div>
+                        </div>
+```
+
+`type="button"` is required — the button sits inside `#playlistForm` and must not submit it.
+
+- [ ] **Step 2: Add identical markup to `user-playlists.html`**
+
+Same block, inserted between the `#edit-mode-indicator` closing `</div>` (line 36) and the `<!-- List Type ... -->` comment (line 37).
+
+- [ ] **Step 3: Add picker logic to `config-templates.js`**
+
+Inside the IIFE, after the `SmartLists.TEMPLATES` array:
+
+```js
+    function visibleTemplates(page) {
+        const isUserPage = SmartLists.isUserPage(page);
+        const caps = SmartLists.userCapabilities || {};
+        return SmartLists.TEMPLATES.filter(function (t) {
+            if (isUserPage && t.adminOnly) {
+                return false;
+            }
+            // Hide collection templates from users who cannot create collections
+            if (isUserPage && t.dto.Type === 'Collection' && !caps.CanCreateCollections) {
+                return false;
+            }
+            return true;
+        });
+    }
+
+    function findTemplate(templateId) {
+        for (let i = 0; i < SmartLists.TEMPLATES.length; i++) {
+            if (SmartLists.TEMPLATES[i].id === templateId) {
+                return SmartLists.TEMPLATES[i];
+            }
+        }
+        return null;
+    }
+
+    SmartLists.initTemplatePicker = function (page) {
+        const select = page.querySelector('#templateSelect');
+        if (!select) {
+            return;
+        }
+
+        const templates = visibleTemplates(page);
+        let html = '<option value="">Select a template...</option>';
+        let currentCategory = null;
+        templates.forEach(function (t) {
+            if (t.category !== currentCategory) {
+                if (currentCategory !== null) {
+                    html += '</optgroup>';
+                }
+                html += '<optgroup label="' + SmartLists.escapeHtml(t.category) + '">';
+                currentCategory = t.category;
+            }
+            html += '<option value="' + SmartLists.escapeHtml(t.id) + '">' + SmartLists.escapeHtml(t.name) + '</option>';
+        });
+        if (currentCategory !== null) {
+            html += '</optgroup>';
+        }
+        select.innerHTML = html;
+
+        if (!select._templatePickerBound) {
+            select._templatePickerBound = true;
+            select.addEventListener('change', function () {
+                const template = findTemplate(select.value);
+                const descriptionDiv = page.querySelector('#templateDescription');
+                const useBtn = page.querySelector('#useTemplateBtn');
+                if (descriptionDiv) {
+                    descriptionDiv.textContent = template ? template.description : '';
+                    descriptionDiv.style.display = template ? 'block' : 'none';
+                }
+                if (useBtn) {
+                    useBtn.disabled = !template;
+                }
+            });
+        }
+    };
+
+    SmartLists.useTemplate = function (page, templateId) {
+        const template = findTemplate(templateId);
+        if (!template) {
+            return;
+        }
+
+        // Deep-copy so form population can never mutate the catalog
+        const dto = JSON.parse(JSON.stringify(template.dto));
+
+        try {
+            SmartLists.populateFormFromDto(page, dto, { name: template.name });
+        } catch (formError) {
+            console.error('Error applying template:', formError);
+            SmartLists.showNotification('Error applying template: ' + formError.message);
+            return;
+        }
+
+        page._templatePlaceholderPending = !!template.inputHint;
+
+        if (template.inputHint) {
+            SmartLists.showNotification(template.inputHint);
+            // Focus the first empty rule value so the user sees what to fill in
+            const inputs = page.querySelectorAll('#rules-container .rule-value-input');
+            for (let i = 0; i < inputs.length; i++) {
+                if (!inputs[i].value) {
+                    inputs[i].focus();
+                    break;
+                }
+            }
+        } else {
+            SmartLists.showNotification('Template applied - review the settings and click Create.', 'success');
+        }
+    };
+```
+
+Style note: `const`/`let` are fine (used throughout the existing modules); arrow functions and template literals are not.
+
+- [ ] **Step 4: Wire init + click in `config-init.js`**
+
+(a) In the page-init path where other populate calls run (near `loadAndPopulateFields` usage in the init/pageshow sequence around config-init.js:97-118), add:
+
+```js
+        if (SmartLists.initTemplatePicker) {
+            SmartLists.initTemplatePicker(page);
+        }
+```
+
+(b) Inside the page-level delegated click listener (config-init.js:984-1316), following the existing `closest` pattern (e.g. the `.clone-playlist-btn` block at 1131-1136), add:
+
+```js
+            if (target.closest('#useTemplateBtn')) {
+                const templateSelect = page.querySelector('#templateSelect');
+                if (templateSelect && templateSelect.value && SmartLists.useTemplate) {
+                    SmartLists.useTemplate(page, templateSelect.value);
+                }
+            }
+```
+
+Before relying on `caps.CanCreateCollections` (Step 3), confirm the exact property name in the capabilities object loaded at user-playlists.html:516-534 / the `Plugins/SmartLists/User/Capabilities` response, and adjust if it differs.
+
+- [ ] **Step 5: Placeholder guard in `createPlaylist` + flag reset in `clearForm`**
+
+In `config-lists.js`, inside `SmartLists.createPlaylist` (starts line 297), after the media-types check (`selectedMediaTypes.length === 0` block, ~lines 322-325) add:
+
+```js
+        // Guard for template placeholders: collectRulesFromForm silently drops
+        // rules with empty values, so an unfilled template rule would otherwise
+        // create a much broader list than the user expects.
+        if (page._templatePlaceholderPending) {
+            const ruleValueInputs = page.querySelectorAll('#rules-container .rule-value-input');
+            let firstEmptyInput = null;
+            for (let i = 0; i < ruleValueInputs.length; i++) {
+                if (!ruleValueInputs[i].value) {
+                    firstEmptyInput = ruleValueInputs[i];
+                    break;
+                }
+            }
+            if (firstEmptyInput) {
+                SmartLists.showNotification('This template needs a value - fill in the empty rule value first.');
+                firstEmptyInput.focus();
+                return;
+            }
+            page._templatePlaceholderPending = false;
+        }
+```
+
+(Empty BUMPER placeholder values are already blocked by the existing `bumperResult.valid` check at config-lists.js:417-420.)
+
+In `SmartLists.clearForm` (config-lists.js:~832), alongside the existing state resets, add:
+
+```js
+        page._templatePlaceholderPending = false;
+```
+
+Also reset the picker there so a cleared form doesn't keep a stale selection:
+
+```js
+        const templateSelect = page.querySelector('#templateSelect');
+        if (templateSelect) {
+            templateSelect.value = '';
+            const templateDescription = page.querySelector('#templateDescription');
+            if (templateDescription) {
+                templateDescription.style.display = 'none';
+            }
+            const useTemplateBtn = page.querySelector('#useTemplateBtn');
+            if (useTemplateBtn) {
+                useTemplateBtn.disabled = true;
+            }
+        }
+```
+
+- [ ] **Step 6: Syntax checks**
+
+Run: `node --check` on `config-templates.js`, `config-init.js`, `config-lists.js`.
+Expected: exit 0 each.
+Run: `node dev/validate-templates.js`
+Expected: `All 10 templates valid.` (config-templates.js now contains functions too — the validator only reads `SmartLists.TEMPLATES`, unaffected.)
+
+- [ ] **Step 7: Build**
+
+Run: `dotnet build Jellyfin.Plugin.SmartLists/Jellyfin.Plugin.SmartLists.csproj -c Release`
+Expected: 0 warnings, 0 errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Jellyfin.Plugin.SmartLists/Configuration/config.html Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html \
+  Jellyfin.Plugin.SmartLists/Configuration/config-templates.js Jellyfin.Plugin.SmartLists/Configuration/config-init.js \
+  Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+git commit -m "feat: add template picker with prefill flow and placeholder guard"
+```
+
+---
+
+### Task 4: Docs
+
+**Files:**
+- Modify: `docs/content/user-guide/configuration.md` (Create List tab section, ~lines 165-203)
+- Modify: `docs/content/getting-started/quick-start.md` (before/inside 'Creating Your First List', ~line 31)
+- Modify: `docs/content/index.md` (Features list, lines 37-44)
+- Modify: `README.md` (Features list, lines 17-24)
+
+**Interfaces:** none (prose).
+
+- [ ] **Step 1: configuration.md — document the picker**
+
+In the Create List tab section, before the existing core-fields description, add:
+
+```markdown
+### Start from a Template
+
+At the top of the Create tab you can pick one of the built-in templates — ready-made
+configurations like **TV Channel** (round-robin episode interleaving), **Continue
+Watching**, **Weekly Jams (ListenBrainz)**, or **Album Roulette**. Selecting a
+template and clicking **Use** fills the whole create form with a working setup.
+Nothing is created yet: review the settings, adjust them to taste, and click
+**Create** as usual.
+
+Some templates need one value from you (for example a title for *Because You
+Watched…* or your ListenBrainz feed URL for *Weekly Jams*) — a notification tells
+you which rule to fill in, and the form won't save until you do.
+```
+
+- [ ] **Step 2: quick-start.md — offer the shortcut**
+
+At the start of 'Creating Your First List' (~line 31), add:
+
+```markdown
+!!! tip "Shortcut: start from a template"
+    The quickest first list: pick a built-in template from **Start from a template**
+    at the top of the Create tab and click **Use** — the form is filled in for you,
+    ready to review and create. The steps below build the same thing by hand.
+```
+
+- [ ] **Step 3: index.md + README.md feature bullet**
+
+Add to both feature lists (index.md ~line 44, README.md ~line 24), matching the surrounding bullet style:
+
+```markdown
+- **Templates**: Start from built-in templates - TV channel round-robin, Continue Watching, external-list imports, album roulette, and more
+```
+
+- [ ] **Step 4: Verify docs build**
+
+Run: `cd docs && mkdocs build --strict` (use the venv/requirements.txt setup if mkdocs isn't on PATH: `pip install -r requirements.txt`).
+Expected: build completes with zero warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/content/user-guide/configuration.md docs/content/getting-started/quick-start.md docs/content/index.md README.md
+git commit -m "docs: document the template picker"
+```
+
+---
+
+### Task 5: End-to-end verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Deploy to the local dev Jellyfin**
+
+Use the project's `/verify` skill flow. CRITICAL (from prior-session incident): `./build-local.sh` / docker compose must run from the MAIN checkout's `dev/` directory, never from this worktree's — running compose from a worktree remounts an empty `jellyfin-data`. Either check out `feature/list-templates` in the main checkout and run `cd dev && ./build-local.sh` there, or build in the worktree and copy the built plugin DLL into the main checkout's deployed plugin directory, then `docker restart jellyfin`. Verify the deployed DLL actually contains the change (config-templates.js is an embedded resource — check with the UTF-16 string search trick from memory: stale-msbuild-deploy-verification).
+
+- [ ] **Step 2: Verify checklist (admin page, http://localhost:8096 → Dashboard → Smart Lists)**
+
+1. Create tab shows "Start from a template" above List Type; dropdown has 10 templates in 3 optgroups (TV / Movies / Music); Use disabled until a selection is made; description appears on selection.
+2. Select **TV Channel** → Use → form fills: type Playlist, name "TV Channel", media type Episode, one rule PlaybackStatus = Unplayed, sort Round Robin grouped by Series Name, auto-refresh On library changes; success notification shown; More-options fold state consistent (auto-expands only when the template sets advanced chips — e.g. schedules/bumpers templates).
+3. Click Create → list is created and materializes (Manage tab shows it; Jellyfin playlist appears).
+4. Select **Because You Watched…** → Use → notification with the hint; SimilarTo rule value empty and focused; click Create without filling → blocked with notification + focus; fill a title → Create succeeds.
+5. Select **Saturday Morning Cartoons** → Use → bumper section populated (interval 2, Random), bumper Tags rule empty; Create blocked by the existing bumper-incomplete message until filled; visibility schedules present (Enable Sat 06:00, Disable Sun 12:00) and Advanced fold auto-expanded.
+6. **Franchise TV Channel** → Use → sort shows Least Recently Watched Round Robin, group by Collections, within-group Air Date, air-block window 3.
+7. **Album Roulette** → Use → no rules (single empty rule row), Random Group Selection enabled/Album/min 5, two sorts (Album Name, Track Number), max playtime 180 — creating works (empty rule row is allowed for non-placeholder templates).
+8. Regression: edit an existing list → form populates correctly, Update works; clone an existing list → " (Copy)" name, create works; cancel edit resets.
+9. User page (sign in as non-admin → user Smart Lists page): picker present; **Trending Now (Trakt)** hidden when the user cannot create collections; applying **TV Channel** works and creates a list owned by the user.
+
+- [ ] **Step 3: Fix anything found, re-run the failing checklist item, commit fixes**
+
+```bash
+git add -A
+git commit -m "fix: address e2e findings for template picker"
+```
+
+(Skip the commit if nothing was found.)
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: catalog (Task 2), picker both pages (Task 3 Steps 1-2), population refactor (Task 1), placeholders blank+notification+guard (Tasks 2/3), registration (Task 2 Steps 2-4), docs including Examples cross-marking — **deliberately dropped**: marking Examples-page entries as shipped templates adds churn with no user value; quick-start/configuration/index/README cover discovery (deviation from spec, flagged for review). v1 set (Task 2) matches the spec's 10 with one substitution: "Trakt Trending" ships with the verified-supported URL hardcoded (no placeholder needed — spec's open verification item resolved: TraktListProvider.cs:17,252 explicitly supports `trakt.tv/movies/trending`); ExternalList confirmed available on the user page, so no `adminOnly` flags are needed in v1 (field kept in the entry shape for future use).
+- "Fresh & Unseen" ships WITHOUT `AllUsers: true` (spec said admin sets AllUsers): `stagePendingUserSelection`'s handling of a dto with no `UserPlaylists` but `AllUsers: true` is unverified, and defaulting to the creating user is the safer, simpler v1 — the description no longer promises all-users. Flagged as a deviation for review; enabling All Users remains a one-checkbox manual step.
+- Type consistency: `populateFormFromDto(page, dto|playlist, opts)` signature identical across Tasks 1-3; `page._templatePlaceholderPending` set in Task 3 Step 3, consumed/cleared in Task 3 Step 5; `SmartLists.TEMPLATES` shape defined in Task 2, consumed in Task 3.
+- Placeholder scan: two open verification points are explicit implementer checks with fallbacks (escaper helper name near config-core.js:214; `CanCreateCollections` property name), not TBDs.

--- a/docs/superpowers/specs/2026-07-22-list-templates-design.md
+++ b/docs/superpowers/specs/2026-07-22-list-templates-design.md
@@ -123,8 +123,12 @@ UserPagesController).
 
 External-list templates get `adminOnly: true` if the ExternalList field turns
 out to be unavailable on the user page (verify during implementation).
-"Fresh & Unseen": admin page sets AllUsers; on the user page the server
-force-overrides ownership anyway, so it degrades to per-user cleanly.
+"Fresh & Unseen" ships **per-user** (final decision, changed during
+implementation): staging an `AllUsers: true` dto through the shared user
+selection was unverified and defaulting to the creating user is the safer v1 —
+enabling All Users stays a one-checkbox manual step after applying the
+template. (The ExternalList field turned out to be available on the user page,
+so no template carries `adminOnly` in v1.)
 
 ## Docs impact
 
@@ -132,7 +136,9 @@ force-overrides ownership anyway, so it degrades to per-user cleanly.
 - getting-started/quick-start.md — "or start from a template" in the
   first-list flow.
 - index.md + README.md — feature bullet.
-- Examples pages — mark entries that ship as built-in templates.
+- Examples pages are NOT cross-marked with "ships as template" tags (final
+  decision, changed during implementation): the markings add churn without
+  user value; discovery is covered by the pages above.
 
 ## Verification
 

--- a/docs/superpowers/specs/2026-07-22-list-templates-design.md
+++ b/docs/superpowers/specs/2026-07-22-list-templates-design.md
@@ -1,0 +1,154 @@
+# List Templates — Design
+
+Date: 2026-07-22
+Status: Approved (Johan, 2026-07-22)
+
+## Problem
+
+The plugin has grown to ~65 rule fields, 40+ sorts, bumpers, external lists,
+round-robin interleaving, and more. New users face a blank create form with no
+guidance. A full setup wizard is too complex for the Jellyfin plugin UI, so
+instead: a curated set of templates the user can pick from, which prefills the
+create form with a working configuration they review and save.
+
+## Approach (decided)
+
+Frontend-only template gallery that prefills the create form. No backend
+changes. The prefilled form itself is the "draft" — nothing is created until
+the user clicks Create, so there is no risk of junk lists and all existing
+validation applies unchanged.
+
+Rejected alternatives:
+
+- **One-click backend create** (templates as API resources instantiating
+  disabled lists): more API surface, and placeholder values would produce
+  broken lists the user has to hunt down in the Manage tab.
+- **Per-list JSON import/export with a docs gallery**: useful for community
+  sharing later, but does not solve onboarding — new users will not paste JSON.
+
+## Why this is cheap: existing machinery
+
+Verified against the codebase (all claims adversarially confirmed):
+
+- `SmartLists.clonePlaylist` (config-lists.js:1114–1309) already implements
+  template instantiation: populate create form from a DTO, clear edit state
+  (`setPageEditState(page, false, null)`), so submit POSTs a new list. It is a
+  ~196-line near-duplicate of `editPlaylist` (config-lists.js:894–1112).
+- The create endpoint (POST `Plugins/SmartLists`, SmartListController.cs:572)
+  accepts a full `SmartListDto` and self-heals Id/FileName/Order/DateCreated;
+  `InputValidator.ValidateSmartList` runs on everything. `DtoMapper.cs:19–158`
+  is the authoritative checklist of copyable vs instance-specific fields.
+- Prefill prior art: `populateFormDefaults`/`applyFormDefaults`
+  (config-init.js:409–527) already prefill the create form from admin default
+  settings.
+- The docs Examples pages hold 66 worked configurations
+  (examples/common-use-cases.md: 49, examples/advanced-examples.md: 17) —
+  the template catalog is curation, not invention.
+
+## Components
+
+### 1. Template catalog — new `config-templates.js`
+
+`SmartLists.TEMPLATES`: static array. Entry shape:
+
+```js
+{
+  id: "tv-channel",
+  name: "TV Channel",              // also prefills the list Name field
+  category: "TV & Movies",         // optgroup label
+  description: "...",              // shown under the picker
+  adminOnly: false,                // hide on user page when true
+  inputHint: null,                 // set when the template needs user input
+  dto: { /* partial SmartListDto */ }
+}
+```
+
+`dto` carries only definition fields: `Type`, `MediaTypes`, `ExpressionSets`,
+`Order.SortOptions`, `MaxItems`, `MaxPlayTimeMinutes`, `Bumpers`,
+`RandomGroupSelection`, `AutoRefresh`, `Schedules`, `VisibilitySchedules`,
+`HideWhenEmpty`, `IncludeExtras`. Never instance fields (Id, FileName,
+Jellyfin IDs, DateCreated, stats, CustomImages, UserPlaylists).
+
+Rule field names must exist in the `FIELD_TYPES` arrays in config-core.js
+(populateRuleRow consults them); enum values serialize as strings
+(SmartListType, AutoRefreshMode, ScheduleTrigger, ScheduleAction).
+
+### 2. Picker UI — both pages
+
+Section at the top of `#playlistForm`, above List Type — never inside
+`#advanced-options-body` (project rule). Native `emby-select` with
+`<optgroup>` per category, a "Use" button, and a description div updated on
+select change. Same markup in config.html and user-playlists.html;
+`adminOnly` templates are filtered out on the user page. No ES6 template
+literals; messages via `showNotification`.
+
+### 3. Population engine — shared helper (refactor)
+
+Extract `populateFormFromDto(page, dto, opts)` from the ~400 duplicated lines
+in `editPlaylist` and `clonePlaylist`; both become thin wrappers. The
+template path calls the same helper with edit state cleared — clone's proven
+flow. The feature rides an already-tested code path and the duplication dies
+as a side effect.
+
+### 4. Placeholders
+
+Templates needing user input (SimilarTo seed title, franchise name, external
+list URL) ship those rule values **empty** plus an `inputHint`. After
+populating: `showNotification(inputHint)`, scroll to and focus the first
+empty rule value input. Empty values must block saving — verify during
+implementation that existing validation rejects empty `TargetValue`; if not,
+add a guard in `createPlaylist`.
+
+### 5. Registration
+
+`config-templates.js` needs: `.csproj` `<EmbeddedResource>`, `Plugin.cs`
+`GetPages()` `PluginPageInfo`, and a script tag in **both** HTML pages
+(user-playlists.html keeps its own script list, served by
+UserPagesController).
+
+## v1 template set (10)
+
+| Template | Showcases | Needs input |
+|---|---|---|
+| TV Channel | Round Robin, group by Series Name | no |
+| Franchise TV Channel | LRW Round Robin, group by Collections, AirDate within group, air-block window | no |
+| Continue Watching | NextUnwatched, LRW Round Robin, AutoRefresh OnAllChanges | no |
+| Weekly Jams (ListenBrainz) | External list feed, External List Order sort, weekly schedule | URL (username) |
+| Saturday Cartoons + Bumpers | Bumper config, visibility schedules | bumper tag |
+| Because You Watched… | SimilarTo, SimilarityComparisonFields, Similarity sort | seed title |
+| Album Roulette | RandomGroupSelection (Album), TrackNumber sort, MaxPlayTime | no |
+| Balanced Mix | Multi-block per-group MaxItems, Rule Block Order | no |
+| Fresh & Unseen (everyone) | DateCreated + Unplayed, AllUsers | no |
+| Trending Now (Trakt) | Collection type, external list, daily schedule, HideWhenEmpty | no |
+
+External-list templates get `adminOnly: true` if the ExternalList field turns
+out to be unavailable on the user page (verify during implementation).
+"Fresh & Unseen": admin page sets AllUsers; on the user page the server
+force-overrides ownership anyway, so it degrades to per-user cleanly.
+
+## Docs impact
+
+- user-guide/configuration.md — Create List tab section gains the picker.
+- getting-started/quick-start.md — "or start from a template" in the
+  first-list flow.
+- index.md + README.md — feature bullet.
+- Examples pages — mark entries that ship as built-in templates.
+
+## Verification
+
+- `dotnet build -c Release` both TFMs (warnings are errors), `node --check`
+  on changed JS.
+- E2E against local Jellyfin (dev container): instantiate TV Channel template
+  → form filled correctly → Create → list materializes with expected rules
+  and sort; placeholder template → save blocked until the value is filled;
+  user page → adminOnly templates hidden; edit and clone still work
+  (regression on the extracted helper).
+
+## Deliberate simplifications
+
+- No overwrite-confirm when "Use" is clicked on a partly-filled form —
+  explicit button, explicit intent.
+- Templates version with the plugin; no remote/community catalog (per-list
+  import/export is the future path for that).
+- No library-content-aware filtering — music templates are visible on
+  movie-only servers; descriptions make the target obvious.


### PR DESCRIPTION
## What
Adds a "Start from a template" picker to the Create tab (admin + user pages) with 10 curated smart-list templates that prefill the whole create form for the user to review, tweak, and save.

## Why
The plugin has grown to ~65 rule fields, 40+ sorts, bumpers, external lists, and round-robin interleaving — new users face a blank form with no guidance. Templates give a working starting point that showcases the newest features (round-robin TV channels, air-block windows, ListenBrainz feeds, bumpers, random group selection) without any backend changes: the prefilled form is the draft, so all existing validation and creation paths apply unchanged.

## Changes
- New `config-templates.js`: template catalog (10 templates grouped TV / Movies / Music) + picker logic (`initTemplatePicker`, `useTemplate`, `resetTemplatePicker`); registered in `.csproj`, `Plugin.cs`, and both HTML pages
- Picker UI above List Type in `config.html` and `user-playlists.html`: native select with category optgroups, description area, Use button, and a docs info icon; Collection templates hidden for users without collection permission
- Extracted shared `populateFormFromDto(page, dto, opts)` in `config-lists.js` from the ~400-line `editPlaylist`/`clonePlaylist` duplication — both are now thin wrappers, and the non-edit path resets stale edit-mode UI and custom-image state
- Placeholder templates (seed title, feed URL, bumper tag) prefill an empty rule value with a persistent hint; a visibility-aware guard (`findFirstEmptyRuleValueInput`) blocks saving until it's filled
- Fixed a pre-existing race in `config-multi-select.js`: the deferred (setTimeout) selection restore after checkbox regeneration could revert explicit selections (media types during populate) or be wrongly cancelled (owner restore in edit/clone) — the restore is now synchronous
- New dev-only `dev/validate-templates.js`: validates the catalog's field/operator/sort/enum vocabulary against `config-core.js`
- Docs: new "Start from a Template" section in configuration.md, quick-start tip, feature bullets in index.md and README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZT8BWVs1DwSgPWa6MimD4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a **“Start from a template”** section to SmartLists creation pages, with a searchable template picker and **Use** button.
  - Included built-in templates (with descriptions and input guidance) that prefill the create form.
  - Templates are shown/hidden based on permissions (including collection visibility rules).

- **Bug Fixes**
  - Improved multi-select restoration so chosen values persist reliably during form changes.
  - Prevented saving when template-required rule inputs are still empty; guides focus to the first missing value.

- **Documentation**
  - Updated README, quick-start, and configuration docs with template usage instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->