### PR TITLE
Add per-rule option to include items with unknown dates

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Configuration/config-core.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-core.js
@@ -50,6 +50,9 @@
         USER_DATA_FIELDS: ['PlaybackStatus', 'IsFavorite', 'PlayCount', 'NextUnwatched', 'LastPlayedDate']
     };
 
+    // Date fields where metadata can be missing - these get the "unknown date" option
+    SmartLists.UNKNOWN_DATE_FIELDS = ['ReleaseDate', 'LastEpisodeAirDate'];
+
     // Media type capabilities - which types support audio/video streams
     SmartLists.AUDIO_CAPABLE_TYPES = ['Movie', 'Episode', 'Audio', 'AudioBook', 'MusicVideo', 'Video'];
     SmartLists.VIDEO_CAPABLE_TYPES = ['Movie', 'Episode', 'MusicVideo', 'Video'];

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -1634,6 +1634,12 @@
                             nextUnwatchedInfo = rule.IncludeUnwatchedSeries ? ' (including unwatched series)' : ' (excluding unwatched series)';
                         }
 
+                        // Add unknown-date configuration info
+                        let unknownDateInfo = '';
+                        if (rule.IncludeUnknownDates === true) {
+                            unknownDateInfo = ' (including unknown dates)';
+                        }
+
                         // Add Collections configuration info
                         let collectionsInfo = '';
                         if (rule.MemberName === 'Collections') {
@@ -1719,7 +1725,7 @@
                         }
 
                         rulesHtml += '<span style="font-family: monospace; background: var(--jf-palette-background-paper); border: 1px solid var(--jf-palette-divider); padding: 4px 4px; border-radius: 3px;">';
-                        rulesHtml += SmartLists.escapeHtml(fieldName) + ' ' + SmartLists.escapeHtml(operator) + ' "' + SmartLists.escapeHtml(value) + '"' + SmartLists.escapeHtml(userInfo) + SmartLists.escapeHtml(nextUnwatchedInfo) + SmartLists.escapeHtml(collectionsInfo) + SmartLists.escapeHtml(playlistsInfo) + SmartLists.escapeHtml(tagsInfo) + SmartLists.escapeHtml(studiosInfo) + SmartLists.escapeHtml(genresInfo) + SmartLists.escapeHtml(audioLanguagesInfo) + SmartLists.escapeHtml(similarityInfo);
+                        rulesHtml += SmartLists.escapeHtml(fieldName) + ' ' + SmartLists.escapeHtml(operator) + ' "' + SmartLists.escapeHtml(value) + '"' + SmartLists.escapeHtml(userInfo) + SmartLists.escapeHtml(nextUnwatchedInfo) + SmartLists.escapeHtml(unknownDateInfo) + SmartLists.escapeHtml(collectionsInfo) + SmartLists.escapeHtml(playlistsInfo) + SmartLists.escapeHtml(tagsInfo) + SmartLists.escapeHtml(studiosInfo) + SmartLists.escapeHtml(genresInfo) + SmartLists.escapeHtml(audioLanguagesInfo) + SmartLists.escapeHtml(similarityInfo);
                         rulesHtml += '</span>';
                     }
 

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-rules.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-rules.js
@@ -1140,6 +1140,15 @@
             '<option value="false">No - Only show next episodes from started series</option>' +
             '</select>' +
             '</div>' +
+            '<div class="rule-unknowndate-options" style="display: none; margin-bottom: 0.75em; padding: 0.5em; background: var(--jf-palette-background-paper); border: 1px solid var(--jf-palette-divider); border-radius: 4px;">' +
+            '<label style="display: block; margin-bottom: 0.25em; font-size: 0.85em; opacity: 0.8; font-weight: 500;">' +
+            'When the date is unknown (missing metadata):' +
+            '</label>' +
+            '<select is="emby-select" class="emby-select rule-unknowndate-select" style="width: 100%;">' +
+            '<option value="false">Exclude items with an unknown date</option>' +
+            '<option value="true">Include items with an unknown date</option>' +
+            '</select>' +
+            '</div>' +
             '<div class="rule-collections-options" style="display: none; margin-bottom: 0.75em; padding: 0.5em; background: var(--jf-palette-background-paper); border: 1px solid var(--jf-palette-divider); border-radius: 4px;">' +
             '<div class="rule-collections-collection-only" style="margin-bottom: 0.75em;">' +
             '<label style="display: flex; align-items: center; margin-bottom: 0.25em; font-size: 0.85em; opacity: 0.8; font-weight: 500;">' +
@@ -1288,6 +1297,9 @@
         // Initialize NextUnwatched options visibility
         SmartLists.updateNextUnwatchedOptionsVisibility(newRuleRow, fieldSelect.value, page);
 
+        // Initialize unknown-date options visibility
+        SmartLists.updateUnknownDateOptionsVisibility(newRuleRow, fieldSelect.value);
+
         // Initialize Collections options visibility
         SmartLists.updateCollectionsOptionsVisibility(newRuleRow, fieldSelect.value, page);
 
@@ -1333,6 +1345,7 @@
             fieldSelect.setAttribute('data-previous-field', newField);
             SmartLists.updateUserSelectorVisibility(newRuleRow, fieldSelect.value);
             SmartLists.updateNextUnwatchedOptionsVisibility(newRuleRow, fieldSelect.value, page);
+            SmartLists.updateUnknownDateOptionsVisibility(newRuleRow, fieldSelect.value);
             SmartLists.updateCollectionsOptionsVisibility(newRuleRow, fieldSelect.value, page);
             SmartLists.updatePlaylistsOptionsVisibility(newRuleRow, fieldSelect.value, page);
             SmartLists.updateExternalListOptionsVisibility(newRuleRow, fieldSelect.value);
@@ -1516,6 +1529,10 @@
         const nextUnwatchedSelect = ruleRow.querySelector('.rule-nextunwatched-select');
         const nextUnwatchedValue = nextUnwatchedSelect ? nextUnwatchedSelect.value : '';
 
+        // Extract unknown-date options
+        const unknownDateSelect = ruleRow.querySelector('.rule-unknowndate-select');
+        const unknownDateValue = unknownDateSelect ? unknownDateSelect.value : '';
+
         // Extract Collections options
         const collectionOnlySelect = ruleRow.querySelector('.rule-collections-collection-only-select');
         const collectionOnlyValue = collectionOnlySelect ? collectionOnlySelect.value : '';
@@ -1580,6 +1597,9 @@
         }
         if (fieldValue === 'NextUnwatched' && nextUnwatchedValue === 'false') {
             expression.IncludeUnwatchedSeries = false;
+        }
+        if (SmartLists.UNKNOWN_DATE_FIELDS.indexOf(fieldValue) !== -1 && unknownDateValue === 'true') {
+            expression.IncludeUnknownDates = true;
         }
         if (fieldValue === 'Collections') {
             if (collectionOnlyValue === 'true') {
@@ -1918,6 +1938,7 @@
                     SmartLists.updateOperatorOptions(currentFieldValue, operatorSelect);
                     SmartLists.updateUserSelectorVisibility(ruleRow, currentFieldValue);
                     SmartLists.updateNextUnwatchedOptionsVisibility(ruleRow, currentFieldValue, page);
+                    SmartLists.updateUnknownDateOptionsVisibility(ruleRow, currentFieldValue);
                     SmartLists.updateCollectionsOptionsVisibility(ruleRow, currentFieldValue, page);
                     SmartLists.updatePlaylistsOptionsVisibility(ruleRow, currentFieldValue, page);
                     SmartLists.updateTagsOptionsVisibility(ruleRow, currentFieldValue, page);
@@ -1948,6 +1969,7 @@
                     fieldSelect.setAttribute('data-previous-field', newField);
                     SmartLists.updateUserSelectorVisibility(ruleRow, newField);
                     SmartLists.updateNextUnwatchedOptionsVisibility(ruleRow, fieldSelect.value, page);
+                    SmartLists.updateUnknownDateOptionsVisibility(ruleRow, fieldSelect.value);
                     SmartLists.updateCollectionsOptionsVisibility(ruleRow, fieldSelect.value, page);
                     SmartLists.updatePlaylistsOptionsVisibility(ruleRow, fieldSelect.value, page);
                     SmartLists.updateTagsOptionsVisibility(ruleRow, fieldSelect.value, page);
@@ -2143,6 +2165,7 @@
                     SmartLists.updateRegexHelp(ruleRow);
                     if (page) {
                         SmartLists.updateNextUnwatchedOptionsVisibility(ruleRow, '', page);
+                        SmartLists.updateUnknownDateOptionsVisibility(ruleRow, '');
                         SmartLists.updateCollectionsOptionsVisibility(ruleRow, '', page);
                         SmartLists.updatePlaylistsOptionsVisibility(ruleRow, '', page);
                         SmartLists.updateTagsOptionsVisibility(ruleRow, '', page);
@@ -2160,6 +2183,7 @@
                     SmartLists.updateRegexHelp(ruleRow);
                     if (page) {
                         SmartLists.updateNextUnwatchedOptionsVisibility(ruleRow, currentValue, page);
+                        SmartLists.updateUnknownDateOptionsVisibility(ruleRow, currentValue);
                         SmartLists.updateCollectionsOptionsVisibility(ruleRow, currentValue, page);
                         SmartLists.updateTagsOptionsVisibility(ruleRow, currentValue, page);
                         SmartLists.updateStudiosOptionsVisibility(ruleRow, currentValue, page);
@@ -2314,6 +2338,20 @@
     // Update visibility of NextUnwatched options for all rules when media types change
     SmartLists.updateAllNextUnwatchedOptionsVisibility = function (page) {
         SmartLists.updateAllRules(page, SmartLists.updateNextUnwatchedOptionsVisibility);
+    };
+
+    SmartLists.updateUnknownDateOptionsVisibility = function (ruleRow, fieldValue) {
+        const isUnknownDateField = SmartLists.UNKNOWN_DATE_FIELDS.indexOf(fieldValue) !== -1;
+        const unknownDateOptionsDiv = ruleRow.querySelector('.rule-unknowndate-options');
+
+        if (unknownDateOptionsDiv) {
+            if (isUnknownDateField) {
+                unknownDateOptionsDiv.style.display = 'block';
+            } else {
+                // Hide but preserve user's selection - don't reset value
+                unknownDateOptionsDiv.style.display = 'none';
+            }
+        }
     };
 
     SmartLists.updateCollectionsOptionsVisibility = function (ruleRow, fieldValue, page) {
@@ -2827,6 +2865,15 @@
                         // If true (default), don't include the parameter to save space
                     }
 
+                    // Check for unknown-date option on date fields where metadata can be missing
+                    const unknownDateSelect = rule.querySelector('.rule-unknowndate-select');
+                    if (unknownDateSelect && SmartLists.UNKNOWN_DATE_FIELDS.indexOf(memberName) !== -1) {
+                        if (unknownDateSelect.value === 'true') {
+                            expression.IncludeUnknownDates = true;
+                        }
+                        // If false (default), don't include the parameter to save space
+                    }
+
                     // Check for Collections specific options
                     if (memberName === 'Collections') {
                         // Check for collection-only option (only for Collections type)
@@ -3057,6 +3104,7 @@
                 SmartLists.refreshSearchableSelect(fieldSelect);
 
                 SmartLists.updateNextUnwatchedOptionsVisibility(ruleRow, actualMemberName, page);
+                SmartLists.updateUnknownDateOptionsVisibility(ruleRow, actualMemberName);
                 SmartLists.updateCollectionsOptionsVisibility(ruleRow, actualMemberName, page);
                 SmartLists.updatePlaylistsOptionsVisibility(ruleRow, actualMemberName, page);
                 SmartLists.updateExternalListOptionsVisibility(ruleRow, actualMemberName);
@@ -3105,6 +3153,12 @@
                 if (nextUnwatchedSelect) {
                     const includeValue = expression.IncludeUnwatchedSeries !== false ? 'true' : 'false';
                     nextUnwatchedSelect.value = includeValue;
+                }
+            }
+            if (SmartLists.UNKNOWN_DATE_FIELDS.indexOf(expression.MemberName) !== -1) {
+                const unknownDateSelect = ruleRow.querySelector('.rule-unknowndate-select');
+                if (unknownDateSelect) {
+                    unknownDateSelect.value = expression.IncludeUnknownDates === true ? 'true' : 'false';
                 }
             }
             if (expression.MemberName === 'Collections') {

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
@@ -828,6 +828,28 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                 return System.Linq.Expressions.Expression.AndAlso(neverPlayedCheck, mainExpression);
             }
 
+            // ReleaseDate/LastEpisodeAirDate can be missing from metadata (stored as 0). Handle the
+            // sentinel explicitly in both directions, mirroring the LastPlayedDate pattern above:
+            // without it, operators like Before/OlderThan/NotEqual would silently match epoch 0.
+            if (r.MemberName == "ReleaseDate" || r.MemberName == "LastEpisodeAirDate")
+            {
+                var zero = System.Linq.Expressions.Expression.Constant(0.0);
+                var mainExpression = BuildStandardDateExpression(r, left, logger);
+
+                if (r.IncludeUnknownDates == true)
+                {
+                    // Combine: (date == 0) OR (main date condition)
+                    return System.Linq.Expressions.Expression.OrElse(
+                        System.Linq.Expressions.Expression.Equal(left, zero),
+                        mainExpression);
+                }
+
+                // Combine: (date != 0) AND (main date condition)
+                return System.Linq.Expressions.Expression.AndAlso(
+                    System.Linq.Expressions.Expression.NotEqual(left, zero),
+                    mainExpression);
+            }
+
             return BuildStandardDateExpression(r, left, logger);
         }
 

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Expression.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Expression.cs
@@ -72,6 +72,10 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? RuntimeUnit { get; set; } = null;
 
+        // Date-field option (ReleaseDate, LastEpisodeAirDate): treat items with no known date as matching - only serialize when meaningful
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? IncludeUnknownDates { get; set; } = null;
+
         // Collections-specific depth option - only serialize when meaningful
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public int? CollectionSearchDepth { get; set; } = null;

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -505,6 +505,8 @@ namespace Jellyfin.Plugin.SmartLists.Core
                         hashBuilder.Append(expr.IncludeUnwatchedSeries?.ToString() ?? "null");
                         hashBuilder.Append(':');
                         hashBuilder.Append(expr.IncludeEpisodesWithinSeries?.ToString() ?? "null");
+                        hashBuilder.Append(':');
+                        hashBuilder.Append(expr.IncludeUnknownDates?.ToString() ?? "null");
                     }
                 }
 

--- a/docs/content/examples/advanced-examples.md
+++ b/docs/content/examples/advanced-examples.md
@@ -23,6 +23,10 @@ Here are some more complex playlist and collection examples:
 ## Weekend Binge Queue
 - **Next Unwatched** = True (excluding unwatched series) for started shows only
 
+## Fresh Episodes (metadata may lag)
+- **Release Date** newer than 2 weeks (including items with an unknown date)
+- Catches brand-new episodes even when they're downloaded before the release date metadata is published; once metadata arrives, the rule re-evaluates normally on the next refresh
+
 ## Kids' Shows Progress
 - **Next Unwatched** = True AND **Tags** contain "Kids" (with parent series tags enabled)
 

--- a/docs/content/user-guide/fields-and-operators.md
+++ b/docs/content/user-guide/fields-and-operators.md
@@ -25,6 +25,14 @@ Fields are organized into categories that match the dropdown menu in the UI. Som
 | **TMDb ID** | TheMovieDb identifier (e.g., `875828`). Use **is in** with semicolons to match multiple IDs. |
 | **TVDb ID** | TheTVDB identifier. Use **is in** with semicolons to match multiple IDs. |
 
+#### Release Date / Last Episode Air Date
+
+These dates come from metadata providers and can be missing — for example, an episode downloaded before its metadata is published. By default, items with an unknown date never match a date rule.
+
+**Options:**
+
+- **When the date is unknown** (default: Exclude) - Choose **Include items with an unknown date** to also match items whose date is missing. Useful for "new releases" lists so freshly added episodes appear even before their release date metadata arrives; once the metadata is filled in, the next refresh re-evaluates the rule normally.
+
 #### Similar To
 
 Find items similar to a reference item based on metadata.


### PR DESCRIPTION
## What
Adds a per-rule "When the date is unknown" option to **Release Date** and **Last Episode Air Date** rules, and makes the default behavior consistent: items with no known date are excluded from date rules on these fields for every operator unless the new option is enabled.

## Why
Fixes #476 — episodes are sometimes downloaded before metadata providers publish the release date, so "newer than" playlists silently missed exactly the fresh episodes they exist for. The missing date is stored as epoch 0 internally, which also meant "older than"/"before"/"not equals" rules silently matched unknown-date items as 1970 releases.

## Changes
- `Expression.cs`: new nullable `IncludeUnknownDates` option, serialized only when set (same pattern as `IncludeUnwatchedSeries` etc.)
- `Engine.cs`: date rules on ReleaseDate/LastEpisodeAirDate now wrap the standard expression with the epoch-0 sentinel handled explicitly in both directions, mirroring the existing `LastPlayedDate != -1` guard — `(date != 0) AND (rule)` by default, `(date == 0) OR (rule)` when the option is on
- `SmartList.cs`: option included in the rule-set hash so toggling it invalidates the rule cache
- `config-rules.js`: option select in the rule row (shown only for the two fields), wired through save, clone, and edit-restore paths
- `config-lists.js`: list cards show "(including unknown dates)" on rules with the option
- `config-core.js`: `UNKNOWN_DATE_FIELDS` constant
- Docs: option reference in fields-and-operators, example in advanced examples

### Behavior change (deliberate)
Unknown-date items no longer match `before` / `older than` / `not equals` / `weekday` rules by default — previously they matched because the epoch-0 sentinel looked like a 1970 release. Lists that should keep matching them can enable the new option.

Verified end-to-end against the dev container: engine matrix (NewerThan/OlderThan × option on/off → 0/1/64/65 items as expected with one null-date movie in a 65-movie library), UI show/hide + save/clone/edit round-trip via browser automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjXfWuB2junrenas4pzuDG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Date-based rules can now include items with unknown release or air dates.
  * The setting is available for Release Date and Last Episode Air Date fields.
  * Rule summaries indicate when unknown dates are included.

* **Bug Fixes**
  * Improved date filtering behavior for items missing date metadata.

* **Documentation**
  * Added guidance and an advanced example for using unknown-date options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->