### PR TITLE
fix: stop per-group limits from dropping include-only collections/playlists

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -905,6 +905,26 @@ namespace Jellyfin.Plugin.SmartLists.Core
                     // Still need to apply sorting and limits to the collection/playlist results
                     try
                     {
+                        // Apply per-group limits and wire Rule Block Order group mappings - the
+                        // include-only matchers record _itemGroupMappings, so these work here too
+                        if (HasPerGroupLimits())
+                        {
+                            results = ApplyPerGroupLimits(results, user, userDataManager, logger, refreshCache);
+                            logger?.LogDebug("Include-only results limited to {Count} items after per-group MaxItems applied", results.Count);
+                        }
+
+                        foreach (var order in Orders)
+                        {
+                            if (order is Orders.RuleBlockOrder ruleBlockOrder)
+                            {
+                                ruleBlockOrder.GroupMappings = _itemGroupMappings;
+                            }
+                            else if (order is Orders.RuleBlockOrderDesc ruleBlockOrderDesc)
+                            {
+                                ruleBlockOrderDesc.GroupMappings = _itemGroupMappings;
+                            }
+                        }
+
                         // Pre-compute Round Robin positions before sorting
                         PrepareRoundRobinPositions(results, logger);
 
@@ -1555,6 +1575,9 @@ namespace Jellyfin.Plugin.SmartLists.Core
         /// </summary>
         private sealed class IncludeOnlyRuleSet
         {
+            /// <summary>Index of the originating ExpressionSet (for group tracking: per-group limits, Rule Block Order).</summary>
+            public int SetIndex { get; set; }
+
             /// <summary>Include-only rules, matched against the collection/playlist name.</summary>
             public List<Expression> NameRules { get; } = [];
 
@@ -1586,13 +1609,13 @@ namespace Jellyfin.Plugin.SmartLists.Core
             bool isCollections = fieldName == "Collections";
             var defaultUserId = user.Id.ToString("N");
 
-            foreach (var set in ExpressionSets)
+            for (int setIndex = 0; setIndex < ExpressionSets.Count; setIndex++)
             {
-                var expressions = set?.Expressions;
+                var expressions = ExpressionSets[setIndex]?.Expressions;
                 if (expressions == null)
                     continue;
 
-                var ruleSet = new IncludeOnlyRuleSet();
+                var ruleSet = new IncludeOnlyRuleSet { SetIndex = setIndex };
 
                 foreach (var expr in expressions)
                 {
@@ -1698,20 +1721,23 @@ namespace Jellyfin.Plugin.SmartLists.Core
         }
 
         /// <summary>
-        /// Checks whether a collection/playlist satisfies at least one include-only rule group.
+        /// Returns the indices of every include-only rule group the collection/playlist satisfies.
         /// A group matches when ALL its include-only rules match the item's name AND all its
         /// sibling rules match the item itself (AND logic within groups, OR across groups).
+        /// The indices feed _itemGroupMappings so per-group limits and Rule Block Order
+        /// treat matched collections/playlists like any other matched item.
         /// </summary>
         /// <param name="names">The item's name (single-element list)</param>
         /// <param name="ruleSets">Prepared include-only rule groups</param>
         /// <param name="nameMatcher">Field-specific name matcher (collection or playlist rules)</param>
         /// <param name="operandProvider">Lazily builds the operand for sibling-rule evaluation; may return null on failure</param>
-        private static bool MatchesIncludeOnlyRuleSets(
+        private static List<int> GetMatchingIncludeOnlySetIndices(
             List<string> names,
             List<IncludeOnlyRuleSet> ruleSets,
             Func<List<string>, Expression, bool> nameMatcher,
             Func<Operand?> operandProvider)
         {
+            var matchedIndices = new List<int>();
             Operand? operand = null;
             bool operandLoaded = false;
 
@@ -1723,36 +1749,52 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 if (!ruleSet.NameRules.All(rule => nameMatcher(names, rule)))
                     continue;
 
-                if (ruleSet.SiblingRules.Count == 0)
-                    return true;
-
-                if (!operandLoaded)
+                if (ruleSet.SiblingRules.Count > 0)
                 {
-                    operand = operandProvider();
-                    operandLoaded = true;
+                    if (!operandLoaded)
+                    {
+                        operand = operandProvider();
+                        operandLoaded = true;
+                    }
+
+                    if (operand == null)
+                        continue; // Extraction failed - conservatively treat sibling rules as not matching
+
+                    bool allSiblingsMatch = ruleSet.SiblingRules.All(rule =>
+                    {
+                        try
+                        {
+                            return rule(operand);
+                        }
+                        catch (Exception)
+                        {
+                            // Conservative approach: assume rule doesn't match if it fails
+                            return false;
+                        }
+                    });
+
+                    if (!allSiblingsMatch)
+                        continue;
                 }
 
-                if (operand == null)
-                    continue; // Extraction failed - conservatively treat sibling rules as not matching
-
-                bool allSiblingsMatch = ruleSet.SiblingRules.All(rule =>
-                {
-                    try
-                    {
-                        return rule(operand);
-                    }
-                    catch (Exception)
-                    {
-                        // Conservative approach: assume rule doesn't match if it fails
-                        return false;
-                    }
-                });
-
-                if (allSiblingsMatch)
-                    return true;
+                matchedIndices.Add(ruleSet.SetIndex);
             }
 
-            return false;
+            return matchedIndices;
+        }
+
+        /// <summary>
+        /// Records which rule groups a matched collection/playlist belongs to, so
+        /// ApplyPerGroupLimits doesn't silently drop it and Rule Block Order places it
+        /// in its group's block. Merges with any existing mapping (an item can be both
+        /// a direct match and a nested child of another matched collection).
+        /// </summary>
+        private void TrackIncludeOnlyGroupMapping(Guid itemId, List<int> matchedSetIndices)
+        {
+            _itemGroupMappings.AddOrUpdate(
+                itemId,
+                _ => new List<int>(matchedSetIndices),
+                (_, existing) => existing.Union(matchedSetIndices).ToList());
         }
 
         /// <summary>
@@ -1855,6 +1897,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 // (name rules + sibling rules) must match for a collection to be included
                 var includeOnlyRuleSets = BuildIncludeOnlyRuleSets("Collections", user, logger);
                 var extractionOptions = BuildIncludeOnlyExtractionOptions(includeOnlyRuleSets);
+                bool trackGroups = NeedsGroupTracking();
 
                 // Check each collection against the collection-only rule groups
                 foreach (var collection in allCollections)
@@ -1872,7 +1915,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                     // The whole rule group must match: name rules against the collection name,
                     // sibling rules against the collection's own metadata
                     var collectionNames = new List<string> { collection.Name };
-                    if (MatchesIncludeOnlyRuleSets(collectionNames, includeOnlyRuleSets, DoesCollectionMatchRule, () =>
+                    var matchedSetIndices = GetMatchingIncludeOnlySetIndices(collectionNames, includeOnlyRuleSets, DoesCollectionMatchRule, () =>
                         {
                             try
                             {
@@ -1883,8 +1926,10 @@ namespace Jellyfin.Plugin.SmartLists.Core
                                 logger?.LogWarning(ex, "Error extracting fields from collection '{CollectionName}' for include-only rule matching", collection.Name);
                                 return null;
                             }
-                        }))
+                        });
+                    if (matchedSetIndices.Count > 0)
                     {
+                        var firstNewIndex = matchingCollections.Count;
                         // Add this collection and recursively add nested collections
                         AddCollectionWithNestedCollections(
                             collection,
@@ -1896,6 +1941,20 @@ namespace Jellyfin.Plugin.SmartLists.Core
                             0,  // Start at depth 0 (root level)
                             maxRecursionDepth,
                             currentListBaseName);
+
+                        if (trackGroups)
+                        {
+                            // Map the matched collection and its nested children to the matched
+                            // groups so per-group limits and Rule Block Order see them.
+                            // The root is mapped explicitly: if it was already added as another
+                            // root's nested child, the visited guard appends nothing new and the
+                            // slice below would miss its direct match.
+                            TrackIncludeOnlyGroupMapping(collection.Id, matchedSetIndices);
+                            for (int i = firstNewIndex; i < matchingCollections.Count; i++)
+                            {
+                                TrackIncludeOnlyGroupMapping(matchingCollections[i].Id, matchedSetIndices);
+                            }
+                        }
                     }
                 }
 
@@ -2138,6 +2197,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 // (name rules + sibling rules) must match for a playlist to be included
                 var includeOnlyRuleSets = BuildIncludeOnlyRuleSets("Playlists", user, logger);
                 var extractionOptions = BuildIncludeOnlyExtractionOptions(includeOnlyRuleSets);
+                bool trackGroups = NeedsGroupTracking();
 
                 // Check each playlist against the playlist-only rule groups
                 foreach (var playlist in allPlaylists)
@@ -2155,7 +2215,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                     // The whole rule group must match: name rules against the playlist name,
                     // sibling rules against the playlist's own metadata
                     var playlistNames = new List<string> { playlist.Name };
-                    if (MatchesIncludeOnlyRuleSets(playlistNames, includeOnlyRuleSets, DoesPlaylistMatchRule, () =>
+                    var matchedSetIndices = GetMatchingIncludeOnlySetIndices(playlistNames, includeOnlyRuleSets, DoesPlaylistMatchRule, () =>
                         {
                             try
                             {
@@ -2166,9 +2226,14 @@ namespace Jellyfin.Plugin.SmartLists.Core
                                 logger?.LogWarning(ex, "Error extracting fields from playlist '{PlaylistName}' for include-only rule matching", playlist.Name);
                                 return null;
                             }
-                        }))
+                        });
+                    if (matchedSetIndices.Count > 0)
                     {
                         matchingPlaylists.Add(playlist);
+                        if (trackGroups)
+                        {
+                            TrackIncludeOnlyGroupMapping(playlist.Id, matchedSetIndices);
+                        }
                         logger?.LogDebug("Playlist '{PlaylistName}' matches a playlist-only rule group", playlist.Name);
                     }
                 }

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -1929,7 +1929,11 @@ namespace Jellyfin.Plugin.SmartLists.Core
                         });
                     if (matchedSetIndices.Count > 0)
                     {
-                        var firstNewIndex = matchingCollections.Count;
+                        // When tracking groups, collect every collection this root's walk reaches -
+                        // including ones already appended by an earlier root - so shared descendants
+                        // get mapped to every matching group, not just the first
+                        var encounteredIds = trackGroups ? new HashSet<Guid>() : null;
+
                         // Add this collection and recursively add nested collections
                         AddCollectionWithNestedCollections(
                             collection,
@@ -1940,19 +1944,16 @@ namespace Jellyfin.Plugin.SmartLists.Core
                             logger,
                             0,  // Start at depth 0 (root level)
                             maxRecursionDepth,
-                            currentListBaseName);
+                            currentListBaseName,
+                            encounteredIds);
 
-                        if (trackGroups)
+                        if (encounteredIds != null)
                         {
                             // Map the matched collection and its nested children to the matched
-                            // groups so per-group limits and Rule Block Order see them.
-                            // The root is mapped explicitly: if it was already added as another
-                            // root's nested child, the visited guard appends nothing new and the
-                            // slice below would miss its direct match.
-                            TrackIncludeOnlyGroupMapping(collection.Id, matchedSetIndices);
-                            for (int i = firstNewIndex; i < matchingCollections.Count; i++)
+                            // groups so per-group limits and Rule Block Order see them
+                            foreach (var encounteredId in encounteredIds)
                             {
-                                TrackIncludeOnlyGroupMapping(matchingCollections[i].Id, matchedSetIndices);
+                                TrackIncludeOnlyGroupMapping(encounteredId, matchedSetIndices);
                             }
                         }
                     }
@@ -1971,6 +1972,11 @@ namespace Jellyfin.Plugin.SmartLists.Core
 
         /// <summary>
         /// Recursively adds a collection and its nested collections up to the specified depth.
+        /// When <paramref name="encounteredIds"/> is provided, every collection reached by this
+        /// walk is recorded in it - including collections already appended by an earlier root -
+        /// so group tracking can map shared descendants to every matching group. The walk then
+        /// continues through already-visited nodes (guarded per-call against cycles) while
+        /// <paramref name="visitedCollectionIds"/> still deduplicates the appended results.
         /// </summary>
         private static void AddCollectionWithNestedCollections(
             BaseItem collection,
@@ -1981,19 +1987,31 @@ namespace Jellyfin.Plugin.SmartLists.Core
             ILogger? logger,
             int currentDepth,
             int maxDepth,
-            string currentListBaseName)
+            string currentListBaseName,
+            HashSet<Guid>? encounteredIds = null)
         {
-            // Circular reference protection
-            if (visitedCollectionIds.Contains(collection.Id))
-            {
-                logger?.LogDebug("Skipping collection '{CollectionName}' - already visited (preventing circular reference)", collection.Name);
-                return;
-            }
-            visitedCollectionIds.Add(collection.Id);
+            bool alreadyAdded = visitedCollectionIds.Contains(collection.Id);
 
-            // Add this collection
-            matchingCollections.Add(collection);
-            logger?.LogDebug("Collection '{CollectionName}' matches Collections rules with IncludeCollectionOnly=true (depth={Depth})", collection.Name, currentDepth);
+            if (encounteredIds == null)
+            {
+                // No group tracking: already-visited nodes need no re-walk
+                if (alreadyAdded)
+                {
+                    logger?.LogDebug("Skipping collection '{CollectionName}' - already visited (preventing circular reference)", collection.Name);
+                    return;
+                }
+            }
+            else if (!encounteredIds.Add(collection.Id))
+            {
+                return; // Circular reference protection within this root's walk
+            }
+
+            if (!alreadyAdded)
+            {
+                visitedCollectionIds.Add(collection.Id);
+                matchingCollections.Add(collection);
+                logger?.LogDebug("Collection '{CollectionName}' matches Collections rules with IncludeCollectionOnly=true (depth={Depth})", collection.Name, currentDepth);
+            }
 
             // If we haven't reached max depth, look for nested collections
             if (currentDepth < maxDepth)
@@ -2020,7 +2038,8 @@ namespace Jellyfin.Plugin.SmartLists.Core
                             logger,
                             currentDepth + 1,
                             maxDepth,
-                            currentListBaseName);
+                            currentListBaseName,
+                            encounteredIds);
                     }
                 }
             }

--- a/docs/content/user-guide/sorting-and-limits.md
+++ b/docs/content/user-guide/sorting-and-limits.md
@@ -390,6 +390,9 @@ When using multiple OR blocks, you can set a **Max Items limit for each individu
 !!! tip "Combining with Global Limits"
     Per-group limits are applied first, then the global Max Items limit. Example: 3 blocks × 50 items each = 150 total, then global limit of 100 = final result of 100 items.
 
+!!! note "Collection-only / playlist-only groups"
+    OR blocks using "collection only" or "playlist only" mode participate like any other block: their matched collections/playlists count toward that block's own limit and are unaffected by limits set on other blocks.
+
 !!! info "See Examples"
     For detailed examples using per-group limits, see [Common Use Cases](../examples/common-use-cases.md#balanced-mix-with-per-group-limits) and [Advanced Examples](../examples/advanced-examples.md#advanced-per-group-limit-techniques).
 


### PR DESCRIPTION
Follow-up to #481. Fixes the pre-existing limitation documented in that PR: combining an include-only rule group ("collection only" / "playlist only") with per-group Max Items silently dropped every matched collection/playlist.

## Problem

`ApplyPerGroupLimits` (active when **any** OR block has a Max Items value) rebuilds the entire result list by bucketing items through `_itemGroupMappings`. That mapping was only populated by the media-item pipeline — collections/playlists matched by include-only groups never entered it, so a single per-group limit on an unrelated block removed all of them from the result. `RuleBlockOrder.GetSortKey` also returns `int.MinValue` for unmapped items, so with Rule Block Order the containers sorted at the wrong end instead of in their group's block.

Reproduced live: group 1 `[Collections contains "Test Collection" (collection only)]` + group 2 `[Studios contains "Bruckheimer", Max Items: 1]` → result contained only one movie; the matched collection vanished despite its group having no limit.

## Fix

- `BuildIncludeOnlyRuleSets` records each group's original `ExpressionSets` index (`SetIndex`).
- The include-only matcher now returns **all** matched group indices (`GetMatchingIncludeOnlySetIndices`) instead of a first-match boolean.
- When group tracking is needed (per-group limits or Rule Block Order), matched collections/playlists are recorded in `_itemGroupMappings`. Nested collections inherit the root's groups; a collection that is both a direct match and another root's nested child gets both mappings merged.
- The all-include-only fast path now applies per-group limits and wires Rule Block Order group mappings, matching mixed-list behavior (previously per-group limits were silently ignored there).

Net effect: matched containers survive limits on other groups, per-group Max Items on an include-only block now actually limits its containers, and Rule Block Order places containers in the correct block.

## Verification

E2E against the dev container (both ABIs compile clean, warnings-as-errors), with "Alpha Test Collection" (Harry Potter/Warner Bros.) and "Beta Test Collection" (Pirates/Bruckheimer):

| Rules | Result |
|---|---|
| Group 1: collection-only "Test Collection" · Group 2: Studios Bruckheimer, Max Items 1 | Both collections + 1 movie ✅ (previously: 1 movie, collections dropped) |
| Group 1: collection-only "Test Collection", Max Items 1 · Group 2: Studios Bruckheimer | 1 collection + all 5 movies ✅ (limit now applies to the include-only block) |
| Single group: collection-only "Test Collection", Max Items 1 (all-include-only path) | 1 collection ✅ (previously: limit ignored, 2 collections) |
| #479 regression — collection-only AND Studios Bruckheimer, no limits | Only Beta Test Collection ✅ |

Also verified through the admin config UI with Playwright (two OR blocks, per-group Max Items field): saved DTO correct, result kept both collections + 1 movie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAEYxy7ZxBjtSvAhoeGuLX