### PR TITLE
feat: add User-Agent override setting for external lists

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.SmartLists/Configuration/PluginConfiguration.cs
@@ -170,6 +170,22 @@ namespace Jellyfin.Plugin.SmartLists.Configuration
         /// </summary>
         public string? ListenBrainzUserToken { get; set; } = null;
 
+        /// <summary>
+        /// Gets or sets how the User-Agent header for external list requests is chosen.
+        /// </summary>
+        public UserAgentMode UserAgentMode { get; set; } = UserAgentMode.Default;
+
+        /// <summary>
+        /// Gets or sets the custom User-Agent used when <see cref="UserAgentMode"/> is Custom.
+        /// </summary>
+        public string? CustomUserAgent { get; set; } = null;
+
+        /// <summary>
+        /// Gets or sets the browser User-Agent captured from the admin page,
+        /// used by the Clone and AutoClone modes.
+        /// </summary>
+        public string? ClonedUserAgent { get; set; } = null;
+
         // ===== Backup Settings =====
 
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
@@ -1917,6 +1917,15 @@
     };
 
     // ===== CONFIGURATION MANAGEMENT =====
+    SmartLists.updateUserAgentContainers = function (page) {
+        var userAgentModeEl = page.querySelector('#userAgentMode');
+        var customContainer = page.querySelector('#customUserAgentContainer');
+        var clonedContainer = page.querySelector('#clonedUserAgentContainer');
+        var mode = userAgentModeEl ? userAgentModeEl.value : 'Default';
+        if (customContainer) customContainer.style.display = mode === 'Custom' ? '' : 'none';
+        if (clonedContainer) clonedContainer.style.display = (mode === 'Clone' || mode === 'AutoClone') ? '' : 'none';
+    };
+
     SmartLists.loadConfiguration = function (page) {
         Dashboard.showLoadingMsg();
         SmartLists.getApiClient().getPluginConfiguration(SmartLists.getPluginId()).then(function (config) {
@@ -2012,6 +2021,41 @@
             var listenBrainzUserTokenEl = page.querySelector('#listenBrainzUserToken');
             if (listenBrainzUserTokenEl) {
                 listenBrainzUserTokenEl.value = config.ListenBrainzUserToken || '';
+            }
+
+            // Load User-Agent settings
+            var userAgentModeEl = page.querySelector('#userAgentMode');
+            if (userAgentModeEl) {
+                userAgentModeEl.value = config.UserAgentMode || 'Default';
+                if (!userAgentModeEl.dataset.changeListenerAdded) {
+                    userAgentModeEl.dataset.changeListenerAdded = 'true';
+                    userAgentModeEl.addEventListener('change', function () {
+                        SmartLists.updateUserAgentContainers(page);
+                    });
+                }
+            }
+            var customUserAgentEl = page.querySelector('#customUserAgent');
+            if (customUserAgentEl) {
+                customUserAgentEl.value = config.CustomUserAgent || '';
+            }
+            var clonedUserAgentDisplayEl = page.querySelector('#clonedUserAgentDisplay');
+            if (clonedUserAgentDisplayEl) {
+                clonedUserAgentDisplayEl.textContent = config.ClonedUserAgent || 'Not captured yet - save the settings to capture it.';
+            }
+            SmartLists.updateUserAgentContainers(page);
+
+            // Auto Clone: keep the stored browser User-Agent current on every admin page load
+            if (config.UserAgentMode === 'AutoClone' && config.ClonedUserAgent !== navigator.userAgent) {
+                SmartLists.getApiClient().getPluginConfiguration(SmartLists.getPluginId()).then(function (freshConfig) {
+                    freshConfig.ClonedUserAgent = navigator.userAgent;
+                    return SmartLists.getApiClient().updatePluginConfiguration(SmartLists.getPluginId(), freshConfig);
+                }).then(function () {
+                    if (clonedUserAgentDisplayEl) {
+                        clonedUserAgentDisplayEl.textContent = navigator.userAgent;
+                    }
+                }).catch(function (err) {
+                    console.error('Failed to auto-clone User-Agent:', err);
+                });
             }
 
             // Load backup settings
@@ -2218,6 +2262,19 @@
             config.TmdbApiKey = tmdbApiKeyInput ? (tmdbApiKeyInput.value.trim() || null) : null;
             var listenBrainzUserTokenInput = page.querySelector('#listenBrainzUserToken');
             config.ListenBrainzUserToken = listenBrainzUserTokenInput ? (listenBrainzUserTokenInput.value.trim() || null) : null;
+
+            // Save User-Agent settings
+            var userAgentModeInput = page.querySelector('#userAgentMode');
+            config.UserAgentMode = userAgentModeInput ? userAgentModeInput.value : 'Default';
+            var customUserAgentInput = page.querySelector('#customUserAgent');
+            config.CustomUserAgent = customUserAgentInput ? (customUserAgentInput.value.trim() || null) : null;
+            if (config.UserAgentMode === 'Clone' || config.UserAgentMode === 'AutoClone') {
+                config.ClonedUserAgent = navigator.userAgent;
+                var clonedUserAgentDisplaySpan = page.querySelector('#clonedUserAgentDisplay');
+                if (clonedUserAgentDisplaySpan) {
+                    clonedUserAgentDisplaySpan.textContent = navigator.userAgent;
+                }
+            }
 
             // Save backup settings
             var backupEnabledCheckbox = page.querySelector('#backupEnabled');

--- a/Jellyfin.Plugin.SmartLists/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config.html
@@ -983,6 +983,35 @@
                             </div>
                         </div>
 
+                        <div class="selectContainer" style="margin-bottom: 1em;">
+                            <label class="selectLabel" for="userAgentMode">User-Agent</label>
+                            <select is="emby-select" id="userAgentMode" class="emby-select">
+                                <option value="Default">Default</option>
+                                <option value="AutoClone">Auto Clone (updates from your browser on every page
+                                    load)</option>
+                                <option value="Clone">Clone (captures your browser's User-Agent when you save)</option>
+                                <option value="Custom">Custom (enter below)</option>
+                            </select>
+                            <div class="fieldDescription">The User-Agent header sent when fetching external lists
+                                (IMDb, Letterboxd, Trakt, ListenBrainz). Change this if a provider starts blocking
+                                requests. The clone modes use the browser you access this admin page with.</div>
+                        </div>
+
+                        <div class="inputContainer" style="margin-bottom: 1em; display: none;"
+                            id="customUserAgentContainer">
+                            <label class="inputLabel" for="customUserAgent">Custom User-Agent</label>
+                            <input type="text" id="customUserAgent" class="emby-input"
+                                placeholder="e.g. Mozilla/5.0 (Windows NT 10.0; Win64; x64) ...">
+                            <div class="fieldDescription">Sent exactly as entered. Leave empty to fall back to the
+                                default.</div>
+                        </div>
+
+                        <div class="inputContainer" style="margin-bottom: 1em; display: none;"
+                            id="clonedUserAgentContainer">
+                            <div class="fieldDescription">Cloned User-Agent: <span id="clonedUserAgentDisplay"
+                                    style="word-break: break-all;"></span></div>
+                        </div>
+
                         <h2 class="sectionTitle" style="margin-top: 2em; display: flex; align-items: center;">
                             Backup & Restore
                             <a href="https://jellyfin-smartlists-plugin.dinsten.se/user-guide/configuration/#backup-restore"

--- a/Jellyfin.Plugin.SmartLists/Core/Enums/UserAgentMode.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Enums/UserAgentMode.cs
@@ -1,0 +1,31 @@
+using System.Text.Json.Serialization;
+
+namespace Jellyfin.Plugin.SmartLists.Core.Enums
+{
+    /// <summary>
+    /// How the User-Agent header for external list requests is chosen.
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum UserAgentMode
+    {
+        /// <summary>
+        /// Each provider uses its own built-in default.
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Use the admin's browser User-Agent, re-captured on every admin page load.
+        /// </summary>
+        AutoClone,
+
+        /// <summary>
+        /// Use the admin's browser User-Agent captured when settings were last saved.
+        /// </summary>
+        Clone,
+
+        /// <summary>
+        /// Use the custom value entered in settings.
+        /// </summary>
+        Custom,
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Services/ExternalList/ExternalListUserAgent.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/ExternalList/ExternalListUserAgent.cs
@@ -1,0 +1,30 @@
+using Jellyfin.Plugin.SmartLists.Core.Enums;
+
+namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
+{
+    /// <summary>
+    /// Resolves the User-Agent header for external list requests, honoring the
+    /// User-Agent override configured in Settings > External Lists.
+    /// </summary>
+    public static class ExternalListUserAgent
+    {
+        /// <summary>
+        /// Returns the configured User-Agent override, or <paramref name="providerDefault"/>
+        /// when the mode is Default or no override value is available yet.
+        /// </summary>
+        /// <param name="providerDefault">The provider's built-in User-Agent.</param>
+        /// <returns>The User-Agent to send.</returns>
+        public static string Resolve(string providerDefault)
+        {
+            var config = Plugin.Instance?.Configuration;
+            var overrideValue = config?.UserAgentMode switch
+            {
+                UserAgentMode.Custom => config.CustomUserAgent,
+                UserAgentMode.Clone or UserAgentMode.AutoClone => config.ClonedUserAgent,
+                _ => null,
+            };
+
+            return string.IsNullOrWhiteSpace(overrideValue) ? providerDefault : overrideValue.Trim();
+        }
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Services/ExternalList/ExternalListUserAgent.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/ExternalList/ExternalListUserAgent.cs
@@ -24,7 +24,25 @@ namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
                 _ => null,
             };
 
-            return string.IsNullOrWhiteSpace(overrideValue) ? providerDefault : overrideValue.Trim();
+            if (string.IsNullOrWhiteSpace(overrideValue))
+            {
+                return providerDefault;
+            }
+
+            var trimmed = overrideValue.Trim();
+
+            // The override is persisted user input and the providers add it via
+            // TryAddWithoutValidation, which skips the framework's CRLF checks —
+            // embedded control characters could corrupt or inject headers.
+            foreach (var ch in trimmed)
+            {
+                if (char.IsControl(ch))
+                {
+                    return providerDefault;
+                }
+            }
+
+            return trimmed;
         }
     }
 }

--- a/Jellyfin.Plugin.SmartLists/Services/ExternalList/ImdbListProvider.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/ExternalList/ImdbListProvider.cs
@@ -411,7 +411,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
                 Content = new StringContent(requestBody, Encoding.UTF8, "application/json")
             };
 
-            request.Headers.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36");
+            request.Headers.TryAddWithoutValidation("User-Agent", ExternalListUserAgent.Resolve("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36"));
 
             // IMDb's edge rejects GraphQL POSTs (403 Forbidden) that carry neither a Referer
             // nor an x-imdb-client-name header. Either one alone is enough; both are sent so

--- a/Jellyfin.Plugin.SmartLists/Services/ExternalList/LetterboxdListProvider.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/ExternalList/LetterboxdListProvider.cs
@@ -236,7 +236,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
         {
             var httpClient = _httpClientFactory.CreateClient("LetterboxdList");
             using var request = new HttpRequestMessage(HttpMethod.Get, url);
-            request.Headers.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36");
+            request.Headers.TryAddWithoutValidation("User-Agent", ExternalListUserAgent.Resolve("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"));
             request.Headers.Add("Accept-Language", "en-US,en;q=0.9");
 
             using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);

--- a/Jellyfin.Plugin.SmartLists/Services/ExternalList/ListenBrainzListProvider.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/ExternalList/ListenBrainzListProvider.cs
@@ -217,7 +217,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            request.Headers.Add("User-Agent", UserAgent);
+            request.Headers.TryAddWithoutValidation("User-Agent", ExternalListUserAgent.Resolve(UserAgent));
 
             var token = Plugin.Instance?.Configuration?.ListenBrainzUserToken;
             if (!string.IsNullOrWhiteSpace(token))

--- a/Jellyfin.Plugin.SmartLists/Services/ExternalList/TraktListProvider.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/ExternalList/TraktListProvider.cs
@@ -82,7 +82,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
                     request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
                     request.Headers.Add("trakt-api-version", "2");
                     request.Headers.Add("trakt-api-key", clientId);
-                    request.Headers.Add("User-Agent", "JellyfinSmartLists/1.0");
+                    request.Headers.TryAddWithoutValidation("User-Agent", ExternalListUserAgent.Resolve("JellyfinSmartLists/1.0"));
 
                     using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
 

--- a/docs/content/user-guide/external-lists.md
+++ b/docs/content/user-guide/external-lists.md
@@ -306,6 +306,19 @@ This creates a collection sorted exactly like IMDb's Top 250 chart.
 
 ---
 
+## User-Agent
+
+The plugin sends a User-Agent header when fetching external lists. Each provider has a sensible built-in default, but if a provider starts blocking the plugin's requests you can override the User-Agent in the plugin **Settings** tab under **External Lists > User-Agent**:
+
+- **Default**: Each provider uses its own built-in User-Agent (recommended).
+- **Auto Clone**: Uses your browser's User-Agent, automatically re-captured every time you open the SmartLists admin page.
+- **Clone**: Uses your browser's User-Agent, captured once when you save the settings.
+- **Custom**: Uses exactly the value you enter in the text field.
+
+The clone modes capture the User-Agent from the browser you access the admin configuration page with. The override applies to all providers that send a User-Agent (IMDb, Letterboxd, Trakt, ListenBrainz).
+
+---
+
 ## Tips
 
 !!! tip "Combining with other rules"


### PR DESCRIPTION
## What
Adds a configurable User-Agent setting for external list providers, as proposed in #484.

## Why
A user was blocked by IMDb's WAF and requested a way to change the User-Agent the plugin sends (#484, discussion #478). Investigation showed the actual block was the missing-Referer issue (fixed in `736c52d`, RC channel only), but a UA override remains a useful escape hatch when a provider starts blocking the default.

Research note: MusicBrainz's identifying-UA policy is good-citizen guidance, not enforced blocking (only a fixed "anonymous" UA list is throttled), and the ListenBrainz API has no UA requirement — so the override safely applies to all UA-sending providers.

## Changes
- New **User-Agent** dropdown in Settings > External Lists with four modes:
  - **Default** — each provider keeps its built-in User-Agent
  - **Auto Clone** — captures the admin browser's User-Agent, silently re-captured on every admin page load
  - **Clone** — captures the admin browser's User-Agent once when settings are saved
  - **Custom** — free-text value, shown conditionally
- New `UserAgentMode` enum + `UserAgentMode`/`CustomUserAgent`/`ClonedUserAgent` on `PluginConfiguration`
- New `ExternalListUserAgent.Resolve(providerDefault)` helper; applied at all four UA-sending call sites (IMDb, Letterboxd, Trakt, ListenBrainz)
- Header writes switched to `TryAddWithoutValidation` — custom UA is user input and plain `Add` throws `FormatException` on non-token strings
- Docs: new "User-Agent" section in `docs/content/user-guide/external-lists.md`

Admin page only — the user page cannot read/write plugin configuration (same precedent as #483).

Verified e2e against the dev container: config API round-trip, IMDb Top 250 fetch with a custom UA, dropdown visibility toggling, Clone capture on save, and AutoClone replacing a stale stored UA on page reload.

Closes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAEYxy7ZxBjtSvAhoeGuLX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable User-Agent options for external list requests.
  * Choose provider defaults, clone the browser User-Agent automatically or manually, or enter a custom value.
  * Applied the selected User-Agent settings across supported external list providers.

* **Documentation**
  * Added guidance explaining User-Agent modes, configuration, and supported providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->