### PR TITLE
One library item per external music list track + authoritative MBID matching

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
@@ -4314,16 +4314,23 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             {
                 var recordingMbid = baseItem.GetProviderId("MusicBrainzRecording");
                 var artistNames = (baseItem as Audio)?.Artists;
+                var positionsByUrl = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
                 foreach (var kvp in cache.ExternalListData)
                 {
                     if (kvp.Value.TryGetMusicPosition(recordingMbid, baseItem.Name, artistNames, out var trackPosition))
                     {
                         matchingLists.Add(kvp.Key);
+                        positionsByUrl[kvp.Key] = trackPosition;
                         // Cache the best (lowest) position across all matched external lists for sorting
                         cache.ExternalListPositions.AddOrUpdate(baseItem.Id, trackPosition, (_, existing) => Math.Min(existing, trackPosition));
                         logger?.LogDebug("Item '{ItemName}' matched external list: {Url} at position {Position}", baseItem.Name, kvp.Key, trackPosition);
                     }
+                }
+
+                if (positionsByUrl.Count > 0)
+                {
+                    cache.MusicListPositionsByUrl[baseItem.Id] = positionsByUrl;
                 }
 
                 cache.ItemExternalLists[baseItem.Id] = matchingLists;

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -9,11 +9,13 @@ using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.SmartLists.Core.Models;
 using Jellyfin.Plugin.SmartLists.Core.Orders;
 using Jellyfin.Plugin.SmartLists.Core.QueryEngine;
+using Jellyfin.Plugin.SmartLists.Services.ExternalList;
 using Jellyfin.Plugin.SmartLists.Services.Shared;
 using Jellyfin.Plugin.SmartLists.Utilities;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.SmartLists.Core
@@ -1097,6 +1099,9 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 logger?.LogDebug("Playlist '{PlaylistName}' expanded from {OriginalCount} items to {ExpandedCount} items after Collections processing",
                     Name, results.Count, expandedResults.Count);
 
+                // Keep a single library item per matched external-list music track
+                expandedResults = DedupExternalMusicListMatches(expandedResults, refreshCache, logger);
+
                 expandedResults = ApplyRandomGroupSelection(expandedResults, libraryManager, user, userDataManager, logger, refreshCache);
 
                 // Apply per-group limits if configured (before sorting and global limits)
@@ -1440,6 +1445,87 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 logger?.LogError(ex, "Error applying per-group limits for playlist '{PlaylistName}'. Returning all items.", Name);
                 return items;
             }
+        }
+
+        /// <summary>
+        /// Keeps a single library item per matched external-list music track. Multiple copies of
+        /// the same song (album + compilation + live versions) can match one list entry; only the
+        /// best match survives — exact MusicBrainz recording ID first, then title matches that
+        /// needed no trailing "(...)" group stripping, then the rest. Items that did not match a
+        /// music external list are never dropped.
+        /// </summary>
+        private static List<BaseItem> DedupExternalMusicListMatches(List<BaseItem> items, RefreshQueueService.RefreshCache refreshCache, ILogger? logger)
+        {
+            if (refreshCache.MusicListPositionsByUrl.IsEmpty)
+            {
+                return items;
+            }
+
+            // Group candidate items by (list URL, track position)
+            var groups = new Dictionary<(string Url, int Position), List<BaseItem>>();
+            foreach (var item in items)
+            {
+                if (!refreshCache.MusicListPositionsByUrl.TryGetValue(item.Id, out var positionsByUrl))
+                {
+                    continue;
+                }
+
+                foreach (var entry in positionsByUrl)
+                {
+                    var key = (entry.Key, entry.Value);
+                    if (!groups.TryGetValue(key, out var group))
+                    {
+                        group = [];
+                        groups[key] = group;
+                    }
+
+                    group.Add(item);
+                }
+            }
+
+            // An item survives when it wins at least one of the tracks it matched
+            var winners = new HashSet<Guid>();
+            var losers = new HashSet<Guid>();
+            foreach (var group in groups.Values)
+            {
+                var winner = group
+                    .OrderBy(MusicListMatchRank)
+                    .ThenBy(i => i.Id)
+                    .First();
+                winners.Add(winner.Id);
+                foreach (var item in group)
+                {
+                    if (item.Id != winner.Id)
+                    {
+                        losers.Add(item.Id);
+                    }
+                }
+            }
+
+            losers.ExceptWith(winners);
+            if (losers.Count == 0)
+            {
+                return items;
+            }
+
+            logger?.LogDebug("External music list dedup removed {Count} duplicate track match(es)", losers.Count);
+            return items.Where(i => !losers.Contains(i.Id)).ToList();
+        }
+
+        /// <summary>
+        /// Ranks how strongly a library item matched an external music list entry. Lower is better:
+        /// 0 = exact recording MBID match (tagged items never match via fallback), 1 = title|artist
+        /// fallback with a clean title, 2 = fallback where a trailing "(Live)"-style group was
+        /// stripped to match.
+        /// </summary>
+        private static int MusicListMatchRank(BaseItem item)
+        {
+            if (!string.IsNullOrEmpty(item.GetProviderId("MusicBrainzRecording")))
+            {
+                return 0;
+            }
+
+            return MusicMatchKey.HasTrailingGroup(item.Name) ? 2 : 1;
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -1452,11 +1452,31 @@ namespace Jellyfin.Plugin.SmartLists.Core
         /// the same song (album + compilation + live versions) can match one list entry; only the
         /// best match survives — exact MusicBrainz recording ID first, then title matches that
         /// needed no trailing "(...)" group stripping, then the rest. Items that did not match a
-        /// music external list are never dropped.
+        /// music external list are never dropped. Only this list's own ExternalList rule URLs are
+        /// considered: the refresh cache retains fetched data for other lists (shared, additive),
+        /// and matches against those must not affect this list's results.
         /// </summary>
-        private static List<BaseItem> DedupExternalMusicListMatches(List<BaseItem> items, RefreshQueueService.RefreshCache refreshCache, ILogger? logger)
+        private List<BaseItem> DedupExternalMusicListMatches(List<BaseItem> items, RefreshQueueService.RefreshCache refreshCache, ILogger? logger)
         {
             if (refreshCache.MusicListPositionsByUrl.IsEmpty)
+            {
+                return items;
+            }
+
+            // URLs referenced by this list's own ExternalList rules
+            var activeListUrls = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var set in ExpressionSets ?? [])
+            {
+                foreach (var expr in set?.Expressions ?? [])
+                {
+                    if (expr?.MemberName == "ExternalList" && !string.IsNullOrWhiteSpace(expr.TargetValue))
+                    {
+                        activeListUrls.Add(expr.TargetValue);
+                    }
+                }
+            }
+
+            if (activeListUrls.Count == 0)
             {
                 return items;
             }
@@ -1472,6 +1492,11 @@ namespace Jellyfin.Plugin.SmartLists.Core
 
                 foreach (var entry in positionsByUrl)
                 {
+                    if (!activeListUrls.Contains(entry.Key))
+                    {
+                        continue;
+                    }
+
                     var key = (entry.Key, entry.Value);
                     if (!groups.TryGetValue(key, out var group))
                     {

--- a/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
@@ -240,6 +240,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                         // ExternalListData (the fetched list data) is kept since it's shared and additive across playlists.
                         refreshCache.ItemExternalLists.Clear();
                         refreshCache.ExternalListPositions.Clear();
+                        refreshCache.MusicListPositionsByUrl.Clear();
 
                         var fetchLimit = ExternalListService.ComputeFetchLimit();
                         _logger.LogDebug("Pre-fetching {Count} external list(s) for collection '{CollectionName}' (fetchLimit: {FetchLimit})", fieldReqs.ExternalListUrls.Count, dto.Name, fetchLimit);

--- a/Jellyfin.Plugin.SmartLists/Services/ExternalList/IExternalListProvider.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/ExternalList/IExternalListProvider.cs
@@ -239,8 +239,11 @@ namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
         }
 
         /// <summary>
-        /// Tries to find the position for a music track by recording MBID first, then by every
-        /// normalized title|artist key. Returns the minimum position across all matches.
+        /// Tries to find the position for a music track. Items with a MusicBrainz recording MBID
+        /// match by MBID only — the tag is authoritative, so a tagged recording that is not in
+        /// the list (e.g. a live version with its own MBID) never falls back to title|artist
+        /// matching. Untagged items match by normalized title|artist keys, returning the minimum
+        /// position across all matches.
         /// </summary>
         /// <param name="recordingMbid">The MusicBrainz recording MBID, if available.</param>
         /// <param name="title">The track title, if available.</param>
@@ -249,20 +252,25 @@ namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
         /// <returns>True if the recording MBID or any title|artist key matched.</returns>
         public bool TryGetMusicPosition(string? recordingMbid, string? title, IEnumerable<string>? artistNames, out int position)
         {
-            var found = false;
             position = -1;
 
-            if (!string.IsNullOrEmpty(recordingMbid) && MusicRecordingIds.TryGetValue(recordingMbid, out var recordingPosition))
+            if (!string.IsNullOrEmpty(recordingMbid))
             {
-                position = recordingPosition;
-                found = true;
+                if (MusicRecordingIds.TryGetValue(recordingMbid, out var recordingPosition))
+                {
+                    position = recordingPosition;
+                    return true;
+                }
+
+                return false;
             }
 
             if (artistNames == null || MusicMatchKey.NormalizeTitle(title).Length == 0)
             {
-                return found;
+                return false;
             }
 
+            var found = false;
             foreach (var artist in artistNames)
             {
                 // Mirror AddMusicTrack: artists that normalize to empty never have keys stored.

--- a/Jellyfin.Plugin.SmartLists/Services/ExternalList/MusicMatchKey.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/ExternalList/MusicMatchKey.cs
@@ -46,6 +46,17 @@ namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
             return Normalize(s, stripTrailingGroups: false);
         }
 
+        /// <summary>
+        /// Returns whether the title ends with a parenthetical/bracket group that
+        /// <see cref="NormalizeTitle"/> would strip, e.g. "Song (Live)".
+        /// </summary>
+        /// <param name="title">The raw title.</param>
+        /// <returns>True when a trailing group is present.</returns>
+        public static bool HasTrailingGroup(string? title)
+        {
+            return !string.IsNullOrEmpty(title) && TrailingGroupPattern().IsMatch(title);
+        }
+
         private static string Normalize(string? s, bool stripTrailingGroups)
         {
             if (string.IsNullOrWhiteSpace(s))

--- a/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
@@ -166,6 +166,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                         // ExternalListData (the fetched list data) is kept since it's shared and additive across playlists.
                         refreshCache.ItemExternalLists.Clear();
                         refreshCache.ExternalListPositions.Clear();
+                        refreshCache.MusicListPositionsByUrl.Clear();
 
                         var fetchLimit = ExternalListService.ComputeFetchLimit();
                         logger.LogDebug("Pre-fetching {Count} external list(s) for playlist '{PlaylistName}' (fetchLimit: {FetchLimit})", fieldReqs.ExternalListUrls.Count, dto.Name, fetchLimit);

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
@@ -785,6 +785,10 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
             // Maps ItemId → best (lowest) position across all matched external lists (for External List Order sorting)
             public ConcurrentDictionary<Guid, int> ExternalListPositions { get; } = new();
 
+            // Maps ItemId → (external list URL → matched track position) for music items.
+            // Used by SmartList to keep a single library item per external-list track.
+            public ConcurrentDictionary<Guid, Dictionary<string, int>> MusicListPositionsByUrl { get; } = new();
+
             // Warnings collected during processing (e.g., missing API keys, fetch failures)
             public ConcurrentBag<string> Warnings { get; } = [];
         }

--- a/docs/content/user-guide/external-lists.md
+++ b/docs/content/user-guide/external-lists.md
@@ -162,7 +162,7 @@ External List / equals / https://listenbrainz.org/syndication-feed/user/rob/reco
 ```
 
 !!! note "How Music Matching Works"
-    Tracks are matched by MusicBrainz recording IDs, which Jellyfin reads from your music files' embedded tags (e.g., files tagged with [MusicBrainz Picard](https://picard.musicbrainz.org)). Tracks without a MusicBrainz recording ID fall back to title + artist matching, so untagged libraries work too — though tagged libraries will match more reliably.
+    Tracks are matched by MusicBrainz recording IDs, which Jellyfin reads from your music files' embedded tags (e.g., files tagged with [MusicBrainz Picard](https://picard.musicbrainz.org)). Files tagged with a recording ID only match by that ID — they never fall back to title + artist matching. Untagged files fall back to title + artist matching, so untagged libraries work too — though tagged libraries will match more reliably. When several library items match the same track (e.g., the same song on an album, a compilation, and a live release), only the best match is added — an exact recording ID match is preferred, then a title match that didn't need a "(Live)"-style suffix stripped.
 
 !!! note "Private Playlists"
     Public playlists work without any configuration. To use your own private playlists, configure a ListenBrainz user token in the plugin settings (see Setup above).


### PR DESCRIPTION
## Summary

Follow-up to #461 user feedback: a 50-track ListenBrainz list produced 74 playlist items because every library copy of a matched song (album, compilation, live versions) matched the same list entry.

- **One item per list track**: after filtering, only the best-matching library item per (list URL, track position) is kept. Exact MusicBrainz recording ID matches are preferred, then title|artist fallback matches with a clean title, then fallback matches that needed a trailing "(Live)"-style suffix stripped. Backed by a new per-refresh `MusicListPositionsByUrl` cache.
- **Authoritative tags**: items tagged with a MusicBrainz recording ID now match by that ID only — no title|artist fallback. Well-tagged live versions (which carry their own recording MBIDs) no longer match the studio track's list entry. The fallback still applies to untagged files.

## Notes

- Non-music external lists (movies/shows/episodes) are byte-identical in behavior.
- Items that matched a music list entry but lost the dedup are dropped even if another rule would also include them (documented limitation — rule outcomes aren't tracked per item).
- Docs updated (`external-lists.md` matching note).

## Test plan

- [x] Release build clean on net9.0 + net10.0 (warnings-as-errors)
- [ ] E2E against dev Jellyfin (deferred — dev container currently shared with another session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZT8BWVs1DwSgPWa6MimD4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved external-list music matching to rely strictly on MusicBrainz recording IDs when available, avoiding title/artist fallback when an ID isn’t found.
  * Prevented duplicate library items by deduplicating matches per external-list track using best-match priority.
  * Ensured refreshed smart playlists and collections reset and recalculate external-list position data to avoid stale ordering.

* **Documentation**
  * Updated “How Music Matching Works” to reflect the recording-ID-only behavior and the match selection priorities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->