### PR TITLE
Global default for hide-when-empty on new lists

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.SmartLists/Configuration/PluginConfiguration.cs
@@ -30,6 +30,12 @@ namespace Jellyfin.Plugin.SmartLists.Configuration
         public bool DefaultMakePublic { get; set; } = false;
 
         /// <summary>
+        /// Gets or sets whether new lists should hide when empty by default.
+        /// Keep the default in sync with SmartLists.getDefaultHideWhenEmpty in config-core.js.
+        /// </summary>
+        public bool DefaultHideWhenEmpty { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets whether to stamp a small smart list badge onto auto-generated
         /// and uploaded cover images so smart lists are recognizable at a glance.
         /// </summary>

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-core.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-core.js
@@ -415,6 +415,16 @@
         return false;
     };
 
+    /**
+     * Resolve the hide-when-empty default for new lists.
+     * Single JS source of truth — must stay in sync with the
+     * PluginConfiguration.DefaultHideWhenEmpty initializer (true) in C#.
+     * Pass null when no config is available (user page, config fetch failure).
+     */
+    SmartLists.getDefaultHideWhenEmpty = function (config) {
+        return !config || config.DefaultHideWhenEmpty !== false;
+    };
+
     SmartLists.getPluginId = function () {
         return SmartLists.PLUGIN_ID;
     };

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
@@ -433,7 +433,10 @@
         // Set default public/enabled/extras checkboxes
         SmartLists.setElementChecked(page, '#playlistIsPublic', config.DefaultMakePublic || false);
         SmartLists.setElementChecked(page, '#playlistIncludeExtras', false);
-        SmartLists.setElementChecked(page, '#playlistHideWhenEmpty', SmartLists.getDefaultHideWhenEmpty(config));
+        // Cache the resolved default so template application can read it even
+        // after the checkbox has been toggled (e.g. by a previous template)
+        page._defaultHideWhenEmpty = SmartLists.getDefaultHideWhenEmpty(config);
+        SmartLists.setElementChecked(page, '#playlistHideWhenEmpty', page._defaultHideWhenEmpty);
         SmartLists.setElementChecked(page, '#playlistIsEnabled', true); // Default to enabled
 
         // Reinitialize schedule system
@@ -488,7 +491,8 @@
         SmartLists.setElementValue(page, '#autoRefreshMode', 'OnLibraryChanges');
         SmartLists.setElementChecked(page, '#playlistIsPublic', false);
         SmartLists.setElementChecked(page, '#playlistIncludeExtras', false);
-        SmartLists.setElementChecked(page, '#playlistHideWhenEmpty', SmartLists.getDefaultHideWhenEmpty(null));
+        page._defaultHideWhenEmpty = SmartLists.getDefaultHideWhenEmpty(null);
+        SmartLists.setElementChecked(page, '#playlistHideWhenEmpty', page._defaultHideWhenEmpty);
         SmartLists.setElementChecked(page, '#playlistIsEnabled', true);
 
         // Reinitialize schedule system with fallback defaults

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
@@ -433,7 +433,7 @@
         // Set default public/enabled/extras checkboxes
         SmartLists.setElementChecked(page, '#playlistIsPublic', config.DefaultMakePublic || false);
         SmartLists.setElementChecked(page, '#playlistIncludeExtras', false);
-        SmartLists.setElementChecked(page, '#playlistHideWhenEmpty', false);
+        SmartLists.setElementChecked(page, '#playlistHideWhenEmpty', SmartLists.getDefaultHideWhenEmpty(config));
         SmartLists.setElementChecked(page, '#playlistIsEnabled', true); // Default to enabled
 
         // Reinitialize schedule system
@@ -488,7 +488,7 @@
         SmartLists.setElementValue(page, '#autoRefreshMode', 'OnLibraryChanges');
         SmartLists.setElementChecked(page, '#playlistIsPublic', false);
         SmartLists.setElementChecked(page, '#playlistIncludeExtras', false);
-        SmartLists.setElementChecked(page, '#playlistHideWhenEmpty', false);
+        SmartLists.setElementChecked(page, '#playlistHideWhenEmpty', SmartLists.getDefaultHideWhenEmpty(null));
         SmartLists.setElementChecked(page, '#playlistIsEnabled', true);
 
         // Reinitialize schedule system with fallback defaults
@@ -1890,6 +1890,7 @@
             const defaultIgnoreArticlesContainer = page.querySelector('#defaultIgnoreArticlesContainer');
             const defaultListTypeEl = page.querySelector('#defaultListType');
             const defaultMakePublicEl = page.querySelector('#defaultMakePublic');
+            const defaultHideWhenEmptyEl = page.querySelector('#defaultHideWhenEmpty');
             const defaultMaxItemsEl = page.querySelector('#defaultMaxItems');
             const defaultMaxPlayTimeMinutesEl = page.querySelector('#defaultMaxPlayTimeMinutes');
             const defaultAutoRefreshEl = page.querySelector('#defaultAutoRefresh');
@@ -1920,6 +1921,8 @@
 
             if (defaultListTypeEl) defaultListTypeEl.value = config.DefaultListType || 'Playlist';
             if (defaultMakePublicEl) defaultMakePublicEl.checked = config.DefaultMakePublic || false;
+
+            if (defaultHideWhenEmptyEl) defaultHideWhenEmptyEl.checked = SmartLists.getDefaultHideWhenEmpty(config);
 
             // Smart list badge defaults to enabled, so only an explicit false unchecks it
             const showSmartListBadgeEl = page.querySelector('#showSmartListBadge');
@@ -2053,6 +2056,7 @@
             config.DefaultSortOrder = page.querySelector('#defaultSortOrder').value;
             config.DefaultListType = page.querySelector('#defaultListType').value;
             config.DefaultMakePublic = page.querySelector('#defaultMakePublic').checked;
+            config.DefaultHideWhenEmpty = SmartLists.getElementChecked(page, '#defaultHideWhenEmpty', SmartLists.getDefaultHideWhenEmpty(config));
             config.ShowSmartListBadge = page.querySelector('#showSmartListBadge').checked;
             const defaultMaxItemsInput = page.querySelector('#defaultMaxItems').value;
             if (defaultMaxItemsInput === '') {

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-templates.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-templates.js
@@ -331,6 +331,12 @@
         // Deep-copy so form population can never mutate the catalog
         const dto = JSON.parse(JSON.stringify(template.dto));
 
+        // Templates that don't specify HideWhenEmpty inherit the form's current
+        // state, which was prefilled from the configured default for new lists
+        if (dto.HideWhenEmpty === undefined) {
+            dto.HideWhenEmpty = SmartLists.getElementChecked(page, '#playlistHideWhenEmpty', SmartLists.getDefaultHideWhenEmpty(null));
+        }
+
         try {
             SmartLists.populateFormFromDto(page, dto, { name: template.name });
         } catch (formError) {

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-templates.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-templates.js
@@ -331,10 +331,13 @@
         // Deep-copy so form population can never mutate the catalog
         const dto = JSON.parse(JSON.stringify(template.dto));
 
-        // Templates that don't specify HideWhenEmpty inherit the form's current
-        // state, which was prefilled from the configured default for new lists
+        // Templates that don't specify HideWhenEmpty inherit the configured
+        // default for new lists (cached by the form-defaults population; the
+        // live checkbox may have been toggled by a previously applied template)
         if (dto.HideWhenEmpty === undefined) {
-            dto.HideWhenEmpty = SmartLists.getElementChecked(page, '#playlistHideWhenEmpty', SmartLists.getDefaultHideWhenEmpty(null));
+            dto.HideWhenEmpty = page._defaultHideWhenEmpty !== undefined
+                ? page._defaultHideWhenEmpty
+                : SmartLists.getDefaultHideWhenEmpty(null);
         }
 
         try {

--- a/Jellyfin.Plugin.SmartLists/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config.html
@@ -430,7 +430,7 @@
                             style="padding: 0.5em 1em; margin-bottom: 1em; margin-top: 0.5em;">
                             <label class="emby-checkbox-label">
                                 <input type="checkbox" is="emby-checkbox" id="playlistHideWhenEmpty"
-                                    data-embycheckbox="true" class="emby-checkbox">
+                                    data-embycheckbox="true" class="emby-checkbox" checked>
                                 <span class="checkboxLabel">Hide when empty</span>
                                 <span class="checkboxOutline">
                                     <span class="material-icons checkboxIcon checkboxIcon-checked check"
@@ -660,6 +660,26 @@
                                 </label>
                                 <div class="fieldDescription">New smart lists will be public by default when this is
                                     enabled.</div>
+                            </div>
+                        </div>
+
+                        <div class="checkboxList paperList"
+                            style="padding: 0.5em 1em; margin-bottom: 1em; margin-top: 1em;">
+                            <div class="sectioncheckbox">
+                                <label class="emby-checkbox-label">
+                                    <input type="checkbox" is="emby-checkbox" id="defaultHideWhenEmpty"
+                                        data-embycheckbox="true" class="emby-checkbox" checked>
+                                    <span class="checkboxLabel">Hide lists when empty by default</span>
+                                    <span class="checkboxOutline">
+                                        <span class="material-icons checkboxIcon checkboxIcon-checked check"
+                                            aria-hidden="true"></span>
+                                        <span class="material-icons checkboxIcon checkboxIcon-unchecked"
+                                            aria-hidden="true"></span>
+                                    </span>
+                                </label>
+                                <div class="fieldDescription">New smart lists will hide when empty by default: the
+                                    Jellyfin playlist/collection isn't created while no items match, and is removed
+                                    and recreated automatically once items match again.</div>
                             </div>
                         </div>
 

--- a/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
@@ -364,7 +364,7 @@
                             style="padding: 0.5em 1em; margin-bottom: 1em; margin-top: 0.5em;">
                             <label class="emby-checkbox-label">
                                 <input type="checkbox" is="emby-checkbox" id="playlistHideWhenEmpty"
-                                    data-embycheckbox="true" class="emby-checkbox">
+                                    data-embycheckbox="true" class="emby-checkbox" checked>
                                 <span class="checkboxLabel">Hide when empty</span>
                                 <span class="checkboxOutline">
                                     <span class="material-icons checkboxIcon checkboxIcon-checked check"

--- a/docs/content/user-guide/configuration.md
+++ b/docs/content/user-guide/configuration.md
@@ -270,6 +270,7 @@ Configure global settings for the plugin:
 
 - Set the default sort order for new lists
 - Set the default max items and max playtime for new lists
+- Set whether new lists hide when empty by default
 - Configure custom prefix and suffix for list names
 - Set the default auto-refresh mode for new lists
 - Set the default custom schedule settings for new lists
@@ -321,13 +322,15 @@ Disabling lists can be useful for:
 
 ## Hide When Empty
 
-By default, a smart list's Jellyfin playlist or collection exists even when its rules match no items. Enable **Hide when empty** (in the **Presentation** group under **More options** when creating or editing a list) to change that:
+With **Hide when empty** (in the **Presentation** group under **More options** when creating or editing a list), a smart list's Jellyfin playlist or collection is hidden while its rules match no items:
 
 - If a refresh finds **no matching items**, the Jellyfin playlist/collection is removed (or never created in the first place).
 - As soon as a later refresh finds matching items again, it is recreated automatically — including any custom images and metadata you configured.
 - The smart list configuration itself is never deleted; it stays visible in the Smart Lists interface.
 
 This is useful for seasonal or rotating lists (e.g. "Halloween movies" driven by a schedule or an external list) that would otherwise linger as empty entries in your library. For multi-user playlists, hiding applies per user: a user with no matching items has their playlist hidden while other users keep theirs.
+
+New lists have this enabled by default. Admins can change the default for new lists with **Hide lists when empty by default** in the Settings tab; the per-list checkbox always takes precedence, and changing the global setting does not affect existing lists. The Settings-tab default applies to lists created from the admin configuration page — the user page always starts new lists with **Hide when empty** enabled.
 
 ## Custom List Naming
 


### PR DESCRIPTION
## What
Adds a global **Hide lists when empty by default** setting (enabled by default) that pre-checks the per-list "Hide when empty" option for newly created smart lists.

## Why
Hide-when-empty is currently opt-in per list. Most users want it on for every list, so the default is now configurable server-wide, following the same creation-time-default pattern as the other `Default*` options (`DefaultMakePublic`, `DefaultAutoRefresh`, ...). The per-list checkbox stays authoritative and existing lists are unaffected.

## Changes
- `PluginConfiguration.cs`: new `DefaultHideWhenEmpty` property, default `true` (upgraded installs without the config element deserialize to enabled)
- `config.html`: new Settings-tab checkbox, wired to load/save in `config-init.js`
- `config-core.js`: new `SmartLists.getDefaultHideWhenEmpty(config)` helper — single JS source of truth for the default, cross-referenced with the C# initializer; all three call sites (form prefill, fallback defaults, settings load) route through it
- `config-templates.js`: templates that don't specify `HideWhenEmpty` now inherit the form's prefilled default instead of forcing unchecked (9 of 10 templates omit it)
- `config.html` / `user-playlists.html`: the `#playlistHideWhenEmpty` and `#defaultHideWhenEmpty` checkboxes ship `checked` in markup, so the pre-config-paint state matches the shipped default (same convention as `#playlistIsEnabled`)
- Settings save uses the null-safe `getElementChecked` helper instead of a raw `querySelector(...).checked`
- Docs: Settings list entry + rewritten Hide When Empty section, including the user-page caveat (the user page cannot read admin config, so it always starts new lists with the shipped default)

Known scope limits (intentional): the default is applied at form-population time only — lists created directly via the API don't consult it, and the user page uses the shipped default rather than the admin's setting (pre-existing limitation shared by all `Default*` options).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsYUGfTYy8xkQeUiNbjNQ5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin setting to control whether new lists hide when empty by default.
  * New smart lists now default to hiding when empty, with per-list options to override.
  * Updated the templates and UI defaults so the configured “hide when empty” behavior is preserved when values are missing.
* **Documentation**
  * Reworked the “Hide When Empty” explanation, including how lists are removed/recreated and the precedence between global defaults and per-list settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->