### PR TITLE
feat: add default media types setting for new smart lists

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.SmartLists/Configuration/PluginConfiguration.cs
@@ -25,6 +25,12 @@ namespace Jellyfin.Plugin.SmartLists.Configuration
         public SmartListType DefaultListType { get; set; } = SmartListType.Playlist;
 
         /// <summary>
+        /// Gets or sets the default media types pre-selected for new lists.
+        /// Null or empty means no media types are pre-selected.
+        /// </summary>
+        public List<string>? DefaultMediaTypes { get; set; } = null;
+
+        /// <summary>
         /// Gets or sets whether new playlists should be public by default.
         /// </summary>
         public bool DefaultMakePublic { get; set; } = false;

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
@@ -223,6 +223,28 @@
             SmartLists.populateSelect(defaultSortOrderSetting, SORT_ORDER_OPTIONS_LEGACY, 'Ascending');
         }
 
+        // Populate the Default Media Types multi-select (Settings tab, admin page only)
+        const defaultMediaTypesContainer = page.querySelector('#defaultMediaTypesMultiSelect');
+        if (defaultMediaTypesContainer) {
+            SmartLists.initializeMultiSelect(page, {
+                containerId: 'defaultMediaTypesMultiSelect',
+                displayId: 'defaultMediaTypesMultiSelectDisplay',
+                dropdownId: 'defaultMediaTypesMultiSelectDropdown',
+                optionsId: 'defaultMediaTypesMultiSelectOptions',
+                placeholderText: 'None (default)',
+                checkboxClass: 'default-media-types-checkbox',
+                onChange: null
+            });
+            SmartLists.loadItemsIntoMultiSelect(
+                page,
+                'defaultMediaTypesMultiSelect',
+                SmartLists.mediaTypes,
+                'default-media-types-checkbox',
+                function (item) { return item.Label; },
+                function (item) { return item.Value; }
+            );
+        }
+
         // Add event listener to show/hide ignore articles checkbox based on sort selection
         if (defaultSortBySetting && defaultIgnoreArticlesContainer) {
             defaultSortBySetting.addEventListener('change', function () {
@@ -292,6 +314,52 @@
         }
     };
 
+    // ===== MEDIA TYPE DEPENDENT UI UPDATES =====
+    // Batch update function for all media type changes
+    // Order matters: repopulate fields first (may invalidate), then sync dependent UI
+    SmartLists.applyMediaTypeDependentUpdates = function (page) {
+        // 1) Re-populate fields (may invalidate current selections)
+        if (SmartLists.updateAllFieldSelects) {
+            SmartLists.updateAllFieldSelects(page);
+        }
+
+        // 2) Re-sync dependent UI for all rules
+        if (SmartLists.updateAllUserSelectorVisibility) {
+            SmartLists.updateAllUserSelectorVisibility(page);
+        }
+        if (SmartLists.updateAllNextUnwatchedOptionsVisibility) {
+            SmartLists.updateAllNextUnwatchedOptionsVisibility(page);
+        }
+        if (SmartLists.updateAllCollectionsOptionsVisibility) {
+            SmartLists.updateAllCollectionsOptionsVisibility(page);
+        }
+        if (SmartLists.updateAllTagsOptionsVisibility) {
+            SmartLists.updateAllTagsOptionsVisibility(page);
+        }
+        if (SmartLists.updateAllStudiosOptionsVisibility) {
+            SmartLists.updateAllStudiosOptionsVisibility(page);
+        }
+        if (SmartLists.updateAllGenresOptionsVisibility) {
+            SmartLists.updateAllGenresOptionsVisibility(page);
+        }
+        if (SmartLists.updateAllAudioLanguagesOptionsVisibility) {
+            SmartLists.updateAllAudioLanguagesOptionsVisibility(page);
+        }
+
+        // 3) Update sort options visibility based on media types
+        if (SmartLists.updateAllSortOptionsVisibility) {
+            SmartLists.updateAllSortOptionsVisibility(page);
+        }
+        if (SmartLists.syncRandomGroupSelectionUI) {
+            SmartLists.syncRandomGroupSelectionUI(page);
+        }
+
+        // 4) Update Include Extras checkbox visibility based on media types
+        if (SmartLists.updateIncludeExtrasVisibility) {
+            SmartLists.updateIncludeExtrasVisibility(page);
+        }
+    };
+
     // ===== MEDIA TYPE CHECKBOXES GENERATION =====
     SmartLists.generateMediaTypeCheckboxes = function (page) {
         const container = page.querySelector('#mediaTypesMultiSelect');
@@ -305,51 +373,6 @@
             page._mediaTypeAbortController.abort();
         }
         page._mediaTypeAbortController = SmartLists.createAbortController();
-
-        // Batch update function for all media type changes
-        // Order matters: repopulate fields first (may invalidate), then sync dependent UI
-        const batchUpdateMediaTypeChanges = function () {
-            // 1) Re-populate fields (may invalidate current selections)
-            if (SmartLists.updateAllFieldSelects) {
-                SmartLists.updateAllFieldSelects(page);
-            }
-
-            // 2) Re-sync dependent UI for all rules
-            if (SmartLists.updateAllUserSelectorVisibility) {
-                SmartLists.updateAllUserSelectorVisibility(page);
-            }
-            if (SmartLists.updateAllNextUnwatchedOptionsVisibility) {
-                SmartLists.updateAllNextUnwatchedOptionsVisibility(page);
-            }
-            if (SmartLists.updateAllCollectionsOptionsVisibility) {
-                SmartLists.updateAllCollectionsOptionsVisibility(page);
-            }
-            if (SmartLists.updateAllTagsOptionsVisibility) {
-                SmartLists.updateAllTagsOptionsVisibility(page);
-            }
-            if (SmartLists.updateAllStudiosOptionsVisibility) {
-                SmartLists.updateAllStudiosOptionsVisibility(page);
-            }
-            if (SmartLists.updateAllGenresOptionsVisibility) {
-                SmartLists.updateAllGenresOptionsVisibility(page);
-            }
-            if (SmartLists.updateAllAudioLanguagesOptionsVisibility) {
-                SmartLists.updateAllAudioLanguagesOptionsVisibility(page);
-            }
-
-            // 3) Update sort options visibility based on media types
-            if (SmartLists.updateAllSortOptionsVisibility) {
-                SmartLists.updateAllSortOptionsVisibility(page);
-            }
-            if (SmartLists.syncRandomGroupSelectionUI) {
-                SmartLists.syncRandomGroupSelectionUI(page);
-            }
-
-            // 4) Update Include Extras checkbox visibility based on media types
-            if (SmartLists.updateIncludeExtrasVisibility) {
-                SmartLists.updateIncludeExtrasVisibility(page);
-            }
-        };
 
         // Generate media types array filtered by list type
         if (!SmartLists.mediaTypes || !Array.isArray(SmartLists.mediaTypes)) {
@@ -388,7 +411,7 @@
 
                 // Schedule batched update after debounce delay
                 page._mediaTypeUpdateTimer = setTimeout(function () {
-                    batchUpdateMediaTypeChanges();
+                    SmartLists.applyMediaTypeDependentUpdates(page);
                     page._mediaTypeUpdateTimer = null;
                 }, SmartLists.MEDIA_TYPE_UPDATE_DEBOUNCE_MS || 200);
             }
@@ -419,6 +442,15 @@
         // Set default list type
         SmartLists.setElementValue(page, '#listType', config.DefaultListType || 'Playlist');
         SmartLists.handleListTypeChange(page);
+
+        // Pre-select default media types. Collection-only types are skipped
+        // automatically for playlists - their checkboxes don't exist after
+        // handleListTypeChange regenerated the multi-select for the list type.
+        if (config.DefaultMediaTypes && Array.isArray(config.DefaultMediaTypes) && config.DefaultMediaTypes.length > 0) {
+            SmartLists.setSelectedItems(page, 'mediaTypesMultiSelect', config.DefaultMediaTypes, 'media-type-multi-select-checkbox', 'Select media types...');
+            // setSelectedItems doesn't fire change handlers - re-sync dependent UI explicitly
+            SmartLists.applyMediaTypeDependentUpdates(page);
+        }
 
         // Set default values for Max Items and Max Playtime
         const defaultMaxItems = config.DefaultMaxItems !== undefined && config.DefaultMaxItems !== null ? config.DefaultMaxItems : 500;
@@ -1924,6 +1956,12 @@
             }
 
             if (defaultListTypeEl) defaultListTypeEl.value = config.DefaultListType || 'Playlist';
+
+            // Options are populated synchronously in populateStaticSelects before this async load resolves
+            if (SmartLists.setSelectedItems) {
+                SmartLists.setSelectedItems(page, 'defaultMediaTypesMultiSelect', config.DefaultMediaTypes || [], 'default-media-types-checkbox', 'None (default)');
+            }
+
             if (defaultMakePublicEl) defaultMakePublicEl.checked = config.DefaultMakePublic || false;
 
             if (defaultHideWhenEmptyEl) defaultHideWhenEmptyEl.checked = SmartLists.getDefaultHideWhenEmpty(config);
@@ -2059,6 +2097,10 @@
             config.DefaultSortBy = sortBy;
             config.DefaultSortOrder = page.querySelector('#defaultSortOrder').value;
             config.DefaultListType = page.querySelector('#defaultListType').value;
+
+            const defaultMediaTypes = SmartLists.getSelectedItems ? SmartLists.getSelectedItems(page, 'defaultMediaTypesMultiSelect', 'default-media-types-checkbox') : [];
+            config.DefaultMediaTypes = defaultMediaTypes && defaultMediaTypes.length > 0 ? defaultMediaTypes : null;
+
             config.DefaultMakePublic = page.querySelector('#defaultMakePublic').checked;
             config.DefaultHideWhenEmpty = SmartLists.getElementChecked(page, '#defaultHideWhenEmpty', SmartLists.getDefaultHideWhenEmpty(config));
             config.ShowSmartListBadge = page.querySelector('#showSmartListBadge').checked;

--- a/Jellyfin.Plugin.SmartLists/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config.html
@@ -613,6 +613,25 @@
                         </div>
 
                         <div class="inputContainer" style="margin-bottom: 1em; margin-top: 1em;">
+                            <label class="inputLabel" for="defaultMediaTypesMultiSelect">Default Media Types</label>
+                            <div id="defaultMediaTypesMultiSelect">
+                                <div class="multi-select-container">
+                                    <div class="multi-select-display emby-select-withcolor" id="defaultMediaTypesMultiSelectDisplay">
+                                        <span class="multi-select-placeholder">None (default)</span>
+                                    </div>
+                                    <div class="multi-select-dropdown" id="defaultMediaTypesMultiSelectDropdown" style="display: none;">
+                                        <div class="multi-select-options" id="defaultMediaTypesMultiSelectOptions">
+                                            <!-- Checkboxes populated dynamically -->
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="fieldDescription">Media types pre-selected when creating a new smart list.
+                                Types only available for collections (Series, Season, Album) are skipped when the new
+                                list is a playlist.</div>
+                        </div>
+
+                        <div class="inputContainer" style="margin-bottom: 1em; margin-top: 1em;">
                             <label class="inputLabel" for="defaultSortBy">Default Sort By</label>
                             <select is="emby-select" id="defaultSortBy" class="emby-select"></select>
                             <div class="fieldDescription">Default sorting method for new smart lists.</div>

--- a/docs/content/user-guide/configuration.md
+++ b/docs/content/user-guide/configuration.md
@@ -269,6 +269,7 @@ Monitor refresh operations and view statistics:
 Configure global settings for the plugin:
 
 - Set the default sort order for new lists
+- Set the default media types pre-selected for new lists (types only available for collections are skipped when creating a playlist)
 - Set the default max items and max playtime for new lists
 - Set whether new lists hide when empty by default
 - Configure custom prefix and suffix for list names

--- a/docs/content/user-guide/media-types.md
+++ b/docs/content/user-guide/media-types.md
@@ -2,6 +2,9 @@
 
 When creating a smart list, you must select at least one **Media Type** to specify what kind of content should be included. Media types in SmartLists correspond directly to the **Content type** options you see when adding a new Media Library in Jellyfin.
 
+!!! tip "Default Media Types"
+    If you usually create lists with the same media types, admins can set **Default Media Types** in the Settings tab of the admin configuration page. New lists created there will start with those types pre-selected (types only available for collections are skipped when the new list is a playlist).
+
 ## Available Media Types
 
 | Media Type | Jellyfin Library | Description |


### PR DESCRIPTION
Closes #480

## What

Adds a **Default Media Types** setting to the admin Settings tab (under Default Settings, next to Default List Type). The selected media types are pre-selected whenever a new smart list is created — on the create tab and after Clear Form — so admins who always build lists for the same media types no longer have to pick them every time.

## How it works

- New `DefaultMediaTypes` (`List<string>?`) property on `PluginConfiguration`, following the existing `Default*` settings pattern. `null`/empty means no pre-selection (current behavior), so existing installs are unaffected.
- The Settings tab gets a multi-select mirroring the create form's media types control, reusing the existing multi-select component (same pattern as the Allowed Users setting).
- Defaults are applied in `applyFormDefaults` right after the default list type is set. Collection-only types (Series, Season, Album) in the default are skipped automatically when the new list is a playlist, because their checkboxes don't exist after the multi-select is regenerated for that list type.
- The media-type-dependent UI refresh (field selects, per-rule option visibility, sort options, Include Extras) was extracted from `generateMediaTypeCheckboxes` into a shared `SmartLists.applyMediaTypeDependentUpdates` so applying the default re-syncs everything without duplicating that logic — programmatic selection doesn't fire the checkbox change handlers.

## Notes

- Like the other default settings (sort, max items, etc.), this applies to the admin configuration page. The user page can't read the plugin configuration (admin-only endpoint) and keeps its current behavior.
- Docs updated: `configuration.md` settings list and a tip in `media-types.md`.

## Testing

- `node --check` passes on the edited JS module. The C# change is a single config property matching the existing `AllowedUserPageUsers` pattern; I couldn't run `dotnet build` in this environment (no SDK and package downloads blocked), so please let CI/local build confirm.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xp5MNdYDSQtW81SBykGtgs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xp5MNdYDSQtW81SBykGtgs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a setting to choose default media types for newly created lists.
  * Default media types are automatically preselected and update related options.
  * Collection-only media types are excluded when creating playlists.

* **Documentation**
  * Added guidance for configuring and using default media type selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->