### PR TITLE
fix: load config page modules without synchronous XHR

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config.html
@@ -1275,38 +1275,55 @@
             </div>
         </div>
 
-        <!-- Core utilities and constants (must load first) -->
-        <script src="configurationpage?name=config-core.js"></script>
-        <!-- Formatters and option generators -->
-        <script src="configurationpage?name=config-formatters.js"></script>
-        <!-- Schedule management -->
-        <script src="configurationpage?name=config-schedules.js"></script>
-        <!-- Image management -->
-        <script src="configurationpage?name=config-images.js"></script>
-        <!-- Sort management -->
-        <script src="configurationpage?name=config-sorts.js"></script>
-        <!-- Generic multi-select component -->
-        <script src="configurationpage?name=config-multi-select.js"></script>
-        <!-- Searchable single-select component -->
-        <script src="configurationpage?name=config-searchable-select.js"></script>
-        <!-- User multi-select for playlists -->
-        <script src="configurationpage?name=config-user-select.js"></script>
-        <!-- Rule management -->
-        <script src="configurationpage?name=config-rules.js"></script>
-        <!-- List CRUD operations -->
-        <script src="configurationpage?name=config-lists.js"></script>
-        <!-- Template catalog and picker -->
-        <script src="configurationpage?name=config-templates.js"></script>
-        <!-- Filtering and search -->
-        <script src="configurationpage?name=config-filters.js"></script>
-        <!-- Bulk actions -->
-        <script src="configurationpage?name=config-bulk-actions.js"></script>
-        <!-- Status page -->
-        <script src="configurationpage?name=config-status.js"></script>
-        <!-- API calls -->
-        <script src="configurationpage?name=config-api.js"></script>
-        <!-- Initialization (must load last) -->
-        <script src="configurationpage?name=config-init.js"></script>
+        <!--
+            Module loader. These must NOT be plain <script src> tags.
+
+            Jellyfin-web parses plugin pages with innerHTML (viewContainer.js
+            parseHtml), which permanently disables the parsed <script> tags, then
+            revives them by re-appending the page with jQuery. jQuery loads a
+            <script src> through jQuery._evalUrl, which is a SYNCHRONOUS XHR - so a
+            reverse proxy sending "Permissions-Policy: sync-xhr=()" (the example in
+            Jellyfin's own nginx docs) blocks every module and the page renders empty.
+
+            An inline block is evaluated directly by jQuery instead, with no request
+            of its own, so it can inject the modules itself. See issue #471.
+        -->
+        <script>
+            (function () {
+                var modules = [
+                    'config-core.js',              // Core utilities and constants (must load first)
+                    'config-formatters.js',        // Formatters and option generators
+                    'config-schedules.js',         // Schedule management
+                    'config-images.js',            // Image management
+                    'config-sorts.js',             // Sort management
+                    'config-multi-select.js',      // Generic multi-select component
+                    'config-searchable-select.js', // Searchable single-select component
+                    'config-user-select.js',       // User multi-select for playlists
+                    'config-rules.js',             // Rule management
+                    'config-lists.js',             // List CRUD operations
+                    'config-templates.js',         // Template catalog and picker
+                    'config-filters.js',           // Filtering and search
+                    'config-bulk-actions.js',      // Bulk actions
+                    'config-status.js',            // Status page
+                    'config-api.js',               // API calls
+                    'config-init.js'               // Initialization (must load last)
+                ];
+
+                for (var i = 0; i < modules.length; i++) {
+                    var script = document.createElement('script');
+                    // Dynamically created scripts default to async; false keeps them
+                    // executing in the order above, which config-init.js depends on.
+                    script.async = false;
+                    script.src = 'configurationpage?name=' + modules[i];
+                    // The SPA re-runs this block on every visit to the page; drop the
+                    // element once it has executed so <head> does not grow unbounded.
+                    script.onload = function () {
+                        this.remove();
+                    };
+                    document.head.appendChild(script);
+                }
+            })();
+        </script>
     </div>
 </body>
 

--- a/Jellyfin.Plugin.SmartLists/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config.html
@@ -1316,8 +1316,9 @@
                     script.async = false;
                     script.src = 'configurationpage?name=' + modules[i];
                     // The SPA re-runs this block on every visit to the page; drop the
-                    // element once it has executed so <head> does not grow unbounded.
-                    script.onload = function () {
+                    // element once it has settled so <head> does not grow unbounded.
+                    // onerror too, so a module that fails to load is not left behind.
+                    script.onload = script.onerror = function () {
                         this.remove();
                     };
                     document.head.appendChild(script);

--- a/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
@@ -632,34 +632,45 @@
             </div>
         </div>
 
-        <!-- Core utilities and constants (must load first) -->
-        <script src="configurationpage?name=config-core.js"></script>
-        <!-- Formatters and option generators -->
-        <script src="configurationpage?name=config-formatters.js"></script>
-        <!-- Schedule management -->
-        <script src="configurationpage?name=config-schedules.js"></script>
-        <!-- Image management -->
-        <script src="configurationpage?name=config-images.js"></script>
-        <!-- Sort management -->
-        <script src="configurationpage?name=config-sorts.js"></script>
-        <!-- Generic multi-select component -->
-        <script src="configurationpage?name=config-multi-select.js"></script>
-        <!-- Searchable single-select component -->
-        <script src="configurationpage?name=config-searchable-select.js"></script>
-        <!-- Rule management -->
-        <script src="configurationpage?name=config-rules.js"></script>
-        <!-- List CRUD operations -->
-        <script src="configurationpage?name=config-lists.js"></script>
-        <!-- Template catalog and picker -->
-        <script src="configurationpage?name=config-templates.js"></script>
-        <!-- Filtering and search -->
-        <script src="configurationpage?name=config-filters.js"></script>
-        <!-- Bulk actions and playlist card interactions -->
-        <script src="configurationpage?name=config-bulk-actions.js"></script>
-        <!-- API calls -->
-        <script src="configurationpage?name=config-api.js"></script>
-        <!-- Initialization (must load last) -->
-        <script src="configurationpage?name=config-init.js"></script>
+        <!--
+            Module loader - kept identical in shape to config.html. Plain <script src>
+            tags are avoided here too so both pages load their modules the same way;
+            see the longer explanation in config.html and issue #471.
+        -->
+        <script>
+            (function () {
+                var modules = [
+                    'config-core.js',              // Core utilities and constants (must load first)
+                    'config-formatters.js',        // Formatters and option generators
+                    'config-schedules.js',         // Schedule management
+                    'config-images.js',            // Image management
+                    'config-sorts.js',             // Sort management
+                    'config-multi-select.js',      // Generic multi-select component
+                    'config-searchable-select.js', // Searchable single-select component
+                    'config-rules.js',             // Rule management
+                    'config-lists.js',             // List CRUD operations
+                    'config-templates.js',         // Template catalog and picker
+                    'config-filters.js',           // Filtering and search
+                    'config-bulk-actions.js',      // Bulk actions and playlist card interactions
+                    'config-api.js',               // API calls
+                    'config-init.js'               // Initialization (must load last)
+                ];
+
+                for (var i = 0; i < modules.length; i++) {
+                    var script = document.createElement('script');
+                    // Dynamically created scripts default to async; false keeps them
+                    // executing in the order above, which config-init.js depends on.
+                    script.async = false;
+                    script.src = 'configurationpage?name=' + modules[i];
+                    // The SPA re-runs this block on every visit to the page; drop the
+                    // element once it has executed so <head> does not grow unbounded.
+                    script.onload = function () {
+                        this.remove();
+                    };
+                    document.head.appendChild(script);
+                }
+            })();
+        </script>
     </div>
 </body>
 

--- a/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
@@ -663,8 +663,9 @@
                     script.async = false;
                     script.src = 'configurationpage?name=' + modules[i];
                     // The SPA re-runs this block on every visit to the page; drop the
-                    // element once it has executed so <head> does not grow unbounded.
-                    script.onload = function () {
+                    // element once it has settled so <head> does not grow unbounded.
+                    // onerror too, so a module that fails to load is not left behind.
+                    script.onload = script.onerror = function () {
                         this.remove();
                     };
                     document.head.appendChild(script);


### PR DESCRIPTION
## What

Replaces the plain `<script src>` tags on both config pages with a single inline block that injects the module scripts itself, so the pages no longer depend on synchronous XHR.

Fixes #471

## Why

Jellyfin-web parses plugin pages with `innerHTML` ([`viewContainer.js` `parseHtml`](https://github.com/jellyfin/jellyfin-web/blob/release-10.11.z/src/components/viewContainer.js#L122-L132)), which permanently disables the parsed `<script>` tags, then revives them by re-appending the page with jQuery. jQuery loads a `<script src>` through `jQuery._evalUrl`, which is a **synchronous** XHR (`async: false`).

A reverse proxy sending `Permissions-Policy: sync-xhr=()` — the example in [Jellyfin's own nginx documentation](https://jellyfin.org/docs/general/post-install/networking/reverse-proxy/nginx#https-config-example) — therefore blocks every one of our 16 `config-*.js` modules. The page paints its static header and tabs, then stays empty with no JS loaded.

Notably this is the pattern *no* official Jellyfin plugin uses. Of the official plugins checked (template, ldapauth, tmdbboxsets, webhook, playbackreporting, opensubtitles, trakt), they all either use a single inline `<script>` block or `data-controller="__plugin/X.js"` (loaded via dynamic ES `import()`). Both avoid XHR entirely; `<script src>` is the only pattern that requires it.

The reporter's stack trace points at a 2FA plugin's `inject.js`, but that is a red herring — that plugin monkeypatches `XMLHttpRequest.prototype.send` globally, so its filename appears in the frame of *jQuery's* sync XHR. The failure reproduces without it.

## Changes

- `config.html` — 16 `<script src>` tags replaced by one inline loader; comment block records why plain `<script src>` must not come back
- `user-playlists.html` — same loader shape (14 modules; no `config-user-select.js` / `config-status.js`). This page was not broken (Plugin Pages uses `createContextualFragment`, which loads scripts natively), but is changed so both pages load modules the same way
- Module lists and load order preserved exactly
- `script.async = false` keeps execution in list order, which `config-init.js` depends on
- Elements are removed on load so `<head>` does not grow as the SPA re-runs the block on each visit

## Verification

Against a local Jellyfin 12.0-rc3 container with sync XHR blocked (simulating the policy by throwing `NotAllowedError` on `open(..., async=false)`, as Chromium does):

| | Before | After |
|---|---|---|
| Blocked sync XHRs | 16 | 0 |
| `window.SmartLists` | absent | object, 363 entries |
| Page initialized | no | yes |
| Form controls rendered | 0 | 153 |

All four tabs exercised under the active block (Create List, Manage Lists loading 20 lists with filters and bulk actions, Status, Settings). Repeat navigation away/back checked — 1 page instance, correct re-execution, 0 leftover `<head>` scripts. No console errors. User page verified by served markup (`GET /Plugins/SmartLists/Pages/UserPlaylists`); it cannot be exercised live because File Transformation is not installed in the dev container.

Both target frameworks build clean (0 warnings, warnings-as-errors).

## Upstream

The underlying issue is jellyfin-web's, and affects every plugin config page using `<script src>`. The clean upstream fix is for `parseHtml` to use `createContextualFragment` instead of `innerHTML` — then scripts load natively and the jQuery revival path can go. Worth filing separately; this PR makes SmartLists immune regardless of that timeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjXfWuB2junrenas4pzuDG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SmartLists configuration and user playlist pages when used within Jellyfin’s single-page interface.
  * Prevented pages from rendering empty or failing to load behind reverse proxies.
  * Ensured configuration modules load in the correct order for reliable initialization.
  * Reduced accumulation of temporary script elements during repeated page visits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->