### PR TITLE
feat: publish a documented integration API for third-party developers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,14 @@ Adding new sort options requires updates in: `Core/Orders/`, `OrderFactory.cs`, 
 - Use `showNotification()` for user messages, not `Dashboard.alert()`
 - **New JS files must be registered in TWO places**: `.csproj` (as `<EmbeddedResource>`) AND `Plugin.cs` (in `GetPages()` as `PluginPageInfo`)
 
+### Multipart uploads break OpenAPI if bound wrong
+Bind uploaded files as a bare `IFormFile` parameter — **never** `[FromForm] IFormFile`. MVC already
+binds `IFormFile` from the multipart body, so the attribute is a runtime no-op, but it downgrades the
+binding source to `BindingSource.Form`, which makes Swashbuckle throw and return **HTTP 500 for
+`/api-docs/openapi.json` server-wide** — breaking API-doc generation for all of Jellyfin, not just this
+plugin. Add `[Consumes("multipart/form-data")]` alongside so the schema declares the right shape.
+`[FromForm]` on plain scalar parameters (e.g. `string imageType`) is fine.
+
 ### Media Type Constants
 Use `MediaTypes.Episode` instead of `"Episode"` - see `Core/Constants/MediaTypes.cs`.
 

--- a/Jellyfin.Plugin.SmartLists/Api/Controllers/SmartListController.cs
+++ b/Jellyfin.Plugin.SmartLists/Api/Controllers/SmartListController.cs
@@ -1791,9 +1791,12 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                 // this collection to me".
                 if (string.IsNullOrEmpty(collection.UserId) || !Guid.TryParse(collection.UserId, out var userId) || userId == Guid.Empty)
                 {
+                    // The stored owner must still resolve to a real user - a deleted account would
+                    // otherwise be preserved as a dangling owner instead of falling through below.
                     if (!string.IsNullOrEmpty(existingCollection.UserId)
                         && Guid.TryParse(existingCollection.UserId, out var existingUserId)
-                        && existingUserId != Guid.Empty)
+                        && existingUserId != Guid.Empty
+                        && _userManager.GetUserById(existingUserId) is not null)
                     {
                         // Keep the current owner untouched.
                         collection.UserId = NormalizeUserId(existingCollection.UserId);

--- a/Jellyfin.Plugin.SmartLists/Api/Controllers/SmartListController.cs
+++ b/Jellyfin.Plugin.SmartLists/Api/Controllers/SmartListController.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SmartLists.Api.Filters;
 using Jellyfin.Plugin.SmartLists.Core;
 using Jellyfin.Plugin.SmartLists.Core.Constants;
 using Jellyfin.Plugin.SmartLists.Core.Models;
@@ -41,6 +42,10 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
     [Authorize(Policy = "RequiresElevation")]
     [Route("Plugins/SmartLists")]
     [Produces("application/json")]
+    // Error bodies below use several ad-hoc shapes (new { message }, new { error }, bare strings).
+    // This attribute rewrites them all to RFC 7807 ProblemDetails on the way out, so the wire
+    // contract is always { title, detail, status }. See SmartListsProblemDetailsAttribute.
+    [SmartListsProblemDetails]
     public partial class SmartListController(
         ILogger<SmartListController> logger,
         ILoggerFactory loggerFactory,
@@ -374,6 +379,40 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
             }
 
             return currentUser;
+        }
+
+        /// <summary>
+        /// Resolves the owner from a request body's CreatedByUserId value.
+        /// Used as a fallback when there is no Jellyfin-UserId claim (API key callers carry no such claim).
+        /// </summary>
+        /// <param name="createdByUserId">The CreatedByUserId value supplied in the request body</param>
+        /// <returns>The User object if the value resolves to a real user, null otherwise</returns>
+        private Jellyfin.Database.Implementations.Entities.User? ResolveCreatedByUser(string? createdByUserId)
+        {
+            if (string.IsNullOrWhiteSpace(createdByUserId)
+                || !Guid.TryParse(createdByUserId, out var createdByGuid)
+                || createdByGuid == Guid.Empty)
+            {
+                return null;
+            }
+
+            return _userManager.GetUserById(createdByGuid);
+        }
+
+        /// <summary>
+        /// Builds the 400 response returned when a collection owner cannot be determined from
+        /// the request body or the authenticated user context.
+        /// </summary>
+        /// <returns>A 400 ProblemDetails result</returns>
+        private ActionResult CollectionOwnerUnresolvable()
+        {
+            logger.LogWarning("Could not determine collection owner: no valid UserId or CreatedByUserId in the request body and no Jellyfin-UserId claim on the request");
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Validation Error",
+                Detail = "Collection owner could not be determined. Supply 'UserId' (or 'CreatedByUserId') in the request body when calling with an API key.",
+                Status = StatusCodes.Status400BadRequest
+            });
         }
 
         /// <summary>
@@ -893,14 +932,29 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
             {
                 // Default to currently logged-in user
                 var currentUserId = GetCurrentUserId();
-                var currentUser = ValidateAndGetCurrentUser(currentUserId, out var errorResult);
-                if (currentUser == null)
+                if (currentUserId != Guid.Empty)
                 {
-                    return errorResult!;
-                }
+                    var currentUser = ValidateAndGetCurrentUser(currentUserId, out var errorResult);
+                    if (currentUser == null)
+                    {
+                        return errorResult!;
+                    }
 
-                collection.UserId = currentUser.Id.ToString("N").ToLowerInvariant();
-                logger.LogDebug("Set default collection owner to currently logged-in user: {Username} ({UserId})", currentUser.Username, currentUser.Id);
+                    collection.UserId = currentUser.Id.ToString("N").ToLowerInvariant();
+                    logger.LogDebug("Set default collection owner to currently logged-in user: {Username} ({UserId})", currentUser.Username, currentUser.Id);
+                }
+                else
+                {
+                    // No Jellyfin-UserId claim (API key callers) - fall back to CreatedByUserId from the request body
+                    var creator = ResolveCreatedByUser(collection.CreatedByUserId);
+                    if (creator == null)
+                    {
+                        return CollectionOwnerUnresolvable();
+                    }
+
+                    collection.UserId = creator.Id.ToString("N").ToLowerInvariant();
+                    logger.LogDebug("Set collection owner from request CreatedByUserId: {Username} ({UserId})", creator.Username, creator.Id);
+                }
             }
             else
             {
@@ -1732,23 +1786,51 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                     return NotFound("Smart collection not found");
                 }
 
-                // Set default owner user if not specified, or normalize if already set (same as CreateCollectionInternal)
+                // Resolve owner. Unlike create, an update must PRESERVE the existing owner when the
+                // request does not name one - omitting UserId means "leave it alone", not "reassign
+                // this collection to me".
                 if (string.IsNullOrEmpty(collection.UserId) || !Guid.TryParse(collection.UserId, out var userId) || userId == Guid.Empty)
                 {
-                    // Default to currently logged-in user
-                    var currentUserId = GetCurrentUserId();
-                    var currentUser = ValidateAndGetCurrentUser(currentUserId, out var errorResult);
-                    if (currentUser == null)
+                    if (!string.IsNullOrEmpty(existingCollection.UserId)
+                        && Guid.TryParse(existingCollection.UserId, out var existingUserId)
+                        && existingUserId != Guid.Empty)
                     {
-                        return errorResult!;
+                        // Keep the current owner untouched.
+                        collection.UserId = NormalizeUserId(existingCollection.UserId);
+                        logger.LogDebug("Preserved existing collection owner during update: {UserId}", collection.UserId);
                     }
+                    else
+                    {
+                        // Stored record has no usable owner (legacy or corrupt data) - re-derive one.
+                        var currentUserId = GetCurrentUserId();
+                        if (currentUserId != Guid.Empty)
+                        {
+                            var currentUser = ValidateAndGetCurrentUser(currentUserId, out var errorResult);
+                            if (currentUser == null)
+                            {
+                                return errorResult!;
+                            }
 
-                    collection.UserId = currentUser.Id.ToString("N").ToLowerInvariant();
-                    logger.LogDebug("Set default collection owner to currently logged-in user during update: {Username} ({UserId})", currentUser.Username, currentUser.Id);
+                            collection.UserId = currentUser.Id.ToString("N").ToLowerInvariant();
+                            logger.LogDebug("Existing collection had no owner; set to currently logged-in user during update: {Username} ({UserId})", currentUser.Username, currentUser.Id);
+                        }
+                        else
+                        {
+                            // No Jellyfin-UserId claim (API key callers) - fall back to CreatedByUserId from the request body
+                            var creator = ResolveCreatedByUser(collection.CreatedByUserId);
+                            if (creator == null)
+                            {
+                                return CollectionOwnerUnresolvable();
+                            }
+
+                            collection.UserId = creator.Id.ToString("N").ToLowerInvariant();
+                            logger.LogDebug("Existing collection had no owner; set from request CreatedByUserId during update: {Username} ({UserId})", creator.Username, creator.Id);
+                        }
+                    }
                 }
                 else
                 {
-                    // Normalize existing UserId to canonical "N" format (no dashes)
+                    // Normalize explicitly-supplied UserId to canonical "N" format (no dashes)
                     collection.UserId = NormalizeUserId(collection.UserId);
                     logger.LogDebug("Normalized collection UserId to canonical format during update: {UserId}", collection.UserId);
                 }
@@ -2584,9 +2666,12 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
         /// <param name="overwrite">If true, overwrites existing lists with the same ID. If false, skips them.</param>
         /// <returns>Restore results with counts of imported and skipped lists.</returns>
         [HttpPost("backups/upload")]
+        [Consumes("multipart/form-data")]
         [DisableRequestSizeLimit]
         [RequestFormLimits(MultipartBodyLengthLimit = 1L * 1024 * 1024 * 1024)]
-        public async Task<ActionResult> RestoreFromUpload([FromForm] IFormFile file, [FromQuery] bool overwrite = false)
+        // Bind the file as a bare IFormFile. [FromForm] here makes Swashbuckle throw and returns
+        // HTTP 500 for /api-docs/openapi.json server-wide. See docs/content/development/integration-api.md
+        public async Task<ActionResult> RestoreFromUpload(IFormFile file, [FromQuery] bool overwrite = false)
         {
             // Maximum upload size: 1GB
             const long MaxUploadSize = 1L * 1024 * 1024 * 1024;
@@ -2624,9 +2709,11 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
         /// <param name="file">ZIP file to preview.</param>
         /// <returns>Preview information including list count.</returns>
         [HttpPost("backups/preview")]
+        [Consumes("multipart/form-data")]
         [DisableRequestSizeLimit]
         [RequestFormLimits(MultipartBodyLengthLimit = 1L * 1024 * 1024 * 1024)]
-        public ActionResult PreviewUploadedBackup([FromForm] IFormFile file)
+        // Bare IFormFile, never [FromForm] — see RestoreFromUpload above.
+        public ActionResult PreviewUploadedBackup(IFormFile file)
         {
             const long MaxUploadSize = 1L * 1024 * 1024 * 1024;
 
@@ -2922,10 +3009,13 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
         /// <param name="imageType">The image type (Primary, Backdrop, Banner, etc.).</param>
         /// <returns>The uploaded image info.</returns>
         [HttpPost("{id}/images")]
+        [Consumes("multipart/form-data")]
         [DisableRequestSizeLimit]
+        // 'file' is a bare IFormFile on purpose — [FromForm] on it breaks OpenAPI generation
+        // server-wide. [FromForm] on the plain string below is fine.
         public async Task<ActionResult<SmartListImageDto>> UploadImage(
             [FromRoute, Required] string id,
-            [FromForm] IFormFile file,
+            IFormFile file,
             [FromForm, Required] string imageType)
         {
             if (file == null || file.Length == 0)

--- a/Jellyfin.Plugin.SmartLists/Api/Controllers/UserSmartListController.cs
+++ b/Jellyfin.Plugin.SmartLists/Api/Controllers/UserSmartListController.cs
@@ -9,6 +9,7 @@ using Jellyfin.Data;
 using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Plugin.SmartLists.Api.Filters;
 using Jellyfin.Plugin.SmartLists.Core;
 using Jellyfin.Plugin.SmartLists.Core.Enums;
 using Jellyfin.Plugin.SmartLists.Core.Models;
@@ -39,6 +40,9 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
     [Authorize]
     [Route("Plugins/SmartLists/User")]
     [Produces("application/json")]
+    // Rewrites this controller's new { message } / new { error } / string error bodies to
+    // RFC 7807 ProblemDetails. See SmartListsProblemDetailsAttribute.
+    [SmartListsProblemDetails]
     public class UserSmartListController : ControllerBase
     {
         private const int MaxMediaTypesLimit = 50;
@@ -1797,13 +1801,16 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
         /// <param name="imageType">The image type (Primary, Backdrop, Banner, etc.).</param>
         /// <returns>The uploaded image info.</returns>
         [HttpPost("{id}/images")]
+        [Consumes("multipart/form-data")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        // 'file' is a bare IFormFile on purpose — [FromForm] on it breaks OpenAPI generation
+        // server-wide. [FromForm] on the plain string below is fine.
         public async Task<ActionResult<SmartListImageDto>> UploadImage(
             [FromRoute, Required] string id,
-            [FromForm] IFormFile file,
+            IFormFile file,
             [FromForm, Required] string imageType)
         {
             // Check if user page is enabled

--- a/Jellyfin.Plugin.SmartLists/Api/Filters/SmartListsProblemDetailsAttribute.cs
+++ b/Jellyfin.Plugin.SmartLists/Api/Filters/SmartListsProblemDetailsAttribute.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Reflection;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Jellyfin.Plugin.SmartLists.Api.Filters
+{
+    /// <summary>
+    /// Normalizes this plugin's error responses to RFC 7807 <see cref="ProblemDetails"/>.
+    /// <para>
+    /// Controllers in this plugin historically returned three different error bodies:
+    /// <c>new { message = "..." }</c>, <c>new { error = "..." }</c> and bare strings
+    /// (<c>BadRequest("Invalid list ID format")</c>). This filter rewrites all three into a single
+    /// documented shape - <c>{ "title": ..., "detail": ..., "status": ... }</c> - so callers only
+    /// ever have to read <c>detail</c>. The HTTP status code is never changed and the
+    /// human-readable text is carried across verbatim into <c>detail</c>.
+    /// </para>
+    /// <para>
+    /// <b>Scoping proof - this filter cannot touch any controller but ours.</b>
+    /// It is an attribute applied to the three SmartLists controller classes and is deliberately
+    /// NOT registered in <c>MvcOptions.Filters</c> (nothing in <c>ServiceRegistrator</c> references
+    /// it). MVC discovers filters per action: <c>DefaultApplicationModelProvider</c> collects
+    /// <see cref="IFilterMetadata"/> attributes declared on a controller type and its methods into
+    /// that controller's own <c>ControllerModel.Filters</c>, and the filter pipeline for an action
+    /// is built exclusively from its own controller/action models plus the global collection. Since
+    /// this type appears in neither the global collection nor any non-SmartLists controller model,
+    /// core Jellyfin actions are structurally unreachable. As belt-and-braces against a future
+    /// global registration, <see cref="OnResultExecuting"/> also bails out when the executing
+    /// controller does not come from this plugin's assembly.
+    /// </para>
+    /// <para>
+    /// Three further gates keep the blast radius minimal even within our own controllers:
+    /// only <see cref="ObjectResult"/>s are considered, only status codes &gt;= 400 (so the
+    /// <c>Ok(new { message = ... })</c> success bodies the UI shows as notifications are untouched),
+    /// and only values this filter recognises as an error body are rewritten - anything else is
+    /// passed through unchanged.
+    /// </para>
+    /// <para>
+    /// Ceiling: this runs inside MVC's result pipeline, so it cannot normalize responses produced
+    /// before or outside it - <c>[Authorize]</c> challenges, model-binding validation failures
+    /// (already framework <c>ValidationProblemDetails</c>) and Jellyfin's exception middleware.
+    /// The contract is "every error body this plugin authors", not "every byte these routes emit".
+    /// </para>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public sealed class SmartListsProblemDetailsAttribute : Attribute, IResultFilter
+    {
+        /// <summary>
+        /// Rewrites a recognised error body into <see cref="ProblemDetails"/> before it is serialized.
+        /// </summary>
+        /// <param name="context">The result-executing context supplied by MVC.</param>
+        public void OnResultExecuting(ResultExecutingContext context)
+        {
+            if (context is null || context.Controller?.GetType().Assembly != typeof(Plugin).Assembly)
+            {
+                return;
+            }
+
+            if (context.Result is not ObjectResult result
+                || result.StatusCode is not int status
+                || status < 400)
+            {
+                return;
+            }
+
+            // Already RFC 7807 (this also covers ValidationProblemDetails) - leave it alone.
+            if (result.Value is ProblemDetails)
+            {
+                return;
+            }
+
+            var detail = ExtractDetail(result.Value);
+            if (detail is null)
+            {
+                return;
+            }
+
+            // The factory fills in Title/Type from the status code and adds traceId, matching what
+            // ASP.NET Core produces for its own client errors. It is registered by AddMvc; if it
+            // somehow is not, leave the response exactly as the controller wrote it.
+            var factory = context.HttpContext.RequestServices.GetService<ProblemDetailsFactory>();
+            if (factory is null)
+            {
+                return;
+            }
+
+            result.Value = factory.CreateProblemDetails(context.HttpContext, statusCode: status, detail: detail);
+            result.DeclaredType = typeof(ProblemDetails);
+        }
+
+        /// <summary>
+        /// No-op; this filter only rewrites the result before it is executed.
+        /// </summary>
+        /// <param name="context">The result-executed context supplied by MVC.</param>
+        public void OnResultExecuted(ResultExecutedContext context)
+        {
+        }
+
+        /// <summary>
+        /// Pulls the human-readable text out of the ad-hoc error bodies this plugin returns.
+        /// Anonymous types (<c>new { message = "..." }</c>) have to be read reflectively - there is
+        /// no shared type to cast to, and introducing one would mean editing ~166 return statements.
+        /// </summary>
+        /// <param name="value">The value the controller put in the <see cref="ObjectResult"/>.</param>
+        /// <returns>The message text, or null when the value is not a recognised error body.</returns>
+        private static string? ExtractDetail(object? value) => value switch
+        {
+            null => null,
+            string text => text,
+            // ponytail: five sites return `new { message, error = ex.Message }`. Only `message` is
+            // carried over; the `error` half is a raw exception string that no caller reads and that
+            // does not belong on the wire. Nothing else drops information.
+            _ => ReadStringProperty(value, "message") ?? ReadStringProperty(value, "error")
+        };
+
+        private static string? ReadStringProperty(object value, string name)
+            => value.GetType().GetProperty(name, BindingFlags.Public | BindingFlags.Instance)?.GetValue(value) as string;
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-api.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-api.js
@@ -8,54 +8,25 @@
         // Try to extract meaningful error message from server response
         if (err && typeof err.text === 'function') {
             return err.text().then(function (serverMessage) {
-                let friendlyMessage = baseMessage;
+                // The API answers with RFC 7807 ProblemDetails; pickErrorText knows that shape
+                // (plus the legacy ones). Anything it can't read falls back to the raw body.
+                let detail = null;
                 try {
-                    const parsedMessage = JSON.parse(serverMessage);
-
-                    // Handle ValidationProblemDetails format (has 'errors' object with field-level errors)
-                    if (parsedMessage && parsedMessage.errors && typeof parsedMessage.errors === 'object') {
-                        const fieldErrors = [];
-                        for (const field in parsedMessage.errors) {
-                            if (parsedMessage.errors.hasOwnProperty(field)) {
-                                const fieldErrorMessages = Array.isArray(parsedMessage.errors[field])
-                                    ? parsedMessage.errors[field].join(', ')
-                                    : parsedMessage.errors[field];
-                                fieldErrors.push(field + ': ' + fieldErrorMessages);
-                            }
-                        }
-                        if (fieldErrors.length > 0) {
-                            friendlyMessage = baseMessage.replace(/\.$/, '') + ': ' + fieldErrors.join('; ');
-                        } else if (parsedMessage.detail) {
-                            friendlyMessage = baseMessage.replace(/\.$/, '') + ': ' + parsedMessage.detail;
-                        }
-                    }
-                    // Handle ProblemDetails format (has 'detail' property)
-                    else if (parsedMessage && parsedMessage.detail) {
-                        friendlyMessage = baseMessage.replace(/\.$/, '') + ': ' + parsedMessage.detail;
-                    }
-                    // Handle other JSON error formats
-                    else if (parsedMessage && parsedMessage.message) {
-                        friendlyMessage = baseMessage.replace(/\.$/, '') + ': ' + parsedMessage.message;
-                    } else if (parsedMessage && parsedMessage.title) {
-                        friendlyMessage = baseMessage.replace(/\.$/, '') + ': ' + parsedMessage.title;
-                    } else if (serverMessage && serverMessage.trim()) {
-                        // Remove quotes and Unicode escapes, then add context
-                        const cleanMessage = serverMessage
-                            .replace(/"/g, '')
-                            .replace(/\\u0027/g, "'")
-                            .replace(/\\u0022/g, '"');
-                        friendlyMessage = baseMessage.replace(/\.$/, '') + ': ' + cleanMessage;
-                    }
+                    detail = SmartLists.pickErrorText(JSON.parse(serverMessage));
                 } catch (e) {
-                    if (serverMessage && serverMessage.trim()) {
-                        // Remove quotes and Unicode escapes, then add context
-                        const cleanMessage = serverMessage
-                            .replace(/"/g, '')
-                            .replace(/\\u0027/g, "'")
-                            .replace(/\\u0022/g, '"');
-                        friendlyMessage = baseMessage.replace(/\.$/, '') + ': ' + cleanMessage;
-                    }
+                    detail = null;
                 }
+                if (!detail && serverMessage && serverMessage.trim()) {
+                    // Remove quotes and Unicode escapes, then add context
+                    detail = serverMessage
+                        .replace(/"/g, '')
+                        .replace(/\\u0027/g, "'")
+                        .replace(/\\u0022/g, '"');
+                }
+
+                const friendlyMessage = detail
+                    ? baseMessage.replace(/\.$/, '') + ': ' + detail
+                    : baseMessage;
                 SmartLists.showNotification(friendlyMessage);
                 return Promise.resolve();
             }).catch(function () {

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-core.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-core.js
@@ -253,6 +253,33 @@
             .replace(/`/g, '&#96;');
     };
 
+    // Pull the human-readable text out of a parsed API error body.
+    // The API returns RFC 7807 ProblemDetails ({ title, detail, status }), so 'detail' is the
+    // primary key. The legacy 'message'/'error' keys are kept so this also works against older
+    // plugin versions, and 'title' is the last resort for detail-less ProblemDetails such as
+    // framework-generated 404s. Returns null when the body carries no usable text.
+    SmartLists.pickErrorText = function (body) {
+        if (!body) return null;
+        if (typeof body === 'string') return body;
+        if (typeof body !== 'object') return null;
+
+        // ValidationProblemDetails: field-level errors take precedence over the generic detail
+        if (body.errors && typeof body.errors === 'object') {
+            const fieldErrors = [];
+            for (const field in body.errors) {
+                if (Object.prototype.hasOwnProperty.call(body.errors, field)) {
+                    const fieldMessages = Array.isArray(body.errors[field])
+                        ? body.errors[field].join(', ')
+                        : body.errors[field];
+                    fieldErrors.push(field + ': ' + fieldMessages);
+                }
+            }
+            if (fieldErrors.length > 0) return fieldErrors.join('; ');
+        }
+
+        return body.detail || body.message || body.error || body.title || null;
+    };
+
     // Extract error message from API error responses
     // Handles both modern Response objects and legacy error formats
     SmartLists.extractErrorMessage = async function (err, defaultMessage) {
@@ -267,11 +294,9 @@
                     if (textContent) {
                         // Try to parse as JSON first
                         try {
-                            const errorData = JSON.parse(textContent);
-                            if (errorData.message) {
-                                return errorData.message;
-                            } else if (typeof errorData === 'string') {
-                                return errorData;
+                            const picked = SmartLists.pickErrorText(JSON.parse(textContent));
+                            if (picked) {
+                                return picked;
                             }
                         } catch (parseError) {
                             // If JSON parsing fails, use the raw text
@@ -285,11 +310,9 @@
             // Legacy check for Response with json method (shouldn't happen, but defensive)
             else if (err && typeof err.json === 'function') {
                 try {
-                    const errorData = await err.json();
-                    if (errorData.message) {
-                        return errorData.message;
-                    } else if (typeof errorData === 'string') {
-                        return errorData;
+                    const picked = SmartLists.pickErrorText(await err.json());
+                    if (picked) {
+                        return picked;
                     }
                 } catch (parseError) {
                     console.log('Could not parse error JSON:', parseError);
@@ -298,11 +321,9 @@
             // Check if the error has response text (legacy error format)
             else if (err.responseText) {
                 try {
-                    const errorData = JSON.parse(err.responseText);
-                    if (errorData.message) {
-                        return errorData.message;
-                    } else if (typeof errorData === 'string') {
-                        return errorData;
+                    const picked = SmartLists.pickErrorText(JSON.parse(err.responseText));
+                    if (picked) {
+                        return picked;
                     }
                 } catch (parseError) {
                     // If JSON parsing fails, use the raw response text

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-images.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-images.js
@@ -525,10 +525,17 @@
                     body: formData
                 }).then(function (response) {
                     if (!response.ok) {
-                        return response.json().then(function (errorData) {
-                            throw new Error(errorData.message || 'Upload failed');
-                        }).catch(function () {
-                            throw new Error('Upload failed with status ' + response.status);
+                        // Read the body once: chaining .catch onto .json().then() used to swallow
+                        // the parsed message along with the parse error and always report the
+                        // generic "status N" text.
+                        return response.text().then(function (bodyText) {
+                            var detail = null;
+                            try {
+                                detail = SmartLists.pickErrorText(JSON.parse(bodyText));
+                            } catch (e) {
+                                detail = null;
+                            }
+                            throw new Error(detail || ('Upload failed with status ' + response.status));
                         });
                     }
                     return response.json();

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
@@ -2326,15 +2326,8 @@
                 return response.text().then(function (errorText) {
                     var errorMessage;
                     try {
-                        var parsed = JSON.parse(errorText);
-                        // Extract string from parsed object if necessary
-                        if (parsed && typeof parsed === 'object') {
-                            errorMessage = parsed.message || parsed.error || JSON.stringify(parsed);
-                        } else if (typeof parsed === 'string') {
-                            errorMessage = parsed;
-                        } else {
-                            errorMessage = String(parsed);
-                        }
+                        errorMessage = SmartLists.pickErrorText(JSON.parse(errorText))
+                            || errorText || 'Unknown error occurred';
                     } catch (e) {
                         errorMessage = errorText || 'Unknown error occurred';
                     }

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -534,15 +534,8 @@
                     return response.text().then(function (errorText) {
                         var errorMessage;
                         try {
-                            var parsed = JSON.parse(errorText);
-                            // Extract string from parsed object if necessary
-                            if (parsed && typeof parsed === 'object') {
-                                errorMessage = parsed.message || parsed.error || JSON.stringify(parsed);
-                            } else if (typeof parsed === 'string') {
-                                errorMessage = parsed;
-                            } else {
-                                errorMessage = String(parsed);
-                            }
+                            errorMessage = SmartLists.pickErrorText(JSON.parse(errorText))
+                                || errorText || 'Unknown error occurred';
                         } catch (e) {
                             errorMessage = errorText || 'Unknown error occurred';
                         }
@@ -1333,15 +1326,8 @@
                 return response.text().then(function (errorText) {
                     var errorMessage;
                     try {
-                        var parsed = JSON.parse(errorText);
-                        // Extract string from parsed object if necessary
-                        if (parsed && typeof parsed === 'object') {
-                            errorMessage = parsed.message || parsed.error || JSON.stringify(parsed);
-                        } else if (typeof parsed === 'string') {
-                            errorMessage = parsed;
-                        } else {
-                            errorMessage = String(parsed);
-                        }
+                        errorMessage = SmartLists.pickErrorText(JSON.parse(errorText))
+                            || errorText || 'Unknown error occurred';
                     } catch (e) {
                         errorMessage = errorText || 'Unknown error occurred';
                     }

--- a/docs/content/development/contributing.md
+++ b/docs/content/development/contributing.md
@@ -69,4 +69,36 @@ All contributions are welcome:
 - Follow existing code style and patterns
 - Write clear, descriptive commit messages
 - Test your changes thoroughly before submitting
+
+## API error responses
+
+Every error body the plugin's controllers return uses [RFC 7807](https://datatracker.ietf.org/doc/html/rfc7807)
+`ProblemDetails`:
+
+```json
+{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.1",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "List name cannot be empty",
+  "traceId": "00-..."
+}
+```
+
+Read `detail` for the human-readable message. Validation failures may additionally carry an
+`errors` object (`ValidationProblemDetails`) with field-level messages.
+
+You do not have to build this shape by hand. Controllers may keep returning
+`BadRequest("...")`, `BadRequest(new { message = "..." })` or `StatusCode(500, new { error = "..." })`;
+the `[SmartListsProblemDetails]` result filter on each controller rewrites those into
+`ProblemDetails` before serialization, preserving both the status code and the message text.
+Returning a `ProblemDetails` explicitly also works and is left untouched.
+
+Two limits are worth knowing:
+
+- The filter only sees results produced by the plugin's own controllers. Authorization
+  challenges, model-binding failures and Jellyfin's exception middleware answer before it runs,
+  so a caller should still cope with a bare `403` or a plain-text `500`.
+- On the client side, `SmartLists.pickErrorText(parsedBody)` in `config-core.js` is the single
+  place that knows this shape. Use it instead of reading `.message` or `.detail` directly.
 - Update documentation if you add new features or change behavior

--- a/docs/content/development/integration-api.md
+++ b/docs/content/development/integration-api.md
@@ -68,8 +68,14 @@ cannot infer "the current user" from the request.
     evaluate user-specific rules. With a logged-in admin token the plugin defaults that owner to
     the caller. With an API key there is no caller to default to.
 
-    Send **`UserId`** (preferred) or **`CreatedByUserId`** in the request body when creating or
-    updating a collection with an API key. Omit both and you get:
+    **Creating:** send **`UserId`** (preferred) or **`CreatedByUserId`** in the request body.
+    There is no existing owner to fall back on, so one of them is required.
+
+    **Updating:** both are optional. Omitting `UserId` means "leave ownership alone" — the stored
+    owner is kept. Send `UserId` only when you actually intend to reassign the collection. An owner
+    is required again only if the stored one is missing or points at a deleted user.
+
+    When no owner can be determined you get:
 
     ```json
     {

--- a/docs/content/development/integration-api.md
+++ b/docs/content/development/integration-api.md
@@ -1,0 +1,527 @@
+# Integration API
+
+SmartLists exposes a REST API on your Jellyfin server. It is the same API the plugin's own
+configuration pages use, and it is the supported way for external scripts, automations and other
+Jellyfin plugins to create, refresh and inspect smart lists.
+
+Typical uses:
+
+- Provisioning lists from a script or config-management tool instead of clicking through the UI
+- Triggering a refresh from an external trigger (a download client finishing, a cron job, a webhook)
+- Reading refresh progress and history into a dashboard
+- Another Jellyfin plugin creating lists on the user's behalf
+
+## Stability
+
+!!! important "What is and isn't covered"
+    The endpoints listed under [Endpoint reference](#endpoint-reference) are the plugin's public
+    integration contract as of the **12.0.x** release line. They will not change shape without a
+    note in the release changelog.
+
+    **Everything else is UI plumbing and is not part of the contract.** That includes
+    `/Plugins/SmartLists/currentuser`, every `/Plugins/SmartLists/User/*` route, the
+    `/Plugins/SmartLists/backups*` routes, `/Plugins/SmartLists/Timer/*`, the image upload and
+    delete routes, and `/Plugins/SmartLists/Pages/UserPlaylists`. They exist to serve the admin and
+    user configuration pages, they change whenever those pages change, and they may be removed or
+    reshaped in any release. Don't build against them.
+
+To check which plugin version a server is running, call Jellyfin's own `GET /Plugins` endpoint and
+look for the SmartLists entry.
+
+## Authentication
+
+Every endpoint requires authentication. The simplest credential for an integration is a Jellyfin
+API key.
+
+### Creating an API key
+
+1. In Jellyfin, go to **Dashboard → Advanced → API Keys**
+2. Click **+** and give the key a name (e.g. `smartlists-automation`)
+3. Copy the generated key
+
+### Sending the key
+
+Jellyfin expects the key in an `Authorization` header:
+
+```
+Authorization: MediaBrowser Token="YOUR_API_KEY"
+```
+
+The quotes around the token are part of the header value.
+
+!!! warning "`?api_key=` no longer works"
+    The legacy `?api_key=YOUR_KEY` query parameter returns **401 Unauthorized** on Jellyfin 12.
+    Use the `Authorization` header.
+
+### Elevation and user context
+
+All endpoints in the reference below are declared `[Authorize(Policy = "RequiresElevation")]` —
+they require an **administrator**. An API key satisfies that policy, so an API key is enough for
+everything documented here.
+
+There is one important difference between an API key and a logged-in admin's access token: an API
+key carries **no user identity**. Jellyfin issues no `Jellyfin-UserId` claim for it, so the plugin
+cannot infer "the current user" from the request.
+
+!!! warning "Collections need an explicit owner when you use an API key"
+    A smart collection has an owner whose watch state, favourites and play counts are used to
+    evaluate user-specific rules. With a logged-in admin token the plugin defaults that owner to
+    the caller. With an API key there is no caller to default to.
+
+    Send **`UserId`** (preferred) or **`CreatedByUserId`** in the request body when creating or
+    updating a collection with an API key. Omit both and you get:
+
+    ```json
+    {
+      "title": "Validation Error",
+      "status": 400,
+      "detail": "Collection owner could not be determined. Supply 'UserId' (or 'CreatedByUserId') in the request body when calling with an API key."
+    }
+    ```
+
+    Get valid user IDs from [`GET /Plugins/SmartLists/users`](#reference-data).
+
+Smart **playlists** are unaffected — they carry their owners explicitly in `UserPlaylists`, so
+they work identically with either credential.
+
+## OpenAPI
+
+Jellyfin publishes a machine-readable schema at:
+
+```
+/api-docs/openapi.json
+```
+
+The SmartLists routes appear in that document alongside the core Jellyfin API, so you can generate
+a typed client:
+
+```bash
+openapi-generator-cli generate \
+  -i http://localhost:8096/api-docs/openapi.json \
+  -g python \
+  -o ./jellyfin-client
+```
+
+!!! note "Fixed in this release"
+    Earlier plugin versions broke the whole document: four multipart upload actions declared their
+    `IFormFile` parameter as `[FromForm] IFormFile`, which Swashbuckle rejects. The schema generator
+    threw and returned HTTP 500 for `/api-docs/openapi.json` **server-wide**, not just for the
+    plugin's routes. That is fixed. If you get a 500 from that URL, you are on an older build —
+    upgrade the plugin.
+
+    Contributors adding a multipart endpoint: bind the file as a bare `IFormFile` parameter, never
+    `[FromForm] IFormFile`. MVC already binds `IFormFile` from the multipart body via
+    `BindingSourceMetadataProvider`, so the attribute changes nothing at runtime — it only downgrades
+    the binding source from `BindingSource.FormFile` to `BindingSource.Form`, which is the exact
+    combination the schema generator throws on. Add `[Consumes("multipart/form-data")]` too, so the
+    generated schema declares the right request shape.
+
+The generated schema is thin on error bodies (most error statuses are declared without a schema).
+Treat the [Error format](#error-format) section below as authoritative for those.
+
+## Endpoint reference
+
+All routes are relative to your Jellyfin server root, e.g.
+`http://localhost:8096/Plugins/SmartLists`.
+
+### Lists
+
+| Method | Route | Description |
+|--------|-------|-------------|
+| `GET` | `/Plugins/SmartLists` | All smart lists. Optional `?type=Playlist` or `?type=Collection` (case-insensitive). |
+| `GET` | `/Plugins/SmartLists/{id}` | A single smart list by ID. Looks in playlists first, then collections. |
+| `POST` | `/Plugins/SmartLists` | Create a list. Returns `201` with the stored list. Optional `?skipRefresh=true`. |
+| `PUT` | `/Plugins/SmartLists/{id}` | Replace a list. Returns `200` with the stored list. Optional `?skipRefresh=true`. |
+| `DELETE` | `/Plugins/SmartLists/{id}` | Delete a list. Returns `204`. Optional `?deleteJellyfinList=false`. |
+
+!!! warning "Query and body gotchas"
+    - **`?type=` is not validated.** Any value that is not exactly `Playlist` or `Collection`
+      returns `200` with an **empty array** rather than a `400`. `?type=playlists` (plural)
+      silently returns nothing.
+    - **`Type` is required** in the body on both `POST` and `PUT`. Send `"Playlist"` or
+      `"Collection"` (the numeric forms `0` and `1` also work). Omitting it fails deserialization
+      and returns a `400` with `errors["$"]`.
+    - **`PUT` with a different `Type` converts the list.** Sending `"Type": "Collection"` for an ID
+      that is currently a playlist deletes the Jellyfin playlist and rebuilds it as a collection
+      under the same smart-list ID. This is a destructive operation, not a validation error.
+    - **`DELETE` defaults to `deleteJellyfinList=true`**, which removes the real Jellyfin
+      playlist/collection as well as the smart-list configuration and any uploaded images. Pass
+      `?deleteJellyfinList=false` to keep the Jellyfin object — it stays behind, minus the
+      `[Smart]` suffix.
+    - **`skipRefresh=true`** stores the configuration without queueing a refresh. Useful when you
+      are about to make several writes and want a single refresh at the end.
+
+### Actions
+
+| Method | Route | Description |
+|--------|-------|-------------|
+| `POST` | `/Plugins/SmartLists/{id}/enable` | Enable a list, then queue a refresh. |
+| `POST` | `/Plugins/SmartLists/{id}/disable` | Disable a list and remove its Jellyfin playlist/collection. |
+| `POST` | `/Plugins/SmartLists/{id}/refresh` | Refresh one list. **Synchronous** — returns when done. |
+| `POST` | `/Plugins/SmartLists/refresh` | Refresh all **playlists**. |
+| `POST` | `/Plugins/SmartLists/refresh-direct` | Refresh all playlists **and** collections. |
+
+All five return `200` with `{ "message": "..." }`.
+
+!!! note "Refresh behaviour"
+    - `POST /{id}/refresh` blocks until the refresh completes. Expect a long-running request for a
+      large library, and set your client timeout accordingly.
+    - `POST /refresh` and `POST /refresh-direct` return **409 Conflict** when a refresh is already
+      running. Use **`refresh-direct`** for "refresh everything" — plain `refresh` skips
+      collections.
+    - Refreshing a disabled list returns `400`. Enable it first.
+
+### Reference data
+
+| Method | Route | Description |
+|--------|-------|-------------|
+| `GET` | `/Plugins/SmartLists/fields` | Every rule field, operator, field→operator map and sort option. |
+| `GET` | `/Plugins/SmartLists/users` | `[{ "Id", "Name" }]` — Jellyfin users, for `UserId` values. |
+| `GET` | `/Plugins/SmartLists/libraries` | `[{ "Id", "Name", "CollectionType" }]` — libraries, for `LibraryName` rules. |
+
+`GET /fields` returns an object with these keys, each a `[{ "Value", "Label" }]` array unless noted:
+
+`ContentFields`, `VideoFields`, `AudioFields`, `RatingsPlaybackFields`, `FileFields`,
+`LibraryFields`, `PeopleFields`, `PeopleSubFields`, `CollectionFields`,
+`SimilarityComparisonFields`, `Operators`, `FieldOperators`
+(field name → allowed operator names), `OrderOptions`.
+
+`Operators` is the full operator catalogue, in the same `[{ "Value", "Label" }]` shape as the field
+lists — `Value` is what you put in a rule's `Operator`, `Label` is the UI wording.
+
+`FieldOperators` is the authoritative answer to "which operators may I use with this field".
+
+### Status
+
+| Method | Route | Description |
+|--------|-------|-------------|
+| `GET` | `/Plugins/SmartLists/Status` | `{ ongoingOperations, history, statistics }`. |
+| `GET` | `/Plugins/SmartLists/Status/History` | The last refresh for each list. |
+| `GET` | `/Plugins/SmartLists/Status/Ongoing` | Refreshes in flight right now. |
+
+An entry in `ongoingOperations` (and in `Status/Ongoing`) contains:
+
+`listId`, `listName`, `listType`, `triggerType`, `startTime` (ISO 8601),
+`totalItems`, `processedItems`, `estimatedTimeRemaining` (seconds), `elapsedTime` (seconds),
+`errorMessage`, `batchCurrentIndex`, `batchTotalCount`.
+
+A `history` entry contains `listId`, `listName`, `listType`, `triggerType`, `startTime`,
+`endTime`, `duration` (seconds), `success`, `errorMessage`.
+
+`statistics` contains `totalLists`, `ongoingOperationsCount`, `queuedOperationsCount`,
+`lastRefreshTime`, `averageRefreshDuration` (seconds), `successfulRefreshes`, `failedRefreshes`.
+
+!!! tip "Where refresh failures surface"
+    A list can be created successfully and still never produce any items — for example if
+    `MediaTypes` is empty. The API returns `201` either way; the failure only appears in the
+    Jellyfin log and in `GET /Plugins/SmartLists/Status/History`. Check history after your first
+    refresh.
+
+## Worked examples
+
+The examples use these shell variables:
+
+```bash
+JF="http://localhost:8096"
+KEY="your-api-key"
+AUTH="Authorization: MediaBrowser Token=\"$KEY\""
+```
+
+### 1. Find a user ID
+
+Both playlists and collections need at least one Jellyfin user.
+
+```bash
+curl -sS "$JF/Plugins/SmartLists/users" -H "$AUTH"
+```
+
+```json
+[
+  { "Id": "d7fb16f13aea4aa79942dcc7cf22c655", "Name": "alice" }
+]
+```
+
+!!! note "GUID formats differ across the API"
+    User IDs come back **without dashes**. Smart-list IDs are returned **with** dashes. Both forms
+    parse on input, but string-comparing an ID from one endpoint against an ID from another will
+    fail — normalize before comparing.
+
+### 2. Create a smart playlist
+
+`Type`, `Name` and at least one owner in `UserPlaylists` are enforced by the API. `MediaTypes` is
+not enforced, but a list without it can never refresh — treat it as required:
+
+```bash
+curl -sS -X POST "$JF/Plugins/SmartLists" \
+  -H "$AUTH" -H "Content-Type: application/json" \
+  -d '{
+    "Type": "Playlist",
+    "Name": "My Smart Playlist",
+    "MediaTypes": ["Movie"],
+    "UserPlaylists": [{ "UserId": "d7fb16f13aea4aa79942dcc7cf22c655" }]
+  }'
+```
+
+A more realistic body, with rules, sorting and a cap:
+
+```json
+{
+  "Type": "Playlist",
+  "Name": "Recent Highly Rated Movies",
+  "MediaTypes": ["Movie"],
+  "UserPlaylists": [{ "UserId": "d7fb16f13aea4aa79942dcc7cf22c655" }],
+  "ExpressionSets": [
+    {
+      "Expressions": [
+        { "MemberName": "ProductionYear", "Operator": "GreaterThanOrEqual", "TargetValue": "2020" },
+        { "MemberName": "CommunityRating", "Operator": "GreaterThan", "TargetValue": "7.5" }
+      ]
+    }
+  ],
+  "Order": { "SortOptions": [{ "SortBy": "ReleaseDate", "SortOrder": "Descending" }] },
+  "MaxItems": 50,
+  "AutoRefresh": "OnLibraryChanges"
+}
+```
+
+The response is `201 Created` with the stored list, including the server-generated `Id`.
+
+### 3. Create a smart collection
+
+Collections take a single `UserId` instead of `UserPlaylists`. **With an API key this field is
+required** — see [Elevation and user context](#elevation-and-user-context).
+
+```bash
+curl -sS -X POST "$JF/Plugins/SmartLists" \
+  -H "$AUTH" -H "Content-Type: application/json" \
+  -d '{
+    "Type": "Collection",
+    "Name": "My Smart Collection",
+    "MediaTypes": ["Movie"],
+    "UserId": "d7fb16f13aea4aa79942dcc7cf22c655"
+  }'
+```
+
+!!! warning "Collection names must be unique"
+    Jellyfin keys collections by name. Creating a second collection whose formatted name collides
+    with an existing one returns `400`. Playlists have no such restriction.
+
+### 4. Trigger a refresh and poll for progress
+
+Single list, synchronous — this call returns only once the refresh has finished:
+
+```bash
+LIST_ID="3fa85f64-5717-4562-b3fc-2c963f66afa6"
+curl -sS -X POST "$JF/Plugins/SmartLists/$LIST_ID/refresh" -H "$AUTH"
+```
+
+Everything, playlists and collections:
+
+```bash
+curl -sS -X POST "$JF/Plugins/SmartLists/refresh-direct" -H "$AUTH"
+```
+
+Because `refresh-direct` can take a while, poll progress from a second connection:
+
+```bash
+curl -sS "$JF/Plugins/SmartLists/Status/Ongoing" -H "$AUTH"
+```
+
+```json
+[
+  {
+    "listId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    "listName": "Recent Highly Rated Movies",
+    "listType": "Playlist",
+    "triggerType": "Manual",
+    "startTime": "2026-01-01T12:00:00.0000000Z",
+    "totalItems": 1200,
+    "processedItems": 640,
+    "estimatedTimeRemaining": 4.2,
+    "elapsedTime": 7.9
+  }
+]
+```
+
+When the array is empty, nothing is running. Confirm the outcome in history:
+
+```bash
+curl -sS "$JF/Plugins/SmartLists/Status/History" -H "$AUTH"
+```
+
+### 5. Delete
+
+Remove the smart list **and** the Jellyfin playlist/collection it manages (the default):
+
+```bash
+curl -sS -X DELETE "$JF/Plugins/SmartLists/$LIST_ID" -H "$AUTH"
+```
+
+Remove only the SmartLists configuration, leaving the Jellyfin playlist/collection in place as a
+plain, no longer managed list:
+
+```bash
+curl -sS -X DELETE "$JF/Plugins/SmartLists/$LIST_ID?deleteJellyfinList=false" -H "$AUTH"
+```
+
+Both return `204 No Content`.
+
+## Rules, fields and operators
+
+Rules are not documented again here. The field names, their allowed operators and their value
+formats are in **[Fields and Operators](../user-guide/fields-and-operators.md)** — use the
+**JSON name** column for `MemberName`.
+
+For the live, authoritative list as your server actually has it, call
+`GET /Plugins/SmartLists/fields` (see [Reference data](#reference-data)).
+
+A few rule facts that bite integrators:
+
+- **Rule logic is structural, not a field.** Expressions inside one `ExpressionSet` are ANDed;
+  separate `ExpressionSets` are ORed. There is no `RuleLogic` property to send.
+- **`TargetValue` is always a string**, including numbers and booleans (`"2020"`, `"true"`).
+- **`IsIn` / `IsNotIn` take a semicolon-separated string**, not a JSON array:
+  `"TargetValue": "Action;Comedy"`. Matching is case-insensitive and by substring, so `"Act"`
+  matches `"Action"`. Commas are not separators.
+- **`NewerThan` / `OlderThan` need `number:unit`**, with unit one of `hours`, `days`, `weeks`,
+  `months`, `years` — e.g. `"3:days"`. `Weekday` takes an integer `0`–`6` (`0` = Sunday).
+- **Unknown media types are silently dropped.** `"MediaTypes": ["Film"]` returns `201` with
+  `MediaTypes: []`, and the list can then never refresh. Validate against
+  [Media Types](../user-guide/media-types.md) before sending.
+- **`SortBy` uses a different vocabulary from `OrderOptions`.** `OrderOptions` from `/fields` are
+  legacy combined strings like `"ReleaseDate Descending"`; `SortOptions` splits that into
+  `"SortBy": "ReleaseDate"` plus `"SortOrder": "Descending"`. An unrecognised `SortBy` silently
+  falls back to no sorting rather than erroring.
+- **Legacy fields are migrated on read.** A stored `IsPlayed` rule is returned as a
+  `PlaybackStatus` rule, so a rule you wrote may not be the rule you read back.
+- **Null values are omitted from responses.** An absent field means "unset", not `false`/`0`/`[]`.
+
+## Error format
+
+Every error body the plugin's controllers produce is
+[RFC 7807](https://datatracker.ietf.org/doc/html/rfc7807) `ProblemDetails`:
+
+```json
+{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.1",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "Invalid list ID format",
+  "traceId": "00-..."
+}
+```
+
+**Read `detail` for the human-readable message.** The HTTP status code always matches `status`.
+
+Request-body validation failures additionally carry an `errors` object
+(`ValidationProblemDetails`) with per-field messages. A missing `Type` discriminator, for example,
+comes back as:
+
+```json
+{
+  "title": "One or more validation errors occurred.",
+  "status": 400,
+  "errors": {
+    "$": ["Smart list JSON is missing required Type property."]
+  }
+}
+```
+
+!!! note "Three responses this does not cover"
+    Normalization happens inside the plugin's controllers, so responses produced before or outside
+    them keep their own shape. A robust client should also tolerate:
+
+    - a bare **`401`/`403`** with an empty body, from Jellyfin's authorization layer
+    - a plain-text **`500`** (`Error processing request.`) from Jellyfin's exception middleware
+    - Jellyfin's own core error bodies on core routes
+
+Success responses are unaffected: action endpoints still return `{ "message": "..." }` on `200`.
+
+## For Jellyfin plugin developers
+
+If you are writing another Jellyfin plugin and want to create or refresh smart lists, the answer
+is **call the REST API over loopback**. Referencing SmartLists' types directly does not work, and
+the reason is worth understanding before you try.
+
+### Why you cannot share types with this plugin
+
+Jellyfin loads each plugin into its **own `AssemblyLoadContext`**.
+`Emby.Server.Implementations/Plugins/PluginManager.cs` creates
+`new PluginLoadContext(plugin.Path)` once per plugin, and `PluginLoadContext` resolves assemblies
+through an `AssemblyDependencyResolver` scoped to that plugin's own folder, returning `null` — and
+so deferring to the Default context, which holds Jellyfin core and the BCL — when the assembly is
+not found there.
+
+The consequence for cross-plugin type sharing:
+
+- **Ship `Jellyfin.Plugin.SmartLists.dll` alongside your plugin** and your load context resolves it
+  from *your* folder. You get a second, independent copy of every type. `SmartPlaylistDto` from
+  your copy is a different `Type` from `SmartPlaylistDto` in ours, so a cast fails and
+  `GetRequiredService<ISmartListService>()` will not match our DI registration.
+- **Don't ship it**, and your context finds it in neither your folder nor the Default context, so
+  the reference fails to resolve at all.
+
+The DI container *is* shared across plugins. Assembly type identity is not, and DI resolution is
+keyed on type identity. There is no arrangement of references that makes this work.
+
+### Self-provisioning an API key
+
+A plugin does not have to ask the user to paste in a key. `IAuthenticationManager` from
+`MediaBrowser.Controller.Security` is injectable, and can create one at startup:
+
+```csharp
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Security;
+
+public sealed class SmartListsClientFactory(
+    IAuthenticationManager authenticationManager,
+    IServerApplicationHost appHost)
+{
+    private const string KeyName = "My Plugin (SmartLists integration)";
+
+    public async Task<HttpClient> CreateAsync()
+    {
+        // CreateApiKey returns Task, not the key itself - read it back by name.
+        var keys = await authenticationManager.GetApiKeys().ConfigureAwait(false);
+        var key = keys.FirstOrDefault(k => string.Equals(k.AppName, KeyName, StringComparison.Ordinal));
+
+        if (key is null)
+        {
+            await authenticationManager.CreateApiKey(KeyName).ConfigureAwait(false);
+            keys = await authenticationManager.GetApiKeys().ConfigureAwait(false);
+            key = keys.First(k => string.Equals(k.AppName, KeyName, StringComparison.Ordinal));
+        }
+
+        // Honours a configured base URL path; no trailing slash.
+        var baseUrl = appHost.GetApiUrlForLocalAccess(IPAddress.Loopback, allowHttps: false);
+
+        var client = new HttpClient { BaseAddress = new Uri(baseUrl + "/") };
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("MediaBrowser", $"Token=\"{key.AccessToken}\"");
+
+        return client;
+    }
+}
+```
+
+From there, `client.PostAsJsonAsync("Plugins/SmartLists", body)` behaves exactly like the curl
+examples above — including the requirement to send an explicit `UserId` when creating a
+collection, since an API key has no user identity.
+
+!!! tip "Be a good citizen"
+    Name the key after your plugin so the server owner can see what it is in **Dashboard →
+    Advanced → API Keys**, and delete it with `IAuthenticationManager.DeleteApiKey(accessToken)`
+    when your plugin is uninstalled.
+
+### An in-process API?
+
+An in-process typed facade — a small interface-only package both plugins could reference, loaded
+from the Default context — is possible, but it is only worth building if people actually want it.
+If you have a use case the REST API handles badly, open an issue on
+[GitHub](https://github.com/jyourstone/jellyfin-smartlists-plugin/issues) describing it.

--- a/docs/content/user-guide/advanced-configuration.md
+++ b/docs/content/user-guide/advanced-configuration.md
@@ -109,11 +109,8 @@ Rules in JSON use internal names, not the labels shown in the web interface:
 - `Operator` — e.g. `Equal`, `Contains`, `IsIn`, `GreaterThanOrEqual`, `MatchRegex`. Listed per operator type in [Fields and Operators](fields-and-operators.md#operators).
 - `TargetValue` — always a string, even for numbers (`"TargetValue": "2000"`).
 
-Administrators can also fetch the authoritative field list from the API (requires an admin API key):
-
-```
-GET /Plugins/SmartLists/fields
-```
+Administrators can also fetch the authoritative field list from the API — see
+[Integration API](../development/integration-api.md#reference-data).
 
 ### Gotchas
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
     - Common Use Cases: examples/common-use-cases.md
     - Advanced Examples: examples/advanced-examples.md
   - Development:
+    - Integration API: development/integration-api.md
     - Building Locally: development/building-locally.md
     - Debugging: development/debugging.md
     - Contributing: development/contributing.md


### PR DESCRIPTION
Opens the SmartLists REST API as a supported integration surface for external tools, scripts and other Jellyfin plugins — and documents it.

## Why

The REST API existed but had exactly one consumer: our own config pages. It was shaped by UI needs, undocumented, and inconsistent. Worse, it was breaking OpenAPI generation for the entire Jellyfin server.

## What changed

### OpenAPI generation was broken server-wide 🔴

`GET /api-docs/openapi.json` returned **HTTP 500 for all of Jellyfin** — not just our routes — whenever this plugin was installed. No client or plugin could generate a typed API client against any Jellyfin endpoint.

Root cause: four multipart actions declared `[FromForm] IFormFile`. The attribute is a runtime no-op (MVC already binds `IFormFile` from the multipart body via `BindingSourceMetadataProvider`) but it downgrades the binding source from `BindingSource.FormFile` to `BindingSource.Form`, which Swashbuckle rejects — it throws and aborts the whole document.

Fixed by binding the file as a bare `IFormFile`, plus `[Consumes("multipart/form-data")]` so the schema declares the right shape. The rule is recorded at all four call sites, in `CLAUDE.md`, and in the new docs page — previously it was written down nowhere.

### Collections were unusable with an API key

Owner resolution read the `Jellyfin-UserId` claim. API keys carry no claim, so callers got `401 "Please ensure you are logged in"` — advice an API key holder cannot act on.

- **Create** falls back to `CreatedByUserId` from the body, and returns `400` with actionable text when no owner can be determined.
- **Update** now **preserves the existing owner** when `UserId` is omitted. Omitting it means "leave ownership alone", not "reassign to me". This also closes a latent case where an admin editing another user's collection silently took ownership.

### Uniform error shape

Bodies were a mix of `ProblemDetails` and anonymous `{message}`/`{error}` objects.

A sealed `IResultFilter` attribute on the two SmartLists controllers rewrites `>=400` responses into RFC7807 `ProblemDetails`. It is applied **per-controller and never registered in `MvcOptions.Filters`**, so core Jellyfin responses are unreachable *by construction* rather than by a runtime type guard. Success bodies and already-typed `ProblemDetails` pass through untouched.

Frontend extraction consolidates into one `pickErrorText` helper — `handleApiError` drops from a 47-line shape ladder to a single call. This also repairs five sites that read only `.message`/`.error` (which would have degraded to generic text) and two that could print raw JSON at the user.

### Docs

New `docs/content/development/integration-api.md`: authentication with a Jellyfin API key, endpoint contract, worked `curl` examples, error format, and a **plugin developer** section explaining why each plugin's own `AssemblyLoadContext` prevents sharing types across plugins, and how to call the API over loopback instead.

## Verification

Against a live Jellyfin 12.0-rc3 container:

| Check | Result |
|---|---|
| `/api-docs/openapi.json` | **500 → 200**, 37 SmartLists paths |
| Core Jellyfin paths intact | ✅ |
| Core error bodies unchanged (blast radius) | ✅ byte-identical |
| Collection create, API key + `CreatedByUserId` | **401 → 201** |
| Collection create, no owner resolvable | **401 → 400**, actionable message |
| Collection update omitting `UserId` | owner preserved, not reassigned |
| All four multipart endpoints, real uploads | ✅ |
| Config page loads, no new exceptions | ✅ |
| Build net9.0 + net10.0, warnings-as-errors | ✅ 0 warnings |

## Notes for review

- The filter's scoping is the highest-risk property here — it is enforced structurally (attribute on two controllers, `ServiceRegistrator.cs` untouched) and verified by an A/B check on a core endpoint's error body.
- Bodies produced outside the MVC result pipeline are deliberately not normalized: `[Authorize]` challenges, framework model-binding 400s, and `ExceptionMiddleware` 500s. Documented rather than chased.
- No `ProducesResponseType` attributes were added; the generated schema stays thin on error bodies, and the docs page is authoritative for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9FFji6MP136o3bq298BWJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent RFC 7807-formatted error responses across SmartLists API endpoints.
  - Improved interface error messages for validation, upload, refresh, and server failures.
  - Collection creation now resolves ownership for API-key requests.

- **Bug Fixes**
  - Improved multipart file-upload handling and API documentation generation.
  - Preserved valid collection ownership during updates unless reassignment is required.

- **Documentation**
  - Added comprehensive Integration API guidance, authentication details, endpoint references, examples, and error handling.
  - Updated navigation and configuration guidance for API integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->