### PR TITLE
feat: add Scrob as an external list provider

### DIFF
--- a/Jellyfin.Plugin.SmartLists.Tests/Services/ExternalList/ScrobListProviderTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Services/ExternalList/ScrobListProviderTests.cs
@@ -1,0 +1,80 @@
+using Jellyfin.Plugin.SmartLists.Services.ExternalList;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Jellyfin.Plugin.SmartLists.Tests.Services.ExternalList;
+
+/// <summary>
+/// PRECONDITION: unlike the other six providers, ScrobListProvider talks to an admin-configured
+/// host rather than a fixed public domain, so CanHandle is a security gate - it must reject any
+/// URL whose origin differs from the configured server, or a non-admin user could point a rule
+/// (and the admin's API key) at an arbitrary host.
+///
+/// Plugin.Instance is never constructed in a test process, so CanHandle itself can only be
+/// observed in its unconfigured state. The comparison it delegates to takes the configured URL
+/// as a parameter, which is what makes the gate itself testable; both it and the list-ID path
+/// parser are internal, reached here through the InternalsVisibleTo wiring in
+/// Jellyfin.Plugin.SmartLists.csproj.
+/// </summary>
+public class ScrobListProviderTests
+{
+    // ---------------------------------------------------------------------------------
+    // MatchesConfiguredServer - the security gate: origin must match exactly
+    // ---------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("https://scrob.example.com/list/12", "https://scrob.example.com", true)]
+    [InlineData("https://scrob.example.com/list/12", "https://scrob.example.com/", true)]      // trailing slash on config
+    [InlineData("https://SCROB.EXAMPLE.COM/list/12", "https://scrob.example.com", true)]       // host compare is case-insensitive
+    [InlineData("http://192.168.1.50:7330/list/12", "http://192.168.1.50:7330", true)]         // LAN address with explicit port
+    [InlineData("https://scrob.example.com/api/proxy/lists/12", "https://scrob.example.com", true)]
+    [InlineData("http://scrob.example.com/list/12", "https://scrob.example.com", false)]       // scheme differs
+    [InlineData("https://scrob.example.com:8443/list/12", "https://scrob.example.com", false)] // port differs
+    [InlineData("https://evil.example.com/list/12", "https://scrob.example.com", false)]       // different host
+    [InlineData("https://sub.scrob.example.com/list/12", "https://scrob.example.com", false)]  // subdomain is not the host
+    [InlineData("https://scrob.example.com.evil.test/list/12", "https://scrob.example.com", false)] // suffix attack
+    [InlineData("ftp://scrob.example.com/list/12", "ftp://scrob.example.com", false)]          // non-http scheme
+    [InlineData("not-a-url", "https://scrob.example.com", false)]
+    [InlineData("", "https://scrob.example.com", false)]
+    [InlineData("https://scrob.example.com/list/12", null, false)]                             // server not configured
+    [InlineData("https://scrob.example.com/list/12", "", false)]
+    [InlineData("https://scrob.example.com/list/12", "scrob.example.com", false)]              // configured value lacks a scheme
+    public void MatchesConfiguredServer_AcceptsOnlyTheConfiguredOrigin(string url, string? configuredServerUrl, bool expected)
+    {
+        Assert.Equal(expected, ScrobListProvider.MatchesConfiguredServer(url, configuredServerUrl));
+    }
+
+    [Fact]
+    public void CanHandle_RejectsEverythingWhenServerNotConfigured()
+    {
+        // Fail closed: with no Plugin.Instance there is no configured server to match against.
+        Assert.Null(Plugin.Instance);
+
+        var provider = new ScrobListProvider(null!, NullLogger<ScrobListProvider>.Instance); // CanHandle issues no HTTP
+
+        Assert.False(provider.CanHandle("https://scrob.example.com/list/12"));
+    }
+
+    // ---------------------------------------------------------------------------------
+    // ParseListId - extracts the list ID from the accepted path forms
+    // ---------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("https://scrob.example/list/12", 12)]              // browser-copied form
+    [InlineData("https://scrob.example/list/12/", 12)]              // trailing slash tolerated
+    [InlineData("https://scrob.example/lists/12", 12)]              // tolerated alias
+    [InlineData("https://scrob.example/api/proxy/lists/12", 12)]    // raw proxy form
+    [InlineData("https://scrob.example/API/PROXY/LISTS/12", 12)]    // path match is case-insensitive
+    [InlineData("https://scrob.example/scrob/list/12", 12)]         // reverse-proxy sub-path deployment
+    [InlineData("https://scrob.example/list/0", null)]              // not a positive integer
+    [InlineData("https://scrob.example/list/-1", null)]             // not a positive integer
+    [InlineData("https://scrob.example/list/abc", null)]            // not numeric
+    [InlineData("https://scrob.example/list/", null)]               // missing id
+    [InlineData("https://scrob.example/movie/12", null)]            // wrong path segment
+    [InlineData("https://scrob.example/mylist/12", null)]           // segment must be exactly list/lists
+    [InlineData("https://scrob.example/list/12/extra", null)]       // trailing extra segment
+    [InlineData("not-a-url", null)]
+    public void ParseListId_ExtractsIdFromSupportedPathForms(string url, int? expected)
+    {
+        Assert.Equal(expected, ScrobListProvider.ParseListId(url));
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.SmartLists/Configuration/PluginConfiguration.cs
@@ -171,6 +171,18 @@ namespace Jellyfin.Plugin.SmartLists.Configuration
         public string? ListenBrainzUserToken { get; set; } = null;
 
         /// <summary>
+        /// Gets or sets the base URL of the self-hosted Scrob server (e.g. https://scrob.example.com)
+        /// for fetching external lists. Find your instance URL at https://github.com/ellite/scrob
+        /// </summary>
+        public string? ScrobServerUrl { get; set; } = null;
+
+        /// <summary>
+        /// Gets or sets the Scrob API key for fetching external lists.
+        /// Find it on your Scrob instance's Connections page.
+        /// </summary>
+        public string? ScrobApiKey { get; set; } = null;
+
+        /// <summary>
         /// Gets or sets how the User-Agent header for external list requests is chosen.
         /// </summary>
         public UserAgentMode UserAgentMode { get; set; } = UserAgentMode.Default;

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
@@ -2022,6 +2022,14 @@
             if (listenBrainzUserTokenEl) {
                 listenBrainzUserTokenEl.value = config.ListenBrainzUserToken || '';
             }
+            var scrobServerUrlEl = page.querySelector('#scrobServerUrl');
+            if (scrobServerUrlEl) {
+                scrobServerUrlEl.value = config.ScrobServerUrl || '';
+            }
+            var scrobApiKeyEl = page.querySelector('#scrobApiKey');
+            if (scrobApiKeyEl) {
+                scrobApiKeyEl.value = config.ScrobApiKey || '';
+            }
 
             // Load User-Agent settings
             var userAgentModeEl = page.querySelector('#userAgentMode');
@@ -2262,6 +2270,10 @@
             config.TmdbApiKey = tmdbApiKeyInput ? (tmdbApiKeyInput.value.trim() || null) : null;
             var listenBrainzUserTokenInput = page.querySelector('#listenBrainzUserToken');
             config.ListenBrainzUserToken = listenBrainzUserTokenInput ? (listenBrainzUserTokenInput.value.trim() || null) : null;
+            var scrobServerUrlInput = page.querySelector('#scrobServerUrl');
+            config.ScrobServerUrl = scrobServerUrlInput ? (scrobServerUrlInput.value.trim() || null) : null;
+            var scrobApiKeyInput = page.querySelector('#scrobApiKey');
+            config.ScrobApiKey = scrobApiKeyInput ? (scrobApiKeyInput.value.trim() || null) : null;
 
             // Save User-Agent settings
             var userAgentModeInput = page.querySelector('#userAgentMode');

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-rules.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-rules.js
@@ -1195,7 +1195,7 @@
             '</div>' +
             '<div class="rule-externallist-options" style="display: none; margin-bottom: 0.75em; padding: 0.5em; background: var(--jf-palette-background-paper); border: 1px solid var(--jf-palette-divider); border-radius: 4px;">' +
             '<div style="font-size: 0.85em; opacity: 0.8; display: flex; align-items: center;">' +
-            '<span>Enter an external list URL. Supported: MDBList, IMDb, Trakt, TMDB, Letterboxd, ListenBrainz. Music lists match by MusicBrainz tags, with title/artist fallback.</span>' +
+            '<span>Enter an external list URL. Supported: MDBList, IMDb, Trakt, TMDB, Letterboxd, ListenBrainz, Scrob. Music lists match by MusicBrainz tags, with title/artist fallback.</span>' +
             '<a href="https://jellyfin-smartlists-plugin.dinsten.se/user-guide/external-lists/" target="_blank" rel="noopener noreferrer" title="Documentation" style="margin-left: 0.5em; text-decoration: none; color: inherit; display: inline-flex; align-items: center;">' +
             '<span class="material-icons" aria-hidden="true" style="font-size: 1.1em; line-height: 0;">info_outline</span>' +
             '</a>' +

--- a/Jellyfin.Plugin.SmartLists/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config.html
@@ -983,6 +983,28 @@
                             </div>
                         </div>
 
+                        <div class="inputContainer" style="margin-bottom: 1em;">
+                            <label class="inputLabel" for="scrobServerUrl">Scrob Server URL</label>
+                            <input type="text" id="scrobServerUrl" class="emby-input"
+                                placeholder="https://scrob.example.com">
+                            <div class="fieldDescription">The base URL of your self-hosted Scrob instance - the
+                                same URL you use to open it in your browser. List URLs in rules must use this
+                                exact address (same scheme, host and port) or they won't be recognised.</div>
+                        </div>
+
+                        <div class="inputContainer" style="margin-bottom: 1em;">
+                            <label class="inputLabel" for="scrobApiKey">Scrob API Key</label>
+                            <input type="password" id="scrobApiKey" class="emby-input"
+                                placeholder="Enter your Scrob API key">
+                            <div class="fieldDescription">Find your key on your Scrob instance's Connections page.
+                                Lists are referenced by their browser URL ({server}/list/{id}); only lists visible
+                                to that Scrob account can be used. See the
+                                <a href="https://jellyfin-smartlists-plugin.dinsten.se/user-guide/external-lists/"
+                                    target="_blank" rel="noopener noreferrer"
+                                    style="color: inherit;">documentation</a> for details.
+                            </div>
+                        </div>
+
                         <div class="selectContainer" style="margin-bottom: 1em;">
                             <label class="selectLabel" for="userAgentMode">User-Agent</label>
                             <select is="emby-select" id="userAgentMode" class="emby-select">

--- a/Jellyfin.Plugin.SmartLists/ServiceRegistrator.cs
+++ b/Jellyfin.Plugin.SmartLists/ServiceRegistrator.cs
@@ -1,3 +1,4 @@
+using System.Net.Http;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Plugins;
 using Microsoft.Extensions.DependencyInjection;
@@ -44,7 +45,15 @@ namespace Jellyfin.Plugin.SmartLists
             serviceCollection.AddSingleton<IExternalListProvider, TmdbListProvider>();
             serviceCollection.AddSingleton<IExternalListProvider, LetterboxdListProvider>();
             serviceCollection.AddSingleton<IExternalListProvider, ListenBrainzListProvider>();
+            serviceCollection.AddSingleton<IExternalListProvider, ScrobListProvider>();
             serviceCollection.AddSingleton<ExternalListService>();
+
+            // Scrob is the only provider that sends a secret in a custom header (X-Api-Key) to an
+            // admin-configured host. .NET strips Authorization on a cross-origin redirect but replays
+            // custom headers verbatim, so an auth-proxy redirect (or a hijacked domain) would hand the
+            // admin's key to a third-party host. Disable redirects: a 3xx is reported as an error instead.
+            serviceCollection.AddHttpClient("Scrob")
+                .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler { AllowAutoRedirect = false });
 
             // Register backup service
             serviceCollection.AddSingleton<IBackupService, BackupService>();

--- a/Jellyfin.Plugin.SmartLists/Services/ExternalList/ScrobListProvider.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/ExternalList/ScrobListProvider.cs
@@ -169,17 +169,18 @@ namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
             }
             catch (JsonException ex)
             {
-                _logger.LogWarning(ex, "Failed to parse Scrob API response for list {ListId}", listId);
+                // Same reasoning as the failure status below: an empty-but-complete result silently
+                // empties the list (or, for a NotEqual rule, matches the whole library) with no warning.
+                throw new InvalidOperationException(
+                    $"Scrob returned a response for list {listId} that could not be read. Check that the "
+                    + "Scrob Server URL in Settings > External Lists points at Scrob itself.", ex);
             }
             catch (HttpRequestException)
             {
-                // Same reasoning as the failure status below (and the same as TraktListProvider):
-                // an unreachable server must not be reported as an empty list.
+                // Same reasoning, and the same as TraktListProvider: an unreachable server must not be
+                // reported as an empty list. Anything else unexpected propagates for the same reason —
+                // ExternalListService logs it and records a refresh warning.
                 throw;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Unexpected error fetching Scrob list {ListId}", listId);
             }
 
             if (failureStatus != null)

--- a/Jellyfin.Plugin.SmartLists/Services/ExternalList/ScrobListProvider.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/ExternalList/ScrobListProvider.cs
@@ -1,0 +1,272 @@
+using System;
+using System.Globalization;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
+{
+    /// <summary>
+    /// Fetches list items from a self-hosted Scrob instance (github.com/ellite/scrob) via its
+    /// Astro frontend proxy at /api/proxy/lists/{id}. The server URL and API key are admin-configured
+    /// (Settings > External Lists) — CanHandle only matches URLs whose scheme/host/port equal the
+    /// configured server, so a non-admin user can never point a rule at an arbitrary host.
+    /// Supports URLs like {server}/list/{id}, {server}/lists/{id}, and {server}/api/proxy/lists/{id}.
+    /// </summary>
+    public partial class ScrobListProvider : IExternalListProvider
+    {
+        private static readonly string UserAgent =
+            "JellyfinSmartLists/" + (typeof(ScrobListProvider).Assembly.GetName().Version?.ToString() ?? "1.0")
+            + " (+https://github.com/jyourstone/jellyfin-smartlists-plugin)";
+
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ILogger<ScrobListProvider> _logger;
+
+        public ScrobListProvider(IHttpClientFactory httpClientFactory, ILogger<ScrobListProvider> logger)
+        {
+            _httpClientFactory = httpClientFactory;
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        public bool CanHandle(string url)
+        {
+            return MatchesConfiguredServer(url, Plugin.Instance?.Configuration?.ScrobServerUrl);
+        }
+
+        /// <summary>
+        /// Checks whether a user-supplied list URL points at the admin-configured Scrob server.
+        /// This is the security gate for this provider: Scrob's host comes from configuration rather
+        /// than from a fixed public domain, so a rule may only reference the configured origin —
+        /// scheme, host and port must all match.
+        /// </summary>
+        /// <param name="url">The user-supplied external list URL.</param>
+        /// <param name="configuredServerUrl">The admin-configured Scrob server URL.</param>
+        /// <returns>True when the URL targets the configured server.</returns>
+        internal static bool MatchesConfiguredServer(string url, string? configuredServerUrl)
+        {
+            if (string.IsNullOrWhiteSpace(url) || !Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            {
+                return false;
+            }
+
+            if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
+            {
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(configuredServerUrl) || !Uri.TryCreate(configuredServerUrl, UriKind.Absolute, out var configuredUri))
+            {
+                return false;
+            }
+
+            return string.Equals(uri.Scheme, configuredUri.Scheme, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(uri.Host, configuredUri.Host, StringComparison.OrdinalIgnoreCase)
+                && uri.Port == configuredUri.Port;
+        }
+
+        /// <inheritdoc />
+        public async Task<ExternalListResult> FetchListAsync(string url, CancellationToken cancellationToken, int maxItems = 0)
+        {
+            var result = new ExternalListResult();
+
+            var serverUrl = Plugin.Instance?.Configuration?.ScrobServerUrl;
+            if (string.IsNullOrWhiteSpace(serverUrl))
+            {
+                throw new InvalidOperationException(
+                    "Scrob server URL is not configured. Set the server URL in Settings > External Lists.");
+            }
+
+            var apiKey = Plugin.Instance?.Configuration?.ScrobApiKey;
+            if (string.IsNullOrWhiteSpace(apiKey))
+            {
+                throw new InvalidOperationException(
+                    "Scrob API key is not configured. Set the API key in Settings > External Lists.");
+            }
+
+            var listId = ParseListId(url);
+            if (listId == null)
+            {
+                throw new InvalidOperationException(
+                    "Invalid Scrob list URL. Supported formats: {server}/list/{id}, {server}/lists/{id}, " +
+                    "{server}/api/proxy/lists/{id}.");
+            }
+
+            _logger.LogInformation("Fetching Scrob list {ListId}", listId);
+
+            // Always request against the admin-configured host, never the user-supplied URL's host.
+            var requestUrl = $"{serverUrl.TrimEnd('/')}/api/proxy/lists/{listId.Value.ToString(CultureInfo.InvariantCulture)}";
+            var httpClient = _httpClientFactory.CreateClient("Scrob");
+
+            int position = 0;
+            HttpStatusCode? failureStatus = null;
+
+            try
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
+                request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                request.Headers.TryAddWithoutValidation("User-Agent", ExternalListUserAgent.Resolve(UserAgent));
+                request.Headers.Add("X-Api-Key", apiKey);
+
+                using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    // Recorded here and thrown after the try block: the catch-all below would
+                    // otherwise swallow it, and an empty-but-complete result silently empties the
+                    // list (or, for a NotEqual rule, matches the whole library) with no warning.
+                    failureStatus = response.StatusCode;
+                }
+                else
+                {
+                    var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                    var items = JsonSerializer.Deserialize<ScrobListResponse>(json)?.Items ?? [];
+
+                    foreach (var item in items)
+                    {
+                        var media = item.Media;
+                        var kind = GetItemKind(media?.Type);
+
+                        // Scrob lists can also hold people (its UI has an add-to-list button on person
+                        // pages). A TMDB person ID shares the numeric range of movie/series IDs, and the
+                        // Unknown bucket is a cross-kind fallback for every library item, so storing one
+                        // would drag an unrelated title into the list. Skip unrecognised kinds instead,
+                        // still advancing the position so the remaining items keep their list order.
+                        if (media == null || kind == ExternalListItemKind.Unknown)
+                        {
+                            position++;
+                            continue;
+                        }
+
+                        // For episodes Scrob resolved from TVDB (no TMDB counterpart) tmdb_id holds the
+                        // TVDB *episode* ID, flagged by tvdb_sourced — route it to the TVDB bucket.
+                        var isTvdbEpisode = kind == ExternalListItemKind.Episode && media.TvdbSourced;
+                        var tmdbId = isTvdbEpisode ? null : media.TmdbId;
+                        var tvdbId = isTvdbEpisode
+                            ? media.TmdbId
+                            : (kind == ExternalListItemKind.Show ? media.ShowTvdbId : null);
+
+                        result.AddProviderIds(kind, null, tmdbId, tvdbId, position);
+                        position++;
+
+                        // Stop early if we have enough items
+                        if (maxItems > 0 && position >= maxItems)
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogDebug("Scrob fetch cancelled for list {ListId}", listId);
+                throw;
+            }
+            catch (JsonException ex)
+            {
+                _logger.LogWarning(ex, "Failed to parse Scrob API response for list {ListId}", listId);
+            }
+            catch (HttpRequestException)
+            {
+                // Same reasoning as the failure status below (and the same as TraktListProvider):
+                // an unreachable server must not be reported as an empty list.
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Unexpected error fetching Scrob list {ListId}", listId);
+            }
+
+            if (failureStatus != null)
+            {
+                // Throwing (rather than returning empty) is what gets the reason in front of the
+                // user: ExternalListService only records a refresh warning when a provider throws.
+                throw new InvalidOperationException(DescribeFailure(failureStatus.Value, listId.Value));
+            }
+
+            result.TotalItems = position;
+            result.IsComplete = maxItems <= 0 || position < maxItems;
+            _logger.LogInformation(
+                "Fetched {Count} items from Scrob list {ListId} (TMDB: {TmdbCount}, TVDB: {TvdbCount})",
+                position, listId, result.TmdbIds.Count, result.TvdbIds.Count);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Turns a Scrob error status into a message that says what the user actually needs to fix.
+        /// </summary>
+        private static string DescribeFailure(HttpStatusCode statusCode, int listId)
+        {
+            return statusCode switch
+            {
+                HttpStatusCode.Unauthorized =>
+                    "Scrob rejected the API key. Check the key in Settings > External Lists.",
+
+                // Scrob's list endpoint treats an unrecognised API key as an anonymous visitor rather
+                // than rejecting it, so a wrong or revoked key also surfaces here as 403 — name both causes.
+                HttpStatusCode.Forbidden =>
+                    $"Scrob denied access to list {listId}. Either the API key is wrong or revoked, or the list "
+                    + "is private and not owned by that Scrob account. Check the key in Settings > External Lists.",
+                HttpStatusCode.NotFound =>
+                    $"Scrob list {listId} was not found. Check the list ID and the configured server URL.",
+
+                // Redirects are not followed: the API key travels in a custom header, which .NET replays
+                // verbatim to the redirect target (unlike Authorization, which it strips).
+                _ when (int)statusCode is >= 300 and < 400 =>
+                    $"The configured Scrob server URL redirects elsewhere ({(int)statusCode}). Set the Scrob Server "
+                    + "URL in Settings > External Lists to the address that serves Scrob directly, so the API key is "
+                    + "never sent to another host.",
+                _ => $"Scrob API returned {statusCode} for list {listId}."
+            };
+        }
+
+        private static ExternalListItemKind GetItemKind(string? mediaType)
+        {
+            return mediaType?.Trim().ToLowerInvariant() switch
+            {
+                "movie" => ExternalListItemKind.Movie,
+                "series" => ExternalListItemKind.Show,
+                "episode" => ExternalListItemKind.Episode,
+                _ => ExternalListItemKind.Unknown
+            };
+        }
+
+        /// <summary>
+        /// Parses the list ID out of a Scrob URL path: /list/{id}, /lists/{id}, or /api/proxy/lists/{id},
+        /// optionally behind a reverse-proxy sub-path (e.g. /scrob/list/{id}).
+        /// Returns null when the URL is not one of those forms or the ID is not a positive integer.
+        /// </summary>
+        internal static int? ParseListId(string url)
+        {
+            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            {
+                return null;
+            }
+
+            var match = ListPathPattern().Match(uri.AbsolutePath);
+            if (!match.Success)
+            {
+                return null;
+            }
+
+            return int.TryParse(match.Groups[1].Value, CultureInfo.InvariantCulture, out var id) && id > 0
+                ? id
+                : null;
+        }
+
+        /// <summary>
+        /// Matches /list/{id}, /lists/{id}, and /api/proxy/lists/{id}. A leading sub-path is tolerated
+        /// so a proxied deployment ({server}/scrob/list/{id}) parses: the host is already pinned by
+        /// <see cref="MatchesConfiguredServer"/> and the request URL is rebuilt from the configured
+        /// server, so only the ID is taken from the user string.
+        /// </summary>
+        [GeneratedRegex(@"(?:^|/)(?:api/proxy/)?lists?/(\d+)/?$", RegexOptions.IgnoreCase)]
+        private static partial Regex ListPathPattern();
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Services/ExternalList/ScrobListProvider.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/ExternalList/ScrobListProvider.cs
@@ -125,7 +125,12 @@ namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
                 else
                 {
                     var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-                    var items = JsonSerializer.Deserialize<ScrobListResponse>(json)?.Items ?? [];
+                    // A missing items collection means this is not a Scrob list response (an error
+                    // envelope, another app on the configured URL, ...). Treating it as an empty list
+                    // would be the same silent failure as a parse error, so make it one. A real list
+                    // with no items still deserializes to an empty array and passes through.
+                    var items = JsonSerializer.Deserialize<ScrobListResponse>(json)?.Items
+                        ?? throw new JsonException("The Scrob response did not contain an items collection.");
 
                     foreach (var item in items)
                     {

--- a/Jellyfin.Plugin.SmartLists/Services/ExternalList/ScrobModels.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/ExternalList/ScrobModels.cs
@@ -1,0 +1,53 @@
+using System.Text.Json.Serialization;
+
+namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
+{
+    /// <summary>
+    /// Response from the Scrob list endpoint (/api/proxy/lists/{id}).
+    /// Items are already sorted by (sort_order, added_at) server-side, so array index reflects list position.
+    /// </summary>
+    public class ScrobListResponse
+    {
+        [JsonPropertyName("items")]
+        public ScrobListItem[]? Items { get; set; }
+    }
+
+    /// <summary>
+    /// A single item entry in a Scrob list.
+    /// </summary>
+    public class ScrobListItem
+    {
+        [JsonPropertyName("media")]
+        public ScrobMedia? Media { get; set; }
+    }
+
+    /// <summary>
+    /// The media referenced by a Scrob list item.
+    /// </summary>
+    public class ScrobMedia
+    {
+        [JsonPropertyName("tmdb_id")]
+        public int? TmdbId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the media kind: "movie", "series", or "episode".
+        /// </summary>
+        [JsonPropertyName("type")]
+        public string? Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the series' TVDB ID. Only populated for episode items and for
+        /// season items (type "series" with a non-null season_number).
+        /// </summary>
+        [JsonPropertyName("show_tvdb_id")]
+        public int? ShowTvdbId { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether this episode row was built from TVDB because it has no TMDB
+        /// counterpart. Scrob stores the TVDB episode ID in <see cref="TmdbId"/> for those rows,
+        /// so the ID must not be treated as a TMDB ID.
+        /// </summary>
+        [JsonPropertyName("tvdb_sourced")]
+        public bool TvdbSourced { get; set; }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This plugin allows you to create dynamic playlists and collections based on a se
 ## ✨ Features
 
 - **Modern Web Interface** - A full-featured UI to create, manage and view status for smart playlists and collections
-- **External Lists** - Populate lists from [MDBList](https://mdblist.com), [IMDb](https://www.imdb.com), [Letterboxd](https://letterboxd.com), [Trakt](https://trakt.tv), [TMDB](https://www.themoviedb.org), and [ListenBrainz](https://listenbrainz.org) — trending charts, watchlists, top lists, music playlists, and more
+- **External Lists** - Populate lists from [MDBList](https://mdblist.com), [IMDb](https://www.imdb.com), [Letterboxd](https://letterboxd.com), [Trakt](https://trakt.tv), [TMDB](https://www.themoviedb.org), [ListenBrainz](https://listenbrainz.org), and [Scrob](https://github.com/ellite/scrob) — trending charts, watchlists, top lists, music playlists, and more
 - **Flexible Rules** - Build simple or complex rules with an intuitive builder
 - **Automatic Updates** - Playlists and collections refresh automatically on library updates, playback status changes, or via scheduled tasks
 - **Refresh Status & Statistics** - Monitor ongoing refresh operations with real-time progress, view refresh history, and track statistics for all your lists

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -30,12 +30,12 @@ SmartLists creates rule-based playlists and collections that refresh automatical
 - Refreshes lists automatically when library content or playback state changes
 - Supports movies, shows, episodes, music, photos, books, and more
 - Lets administrators and regular users manage lists through the Jellyfin web UI
-- Supports external sources such as IMDb, TMDB, Trakt, MDBList, Letterboxd, and ListenBrainz
+- Supports external sources such as IMDb, TMDB, Trakt, MDBList, Letterboxd, ListenBrainz, and Scrob
 
 ## Features
 
 - **Modern Web Interface** - A full-featured UI to create, manage and view status for smart playlists and collections
-- **External Lists** - Populate lists from [MDBList](https://mdblist.com), [IMDb](https://www.imdb.com), [Letterboxd](https://letterboxd.com), [Trakt](https://trakt.tv), [TMDB](https://www.themoviedb.org), and [ListenBrainz](https://listenbrainz.org)
+- **External Lists** - Populate lists from [MDBList](https://mdblist.com), [IMDb](https://www.imdb.com), [Letterboxd](https://letterboxd.com), [Trakt](https://trakt.tv), [TMDB](https://www.themoviedb.org), [ListenBrainz](https://listenbrainz.org), and [Scrob](https://github.com/ellite/scrob)
 - **User Selection** - Choose which users should own a playlist or collection with an intuitive dropdown
 - **Flexible Rules** - Build simple or complex rules with an intuitive builder
 - **Automatic Updates** - Playlists and collections refresh automatically on library updates, playback status changes, or via scheduled tasks

--- a/docs/content/user-guide/external-lists.md
+++ b/docs/content/user-guide/external-lists.md
@@ -205,6 +205,9 @@ List items are matched in the order Scrob returns them, so **External List Order
 !!! warning "Matching Requires TMDB IDs"
     Scrob doesn't store IMDb IDs — items match on TMDB ID, plus the series TVDB ID for season entries and the episode TVDB ID for episodes Scrob resolved from TVDB. Library items with none of those won't match.
 
+!!! note "Seasons Match the Whole Series"
+    A season added to a Scrob list is matched as its parent series, so the rule pulls in the whole show rather than that one season. This is the same behaviour as season entries in Trakt lists. Person entries are ignored entirely.
+
 ---
 
 ### Trakt

--- a/docs/content/user-guide/external-lists.md
+++ b/docs/content/user-guide/external-lists.md
@@ -1,6 +1,6 @@
 # External Lists
 
-External Lists let you populate smart lists from external services like MDBList, IMDb, Letterboxd, Trakt, TMDB, and ListenBrainz. Use them to create collections based on trending lists, watchlists, top charts, curated lists, and music playlists from these services.
+External Lists let you populate smart lists from external services like MDBList, IMDb, Letterboxd, Trakt, TMDB, ListenBrainz, and Scrob. Use them to create collections based on trending lists, watchlists, top charts, curated lists, and music playlists from these services.
 
 ## How It Works
 
@@ -18,6 +18,7 @@ Items are matched by comparing provider IDs between the external list and your l
 | **IMDb** | No | IMDb |
 | **Letterboxd** | No | TMDB |
 | **ListenBrainz** | No (optional user token) | MusicBrainz recording ID (title + artist fallback) |
+| **Scrob** | Yes | TMDB, TVDB |
 | **Trakt** | Yes (client ID) | IMDb, TMDB, TVDB |
 | **TMDB** | Yes | TMDB |
 
@@ -169,6 +170,43 @@ External List / equals / https://listenbrainz.org/syndication-feed/user/rob/reco
 
 ---
 
+### Scrob
+
+[Scrob](https://github.com/ellite/scrob) is a self-hosted media tracker with user-created lists. Because it's self-hosted, the admin configures the Scrob server URL and API key once for the whole plugin, in the same place as the other provider credentials.
+
+**Setup:**
+
+1. Enter your Scrob server URL — the same URL you use in your browser, e.g. `https://scrob.example.com` — in the plugin **Settings** tab under **External Lists > Scrob Server URL**
+2. Go to your Scrob instance's **Connections** page and copy your API key
+3. Enter the API key under **External Lists > Scrob API Key**
+
+**Supported URLs:**
+
+| Type | URL format |
+|------|-----------|
+| User list | `{server}/list/{id}` |
+
+**Example:**
+
+```
+External List / equals / https://scrob.example.com/list/12
+```
+
+List items are matched in the order Scrob returns them, so **External List Order** sort works the same as with the other providers.
+
+!!! note "List URLs Must Match the Configured Server"
+    A list URL is only recognised when it uses the exact address configured in **Settings** — same scheme, host and port. If you configured `https://scrob.example.com`, then `http://192.168.1.50:7330/list/12` won't be recognised even though it's the same Scrob instance.
+
+!!! note "Only Lists Visible to the Configured Account"
+    The configured API key determines what's accessible: your own lists always work, and other users' lists work only if they're public. A private list belonging to a different Scrob user returns an error.
+
+    Note that this is a grant, not just a limit: one key is shared by the whole Jellyfin server, so **every user allowed to create smart lists can reference any list that key can see** — including the key owner's private lists. Use a Scrob account whose visibility you're happy to share.
+
+!!! warning "Matching Requires TMDB IDs"
+    Scrob doesn't store IMDb IDs — items match on TMDB ID, plus the series TVDB ID for season entries and the episode TVDB ID for episodes Scrob resolved from TVDB. Library items with none of those won't match.
+
+---
+
 ### Trakt
 
 [Trakt](https://trakt.tv) is a popular tracking service with user lists, watchlists, and curated charts. The plugin uses the Trakt API which requires a client ID.
@@ -315,7 +353,7 @@ The plugin sends a User-Agent header when fetching external lists. Each provider
 - **Clone**: Uses your browser's User-Agent, captured once when you save the settings.
 - **Custom**: Uses exactly the value you enter in the text field.
 
-The clone modes capture the User-Agent from the browser you access the admin configuration page with. The override applies to all providers that send a User-Agent (IMDb, Letterboxd, Trakt, ListenBrainz).
+The clone modes capture the User-Agent from the browser you access the admin configuration page with. The override applies to all providers that send a User-Agent (IMDb, Letterboxd, Trakt, ListenBrainz, Scrob).
 
 ---
 

--- a/docs/content/user-guide/fields-and-operators.md
+++ b/docs/content/user-guide/fields-and-operators.md
@@ -194,7 +194,7 @@ Filter by cast and crew members. Select "People" in the field dropdown, then cho
 | **Album** | `Album` | Album name (music) |
 | **Artists** | `Artists` | Track-level artists (music) |
 | **Album Artists** | `AlbumArtists` | Album-level primary artists (music) |
-| **External List** | `ExternalList` | Match items from an external list (MDBList, IMDb, Letterboxd, Trakt, TMDB, ListenBrainz). [See details below.](#external-list) |
+| **External List** | `ExternalList` | Match items from an external list (MDBList, IMDb, Letterboxd, Trakt, TMDB, ListenBrainz, Scrob). [See details below.](#external-list) |
 
 **Parent metadata options** for Tags, Studios, and Genres (shown when Episode or Audio media type is selected):
 
@@ -265,7 +265,7 @@ Filter items based on Jellyfin playlist membership.
 
 #### External List
 
-Filter items based on membership in an external list. Supports [MDBList](https://mdblist.com), [IMDb](https://www.imdb.com), [Letterboxd](https://letterboxd.com), [Trakt](https://trakt.tv), [TMDB](https://www.themoviedb.org), and [ListenBrainz](https://listenbrainz.org) — including user lists, watchlists, charts/trending, and music playlists.
+Filter items based on membership in an external list. Supports [MDBList](https://mdblist.com), [IMDb](https://www.imdb.com), [Letterboxd](https://letterboxd.com), [Trakt](https://trakt.tv), [TMDB](https://www.themoviedb.org), [ListenBrainz](https://listenbrainz.org), and [Scrob](https://github.com/ellite/scrob) — including user lists, watchlists, charts/trending, and music playlists.
 
 | Provider | API key required | Matches by |
 |----------|-----------------|------------|
@@ -273,6 +273,7 @@ Filter items based on membership in an external list. Supports [MDBList](https:/
 | **IMDb** | No | IMDb |
 | **Letterboxd** | No | TMDB |
 | **ListenBrainz** | No (optional user token) | MusicBrainz recording ID (title + artist fallback) |
+| **Scrob** | Yes | TMDB, TVDB |
 | **Trakt** | Yes (client ID) | IMDb, TMDB, TVDB |
 | **TMDB** | Yes | TMDB |
 


### PR DESCRIPTION
Closes #488

Adds [Scrob](https://github.com/ellite/scrob) — a self-hosted media tracker with user lists — as an external list provider.

## How it works

Scrob is self-hosted, so unlike every other provider its host is not a fixed public domain. The admin configures the server URL and an API key once under **Settings → External Lists**; users then reference a list by its browser URL, `{server}/list/{id}`.

Lists are fetched through Scrob's frontend proxy (`GET {server}/api/proxy/lists/{id}`) — its FastAPI backend is not exposed externally. The response returns all items in one request, already ordered, so `sort_order` maps directly to list position and the **External List Order** sort works with it.

Matching is by TMDB ID (Scrob stores no IMDb IDs), plus TVDB for shows and for episodes Scrob resolved from TVDB (`tvdb_sourced`, where `tmdb_id` actually holds a TVDB episode ID). Person entries are skipped — a TMDB person ID shares a numeric range with movie and series IDs, and the unknown-kind bucket is a cross-kind fallback, so storing one would drag an unrelated title into the list.

## Security

Every existing provider hardcodes its host. This one takes it from configuration, and non-admin users can put arbitrary strings into a rule, so the provider is host-pinned:

- `CanHandle` returns false unless the URL's scheme, host **and** port equal the configured server. A rule can never cause a request to a host the admin did not configure.
- The request URL is rebuilt from the configured server plus a validated positive-integer list ID — never by string-editing the user-supplied URL.
- The API key is sent as an `X-Api-Key` header, never a query parameter, and is never logged.
- The named `Scrob` HttpClient disables auto-redirect. .NET strips `Authorization` on a cross-origin redirect but replays custom headers verbatim, so an auth-proxy redirect (or a hijacked domain) would otherwise hand the key to a third-party host. A 3xx now surfaces as an actionable error.

One trade-off worth stating plainly: a single global key means every user who can create a smart list can read any list that key can see, including the configured account's private lists. This is documented as a grant rather than a limitation.

## Failure behaviour

Non-success responses and connection failures throw rather than returning an empty list — `ExternalListService` only records a refresh warning when a provider throws, and a silently empty list also inverts `NotEqual` rules into whole-library matches. 401/403/404 get distinct, actionable messages (Scrob treats an unrecognised key as an anonymous visitor, so a bad key surfaces as 403).

## Verification

- `dotnet build` clean on both TFMs (net9.0 / net10.0), 0 warnings under `TreatWarningsAsErrors` + `AnalysisMode=Recommended`
- `dotnet test`: 545 passed, including 31 new `ScrobListProviderTests` covering host pinning (case, port, scheme, userinfo, subdomain), URL parsing, and list-ID validation
- Docs updated: new **Scrob** section in the external lists guide, plus the provider tables in `fields-and-operators.md`, `index.md`, README, and the rule-builder hint

Not yet exercised against a live Scrob instance — static verification only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uoHfi9qvEJYXR7AdZNEC5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing external lists from self-hosted Scrob servers.
  * Added configuration fields for the Scrob server URL and API key.
  * Added support for movie, show, and episode matching using TMDB and TVDB identifiers.
  * Added validation, item limits, error handling, and cancellation support for Scrob imports.

* **Documentation**
  * Updated setup guidance and provider references to include Scrob integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->