### PR TITLE
Restore playlist aggregate metadata (duration, genres, studios, rating)

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
@@ -209,6 +209,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                     .Select(itemId => LinkedChildFactory.Create(itemId, mediaLookup[itemId]))
                     .ToArray();
 
+                var resolvedItems = finalItemIds.Select(id => mediaLookup[id]).ToArray();
+
                 // Calculate playlist statistics from the same filtered list used for the actual playlist
                 dto.ItemCount = newLinkedChildren.Length;
                 dto.TotalRuntimeMinutes = RuntimeCalculator.CalculateTotalRuntimeMinutes(
@@ -385,7 +387,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                     }
 
                     // Update the playlist items (includes metadata refresh)
-                    await UpdatePlaylistPublicStatusAsync(existingPlaylist, dto.Public, newLinkedChildren, dto, user, cancellationToken);
+                    await UpdatePlaylistPublicStatusAsync(existingPlaylist, dto.Public, newLinkedChildren, resolvedItems, dto, user, cancellationToken);
 
                     logger.LogDebug("Successfully updated existing playlist: {PlaylistName} with {ItemCount} items",
                         existingPlaylist.Name, newLinkedChildren.Length);
@@ -438,7 +440,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                     // Create new playlist
                     logger.LogDebug("Creating new playlist: {PlaylistName}", smartPlaylistName);
 
-                    var newPlaylistId = await CreateNewPlaylistAsync(smartPlaylistName, user, dto.Public, newLinkedChildren, dto, cancellationToken);
+                    var newPlaylistId = await CreateNewPlaylistAsync(smartPlaylistName, user, dto.Public, newLinkedChildren, resolvedItems, dto, cancellationToken);
 
                     // Check if playlist creation actually succeeded
                     if (string.IsNullOrEmpty(newPlaylistId))
@@ -849,7 +851,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
             }
         }
 
-        private async Task UpdatePlaylistPublicStatusAsync(Playlist playlist, bool isPublic, LinkedChild[] linkedChildren, SmartPlaylistDto dto, User user, CancellationToken cancellationToken)
+        private async Task UpdatePlaylistPublicStatusAsync(Playlist playlist, bool isPublic, LinkedChild[] linkedChildren, IReadOnlyList<BaseItem> resolvedChildren, SmartPlaylistDto dto, User user, CancellationToken cancellationToken)
         {
             _logger.LogDebug("Updating playlist {PlaylistName} public status to {PublicStatus} and items to {ItemCount}",
     playlist.Name, isPublic ? "public" : "private", linkedChildren.Length);
@@ -889,6 +891,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
             var mediaType = DeterminePlaylistMediaType(dto);
             SetPlaylistMediaType(playlist, mediaType);
 
+            UpdateAggregateMetadata(playlist, resolvedChildren);
+
             // Save the changes after updating PlaylistMediaType
             await playlist.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
 
@@ -912,7 +916,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
             await ApplyCustomMetadataAsync(playlist, dto, user, cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task<string> CreateNewPlaylistAsync(string playlistName, User user, bool isPublic, LinkedChild[] linkedChildren, SmartPlaylistDto dto, CancellationToken cancellationToken)
+        private async Task<string> CreateNewPlaylistAsync(string playlistName, User user, bool isPublic, LinkedChild[] linkedChildren, IReadOnlyList<BaseItem> resolvedChildren, SmartPlaylistDto dto, CancellationToken cancellationToken)
         {
             _logger.LogDebug("Creating new smart playlist {PlaylistName} with {ItemCount} items and {PublicStatus} status",
                 playlistName, linkedChildren.Length, isPublic ? "public" : "private");
@@ -941,6 +945,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                 // Set MediaType before persisting to avoid a second write
                 var mediaType = DeterminePlaylistMediaType(dto);
                 SetPlaylistMediaType(newPlaylist, mediaType);
+
+                UpdateAggregateMetadata(newPlaylist, resolvedChildren);
 
                 // Persist once with items + media type
                 await newPlaylist.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
@@ -1726,6 +1732,47 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error setting playlist {PlaylistName} MediaType to {MediaType}", playlist.Name, mediaType);
+            }
+        }
+
+        /// <summary>
+        /// Mirrors the child aggregation Jellyfin's provider refresh normally performs
+        /// (MetadataService.UpdateMetadataFromChildren): cumulative runtime, genres, studios, and official rating.
+        /// Required because the plugin saves playlists via UpdateToRepositoryAsync,
+        /// which bypasses the provider pipeline that computes these fields.
+        /// </summary>
+        /// <param name="playlist">The playlist whose aggregate metadata to update.</param>
+        /// <param name="children">The resolved playlist items to aggregate from.</param>
+        private static void UpdateAggregateMetadata(Playlist playlist, IReadOnlyList<BaseItem> children)
+        {
+            long ticks = 0;
+            foreach (var child in children)
+            {
+                if (!child.IsFolder)
+                {
+                    ticks += child.RunTimeTicks ?? 0;
+                }
+            }
+
+            playlist.RunTimeTicks = ticks;
+
+            if (!playlist.IsLocked && !playlist.LockedFields.Contains(MetadataField.Genres))
+            {
+                playlist.Genres = children.SelectMany(c => c.Genres)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+            }
+
+            if (!playlist.IsLocked && !playlist.LockedFields.Contains(MetadataField.Studios))
+            {
+                playlist.Studios = children.SelectMany(c => c.Studios)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+            }
+
+            if (!playlist.IsLocked && !playlist.LockedFields.Contains(MetadataField.OfficialRating))
+            {
+                playlist.UpdateRatingToItems(children);
             }
         }
 


### PR DESCRIPTION
## What
Restores automatic calculation of a smart playlist's aggregate metadata — total duration, genres, studios, and parental rating — which stopped working for new playlists after #454.

## Why
Jellyfin only computes these fields from a playlist's children inside its provider-refresh pipeline (`MetadataService.UpdateMetadataFromChildren`). #454 removed the plugin's `RefreshSingleItem` call (it wiped provider IDs and fought plugin-generated covers), and the plugin's `UpdateToRepositoryAsync` saves bypass that pipeline entirely — so newly created playlists showed no total duration or genre tags until a manual metadata refresh, and existing playlists' values went stale as their contents changed.

## Changes
- New `UpdateAggregateMetadata` helper in `PlaylistService` mirroring native `PlaylistMetadataService` aggregation semantics:
  - `RunTimeTicks` = sum of non-folder children's runtime (matches `UpdateCumulativeRunTimeTicks`, including updating locked items — native parity)
  - `Genres` and `Studios` = case-insensitive distinct union of children's values, skipped when the item is locked or the field is locked
  - `OfficialRating` via Jellyfin's own `BaseItem.UpdateRatingToItems` (highest child rating by rating score) — without this, smart playlists were treated as unrated by parental controls
- Called on both save paths that assign `LinkedChildren` (create + update), right before the repository save, so aggregates refresh on every smart refresh
- The helper receives the already-resolved items from the refresh pass instead of re-resolving every linked child through the item repository (avoids one DB query per child per refresh)

Verified against a live Jellyfin container: new and refreshed playlists now show duration, genres, studios, and rating matching a natively refreshed playlist; both ABIs (10.11/net9.0, 12.x/net10.0) build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsYUGfTYy8xkQeUiNbjNQ5