### PR TITLE
test: cover RoundRobinOrder, and unify the two air-block gates

### DIFF
--- a/Jellyfin.Plugin.SmartLists.Tests/Core/Orders/RoundRobinAirBlockTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/Orders/RoundRobinAirBlockTests.cs
@@ -312,9 +312,15 @@ public class RoundRobinAirBlockTests
     }
 
     /// <summary>
-    /// An item with no air date can never chain onto a preceding block (forms a block of one) and
-    /// also breaks the chain for whatever follows it - even when the item after it would otherwise
-    /// have been within the window of the item before the gap.
+    /// An item with no air date forms a block of one and breaks the chain for whatever follows it:
+    /// the next dated item starts a fresh block even though nothing dated preceded it in range.
+    ///
+    /// The undated item goes FIRST because that is the only arrangement production can hand this
+    /// method. Both callers sort by <see cref="RoundRobinBase.CompareWithinGroupByAirDate"/> first,
+    /// and a missing date is DateTime.MinValue, which sorts ahead of every real date - so an
+    /// undated item can never appear mid-group. Feeding it in the middle would assert on a
+    /// sequence the production pipeline cannot produce, which looks like coverage while pinning
+    /// nothing real.
     /// </summary>
     [Fact]
     public void ChunkIntoAirBlocks_ItemWithNoAirDate_FormsItsOwnBlock_AndBreaksTheChainAfterIt()
@@ -322,9 +328,41 @@ public class RoundRobinAirBlockTests
         var day = new DateTime(2024, 1, 1);
         var items = new List<BaseItem>
         {
+            TestItems.Ep("ShowB", 1, 1, aired: null, name: "NoDate"),
+            TestItems.Ep("ShowA", 1, 1, aired: day, name: "A1"),
+            TestItems.Ep("ShowC", 1, 1, aired: day, name: "C1"), // same day as A1, different show - chains to it
+        };
+
+        var blocks = RoundRobinBase.ChunkIntoAirBlocks(items, windowDays: 3);
+
+        // NoDate alone; A1 cannot chain onto an undated predecessor so it opens a new block, and
+        // C1 then chains to A1 normally.
+        Assert.Equal("NoDate | A1,C1", RenderBlocks(blocks));
+    }
+
+    /// <summary>
+    /// Deliberately OUT OF CONTRACT: an undated item mid-sequence, which the sort in front of
+    /// every production caller cannot produce. It is here because it is the only thing that
+    /// exercises the `date > DateTime.MinValue` clause of the chaining condition.
+    ///
+    /// Without that clause an undated item chains onto a dated predecessor, because the gap
+    /// computes as `(MinValue - prevDate).TotalDays` — a large NEGATIVE number, which satisfies
+    /// `&lt;= windowDays` for every window. The result would be "A1,NoDate | C1": an item with no
+    /// air date silently absorbed into someone else's air block.
+    ///
+    /// The in-contract test above cannot catch that (verified by mutation: with the undated item
+    /// sorted first, removing the clause changes nothing). So the two tests are not redundant —
+    /// one pins the reachable behaviour, this one pins the guard that keeps it reachable-only.
+    /// </summary>
+    [Fact]
+    public void ChunkIntoAirBlocks_UndatedItemMidSequence_StillRefusesToChain_GuardingAgainstAnUnsortedCaller()
+    {
+        var day = new DateTime(2024, 1, 1);
+        var items = new List<BaseItem>
+        {
             TestItems.Ep("ShowA", 1, 1, aired: day, name: "A1"),
             TestItems.Ep("ShowB", 1, 1, aired: null, name: "NoDate"),
-            TestItems.Ep("ShowC", 1, 1, aired: day, name: "C1"), // same day as A1 - would chain if NoDate weren't between them
+            TestItems.Ep("ShowC", 1, 1, aired: day, name: "C1"),
         };
 
         var blocks = RoundRobinBase.ChunkIntoAirBlocks(items, windowDays: 3);

--- a/Jellyfin.Plugin.SmartLists.Tests/Core/Orders/RoundRobinAirBlockTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/Orders/RoundRobinAirBlockTests.cs
@@ -1,0 +1,490 @@
+using System.Collections.Concurrent;
+using Jellyfin.Plugin.SmartLists.Core.Orders;
+using Jellyfin.Plugin.SmartLists.Tests.Support;
+using MediaBrowser.Controller.Entities;
+
+namespace Jellyfin.Plugin.SmartLists.Tests.Core.Orders;
+
+/// <summary>
+/// Covers the air-block machinery in <see cref="RoundRobinBase"/>: grouping a playlist by
+/// Collections with air-date within-group order is meant to replay a franchise the way it aired.
+/// A "block" is a run of episodes that aired within a configurable window of each other across
+/// DIFFERENT shows - a same-night crossover, or a franchise week - and the interleave emits one
+/// WHOLE block per collection per cycle instead of one item, so a crossover night is never split
+/// across a rotation.
+///
+/// Four things this file pins:
+/// 1. <see cref="RoundRobinBase.UsesAirBlocks"/> - the public gate: Collections grouping AND
+///    air-date within-group order AND no shuffle, all three required independently.
+/// 2. <see cref="RoundRobinBase.CompareWithinGroupByAirDate"/> - the tiered comparator: day
+///    precision, missing-date-sorts-first, episode-before-non-episode, series-Sort-Title for
+///    same-day cross-series ties, then fall-through to <see cref="RoundRobinBase.CompareWithinGroup"/>.
+/// 3. <see cref="RoundRobinBase.ChunkIntoAirBlocks"/> - the chaining rule: a block extends only
+///    while the NEXT item aired within the window of the PREVIOUS item, never repeats a show, and
+///    an item with no air date can neither join nor be joined.
+/// 4. The AIR-BLOCK branch of <c>BuildInterleavedPositions</c> (reached through
+///    <see cref="RoundRobinBase.PreComputePositions"/> with GroupByField == "Collections",
+///    OrderWithinGroupsByAirDate == true, and a populated CollectionGroupKeys map) - block-at-a-time
+///    interleaving, contrasted against the plain item-at-a-time interleave.
+///
+/// NOTE ON THE TWO GATES: <c>UsesAirBlocks</c> (which tells SmartList whether to prepare block
+/// state) and the internal flag inside <c>BuildInterleavedPositions</c> (which decides whether the
+/// interleave emits blocks) both route through <c>RoundRobinBase.ShouldUseAirBlocks</c>, so they
+/// cannot drift. They previously did: the interleave gated on <c>collectionGroupKeys != null</c>
+/// alone and never inspected the field name. A dedicated test below guards against a regression.
+///
+/// OUT OF SCOPE (owned by other test files): ExtractGroupKey/CompareWithinGroup/Shuffle in
+/// isolation, the plain non-air-block interleave on its own, and
+/// RoundRobinLeastRecentlyWatchedOrder's recency ordering / mid-block hold.
+/// </summary>
+public class RoundRobinAirBlockTests
+{
+    // ---------------------------------------------------------------------------------- helpers
+
+    /// <summary>Renders a chunked block list as "a,b | c,d" - one block per " | " segment.</summary>
+    private static string RenderBlocks(List<List<BaseItem>> blocks) =>
+        string.Join(" | ", blocks.Select(b => string.Join(",", b.Select(i => i.Name))));
+
+    /// <summary>Item names in ascending assigned-position order; unassigned items sort last.</summary>
+    private static string[] NamesInPositionOrder(ConcurrentDictionary<Guid, int> positions, IEnumerable<BaseItem> items) =>
+        items.OrderBy(i => positions.TryGetValue(i.Id, out var p) ? p : int.MaxValue).Select(i => i.Name).ToArray();
+
+    /// <summary>The group-ordering strategy RoundRobinOrder uses: plain alphabetical ascending.</summary>
+    private static readonly Func<IEnumerable<string>, List<string>> OrderKeysAsc =
+        keys => keys.OrderBy(k => k, StringComparer.OrdinalIgnoreCase).ToList();
+
+    // ============================================================================================
+    // UsesAirBlocks - the gate
+    // ============================================================================================
+
+    [Theory]
+    [InlineData("Collections", true, true)] // baseline: all conditions met
+    [InlineData("SeriesName", true, false)] // wrong field
+    [InlineData("Genres", true, false)] // wrong field, another value
+    [InlineData("Collections", false, false)] // no air-date within-group order
+    public void UsesAirBlocks_RequiresCollectionsGroupingAndAirDateOrder(string groupByField, bool orderByAirDate, bool expected)
+    {
+        var order = new RoundRobinOrder { GroupByField = groupByField, OrderWithinGroupsByAirDate = orderByAirDate };
+
+        Assert.Equal(expected, order.UsesAirBlocks);
+    }
+
+    [Fact]
+    public void UsesAirBlocks_False_ForShuffledOrder_EvenWhenConfiguredForCollectionsAndAirDate()
+    {
+        // RoundRobinShuffledOrder overrides ShuffleWithinGroups => true; shuffle wins over
+        // air-date order even when every other condition for blocks is satisfied.
+        var shuffled = new RoundRobinShuffledOrder { GroupByField = "Collections", OrderWithinGroupsByAirDate = true };
+        Assert.False(shuffled.UsesAirBlocks);
+
+        // Contrast: RoundRobinRandomOrder randomizes GROUP order but never overrides
+        // ShuffleWithinGroups, so the identical configuration keeps blocks on for it - proving
+        // ShuffleWithinGroups specifically (not "any random-flavoured order") is the differentiator.
+        var random = new RoundRobinRandomOrder { GroupByField = "Collections", OrderWithinGroupsByAirDate = true };
+        Assert.True(random.UsesAirBlocks);
+    }
+
+    /// <summary>
+    /// The two air-block gates must agree. <see cref="RoundRobinBase.UsesAirBlocks"/> tells
+    /// SmartList whether to prepare block state; the internal flag inside
+    /// BuildInterleavedPositions decides whether the interleave actually emits blocks. Both now
+    /// route through <see cref="RoundRobinBase.ShouldUseAirBlocks"/>, so a non-Collections field
+    /// cannot get block interleaving no matter what else is supplied.
+    ///
+    /// This previously diverged: the interleave gated on `collectionGroupKeys != null` alone and
+    /// never inspected the field name, so grouping by "Genres" got full air-block chunking the
+    /// instant ANY non-null map was passed - even an empty one with no relevant entries. It was
+    /// unreachable in production only because SmartList.cs happens to set CollectionGroupKeys
+    /// exclusively for Collections grouping; nothing enforced that. The assertion below is the
+    /// regression guard.
+    /// </summary>
+    [Fact]
+    public void BuildInterleavedPositions_GatesAirBlocksOnGroupByFieldName_NotOnCollectionMapPresenceAlone()
+    {
+        var day = new DateTime(2024, 1, 1);
+
+        var comedy1 = TestItems.Ep("Gamma", 1, 1, aired: day, name: "Comedy1");
+        comedy1.Genres = ["Comedy"];
+        var comedy2 = TestItems.Ep("Gamma", 1, 2, aired: day.AddDays(1), name: "Comedy2");
+        comedy2.Genres = ["Comedy"];
+
+        var dramaAlpha = TestItems.Ep("Alpha", 1, 1, aired: day, name: "DramaAlpha");
+        dramaAlpha.Genres = ["Drama"];
+        var dramaBeta = TestItems.Ep("Beta", 1, 2, aired: day, name: "DramaBeta"); // crossover: same day, different show
+        dramaBeta.Genres = ["Drama"];
+
+        var items = new List<BaseItem> { comedy1, comedy2, dramaAlpha, dramaBeta };
+        var emptyCollectionMap = new Dictionary<Guid, string>(); // non-null, and its (zero) entries are irrelevant to "Genres"
+
+        var withoutMap = RoundRobinBase.BuildInterleavedPositions(
+            items, "Genres", OrderKeysAsc, "Test", null, false, collectionGroupKeys: null, airDateWithinGroups: true);
+        var withEmptyMap = RoundRobinBase.BuildInterleavedPositions(
+            items, "Genres", OrderKeysAsc, "Test", null, false, collectionGroupKeys: emptyCollectionMap, airDateWithinGroups: true);
+
+        // "Genres" grouping is a plain per-item interleave - the Drama pair is split across cycles.
+        Assert.Equal(new[] { "Comedy1", "DramaAlpha", "Comedy2", "DramaBeta" }, NamesInPositionOrder(withoutMap, items));
+
+        // Supplying a non-null map does NOT switch it into block mode: the field name is part of
+        // the gate, so the result is identical. Before the gates were unified this produced
+        // "Comedy1, DramaAlpha, DramaBeta, Comedy2" - the Drama pair glued into one block.
+        Assert.Equal(NamesInPositionOrder(withoutMap, items), NamesInPositionOrder(withEmptyMap, items));
+        Assert.NotEqual(new[] { "Comedy1", "DramaAlpha", "DramaBeta", "Comedy2" }, NamesInPositionOrder(withEmptyMap, items));
+
+        // And the public gate agrees with what the interleave just did.
+        Assert.False(new RoundRobinOrder { GroupByField = "Genres", OrderWithinGroupsByAirDate = true }.UsesAirBlocks);
+    }
+
+    // ============================================================================================
+    // CompareWithinGroupByAirDate - tiered comparator
+    // ============================================================================================
+
+    /// <summary>
+    /// Two items on the same calendar day but different times of day must tie on date (day
+    /// precision, not full DateTime). Proven by making the earlier-time item ALSO the
+    /// higher-episode-number item: if raw DateTime were compared, the earlier time would win; day
+    /// precision instead ties on date and lets the season/episode fallback decide, producing the
+    /// opposite order.
+    /// </summary>
+    [Fact]
+    public void CompareWithinGroupByAirDate_TiesAtDayPrecision_IgnoringTimeOfDay()
+    {
+        var day = new DateTime(2024, 6, 1);
+        var earlyTimeHigherEpisode = TestItems.Ep("Show", 1, 2, aired: day.AddHours(3));
+        var lateTimeLowerEpisode = TestItems.Ep("Show", 1, 1, aired: day.AddHours(20));
+
+        // If time-of-day mattered, the 03:00 item would sort first. It does not: both fall on the
+        // same day, so the tie falls through to season/episode, and episode 1 sorts before episode 2.
+        Assert.True(RoundRobinBase.CompareWithinGroupByAirDate(lateTimeLowerEpisode, earlyTimeHigherEpisode) < 0);
+        Assert.True(RoundRobinBase.CompareWithinGroupByAirDate(earlyTimeHigherEpisode, lateTimeLowerEpisode) > 0);
+    }
+
+    [Fact]
+    public void CompareWithinGroupByAirDate_MissingDate_SortsFirst()
+    {
+        var noDate = TestItems.Ep("Show", 1, 1, aired: null);
+        var withDate = TestItems.Ep("Show", 1, 1, aired: new DateTime(2024, 1, 1));
+
+        Assert.True(RoundRobinBase.CompareWithinGroupByAirDate(noDate, withDate) < 0);
+        Assert.True(RoundRobinBase.CompareWithinGroupByAirDate(withDate, noDate) > 0);
+    }
+
+    [Fact]
+    public void CompareWithinGroupByAirDate_SameDay_EpisodesSortBeforeNonEpisodes()
+    {
+        var day = new DateTime(2024, 1, 1);
+        var episode = TestItems.Ep("Show", 1, 1, aired: day);
+        var movie = TestItems.Mov("A Movie", aired: day);
+
+        Assert.True(RoundRobinBase.CompareWithinGroupByAirDate(episode, movie) < 0);
+        Assert.True(RoundRobinBase.CompareWithinGroupByAirDate(movie, episode) > 0);
+    }
+
+    /// <summary>
+    /// The documented knob users edit to order a crossover night: same-day episodes of DIFFERENT
+    /// series compare by the series' Sort Title. Both cases below use the SAME two series NAMES
+    /// ("Zulu Show", "Alpha Show" - Zulu alphabetically after Alpha) so that only the Sort Title
+    /// changes between rows; the flip in expected order proves Sort Title decides, not Name.
+    /// Episode numbers are deliberately reversed (Zulu = ep2, Alpha = ep1) relative to the
+    /// expected order, so a mutation that dropped this tier and fell through to
+    /// CompareWithinGroup's season/episode ordering would fail row 1's assertion.
+    /// </summary>
+    [Theory]
+    [InlineData("1 First", "2 Second", true)] // Zulu's sort title comes first -> Zulu before Alpha
+    [InlineData("9 Last", "0 First", false)] // swapped sort titles -> now Alpha before Zulu
+    public void CompareWithinGroupByAirDate_SameDayDifferentSeries_DecidesBySeriesSortTitle_NotName(
+        string zuluSortTitle, string alphaSortTitle, bool zuluFirst)
+    {
+        var day = new DateTime(2024, 3, 1);
+        var zuluShow = TestItems.Show("Zulu Show", sortName: zuluSortTitle);
+        var alphaShow = TestItems.Show("Alpha Show", sortName: alphaSortTitle);
+        var zuluEp = TestItems.Ep("Zulu Show", 1, 2, aired: day, show: zuluShow);
+        var alphaEp = TestItems.Ep("Alpha Show", 1, 1, aired: day, show: alphaShow);
+
+        var cmp = RoundRobinBase.CompareWithinGroupByAirDate(zuluEp, alphaEp);
+
+        Assert.Equal(zuluFirst, cmp < 0);
+    }
+
+    /// <summary>
+    /// An episode whose Series cannot be resolved (SeriesId points at nothing registered) falls
+    /// back to its denormalized SeriesName rather than throwing or collapsing to empty. The
+    /// fallback name is chosen to sort AFTER the resolvable episode's real sort title, so a
+    /// mutation that fell back to "" (which would sort before everything) cannot masquerade as
+    /// this test passing.
+    /// </summary>
+    [Fact]
+    public void CompareWithinGroupByAirDate_UnresolvableSeries_FallsBackToDenormalizedSeriesName()
+    {
+        var day = new DateTime(2024, 3, 1);
+        var registeredShow = TestItems.Show("Registered Show", sortName: "Aaa Registered Show");
+        var resolvable = TestItems.Ep("Registered Show", 1, 1, aired: day, show: registeredShow);
+
+        var unresolvable = TestItems.Ep("Zzz Ghost Show", 1, 1, aired: day);
+        unresolvable.SeriesId = Guid.NewGuid(); // never registered with TestLibraryManager -> Series resolves null
+
+        Assert.True(RoundRobinBase.CompareWithinGroupByAirDate(unresolvable, resolvable) > 0);
+        Assert.True(RoundRobinBase.CompareWithinGroupByAirDate(resolvable, unresolvable) < 0);
+    }
+
+    [Fact]
+    public void CompareWithinGroupByAirDate_SameDaySameSeries_FallsThroughToSeasonThenEpisode()
+    {
+        var day = new DateTime(2024, 3, 1);
+        var show = TestItems.Show("Show");
+
+        var earlierSeason = TestItems.Ep("Show", 1, 5, aired: day, show: show);
+        var laterSeason = TestItems.Ep("Show", 2, 1, aired: day, show: show);
+        Assert.True(RoundRobinBase.CompareWithinGroupByAirDate(earlierSeason, laterSeason) < 0);
+
+        var earlierEpisode = TestItems.Ep("Show", 1, 1, aired: day, show: show);
+        var laterEpisode = TestItems.Ep("Show", 1, 3, aired: day, show: show);
+        Assert.True(RoundRobinBase.CompareWithinGroupByAirDate(earlierEpisode, laterEpisode) < 0);
+    }
+
+    // ============================================================================================
+    // ChunkIntoAirBlocks - the chaining rule
+    // Input below is always fed already sorted by air date, matching the documented contract
+    // (the caller sorts first); unsorted input is out of contract and not exercised here.
+    // ============================================================================================
+
+    /// <summary>
+    /// A block extends only while the next item aired within the window of the PREVIOUS item, not
+    /// of the block's start - so a chain of small link-to-link gaps can span far more than the
+    /// window overall. Five items 1 day apart, window 1 day: every consecutive pair chains, so
+    /// all five land in one block spanning 4 days.
+    /// </summary>
+    [Fact]
+    public void ChunkIntoAirBlocks_ChainsItemToItem_SoATightChainCanSpanFarMoreThanTheWindow()
+    {
+        var start = new DateTime(2024, 1, 1);
+        var items = new List<BaseItem>
+        {
+            TestItems.Ep("Show1", 1, 1, aired: start, name: "Ep1"),
+            TestItems.Ep("Show2", 1, 1, aired: start.AddDays(1), name: "Ep2"),
+            TestItems.Ep("Show3", 1, 1, aired: start.AddDays(2), name: "Ep3"),
+            TestItems.Ep("Show4", 1, 1, aired: start.AddDays(3), name: "Ep4"),
+            TestItems.Ep("Show5", 1, 1, aired: start.AddDays(4), name: "Ep5"),
+        };
+
+        var blocks = RoundRobinBase.ChunkIntoAirBlocks(items, windowDays: 1);
+
+        Assert.Equal("Ep1,Ep2,Ep3,Ep4,Ep5", RenderBlocks(blocks));
+    }
+
+    [Fact]
+    public void ChunkIntoAirBlocks_NeverContainsTheSameShowTwice_EvenOnTheSameDay()
+    {
+        var day = new DateTime(2024, 1, 1);
+        var items = new List<BaseItem>
+        {
+            TestItems.Ep("ShowX", 1, 1, aired: day, name: "X1"),
+            TestItems.Ep("ShowX", 1, 2, aired: day, name: "X2"), // same show, same day - must NOT chain
+        };
+
+        var blocks = RoundRobinBase.ChunkIntoAirBlocks(items, windowDays: 3);
+
+        Assert.Equal("X1 | X2", RenderBlocks(blocks));
+    }
+
+    /// <summary>
+    /// An item with no air date can never chain onto a preceding block (forms a block of one) and
+    /// also breaks the chain for whatever follows it - even when the item after it would otherwise
+    /// have been within the window of the item before the gap.
+    /// </summary>
+    [Fact]
+    public void ChunkIntoAirBlocks_ItemWithNoAirDate_FormsItsOwnBlock_AndBreaksTheChainAfterIt()
+    {
+        var day = new DateTime(2024, 1, 1);
+        var items = new List<BaseItem>
+        {
+            TestItems.Ep("ShowA", 1, 1, aired: day, name: "A1"),
+            TestItems.Ep("ShowB", 1, 1, aired: null, name: "NoDate"),
+            TestItems.Ep("ShowC", 1, 1, aired: day, name: "C1"), // same day as A1 - would chain if NoDate weren't between them
+        };
+
+        var blocks = RoundRobinBase.ChunkIntoAirBlocks(items, windowDays: 3);
+
+        Assert.Equal("A1 | NoDate | C1", RenderBlocks(blocks));
+    }
+
+    [Theory]
+    [InlineData(0, "First,Second")] // same day (0-day gap) chains when the window is 0
+    [InlineData(1, "First | Second")] // 1-day gap does not chain when the window is 0
+    public void ChunkIntoAirBlocks_WindowZero_MeansSameDayOnly(int gapDays, string expected)
+    {
+        var day = new DateTime(2024, 1, 1);
+        var items = new List<BaseItem>
+        {
+            TestItems.Ep("ShowA", 1, 1, aired: day, name: "First"),
+            TestItems.Ep("ShowB", 1, 1, aired: day.AddDays(gapDays), name: "Second"),
+        };
+
+        var blocks = RoundRobinBase.ChunkIntoAirBlocks(items, windowDays: 0);
+
+        Assert.Equal(expected, RenderBlocks(blocks));
+    }
+
+    // ============================================================================================
+    // BuildInterleavedPositions - windowDays clamping
+    // Clamping itself happens at the CALL SITE (Math.Clamp before invoking ChunkIntoAirBlocks),
+    // not inside ChunkIntoAirBlocks, which takes windowDays as given. Each test below proves the
+    // clamp actually ran by contrasting against what the UNCLAMPED value would have produced.
+    // ============================================================================================
+
+    [Fact]
+    public void BuildInterleavedPositions_ClampsNegativeAirBlockWindowDaysToZero()
+    {
+        var day = new DateTime(2024, 1, 1);
+        var itemA = TestItems.Ep("ShowA", 1, 1, aired: day, name: "A");
+        var itemB = TestItems.Ep("ShowB", 1, 1, aired: day, name: "B"); // same day as A, different show
+        var itemC = TestItems.Ep("ShowC", 1, 1, aired: day.AddDays(10), name: "C"); // far away - never chains either way
+        var itemD = TestItems.Ep("ShowD", 1, 1, aired: day, name: "D");
+
+        var franchiseItems = new List<BaseItem> { itemA, itemB, itemC };
+        var allItems = new List<BaseItem> { itemA, itemB, itemC, itemD };
+        var map = TestItems.CollectionMap(("Franchise", [.. franchiseItems]), ("Solo", [itemD]));
+
+        var withNegative = RoundRobinBase.BuildInterleavedPositions(
+            allItems, "Collections", OrderKeysAsc, "Test", null, false, map, true, airBlockWindowDays: -5);
+
+        // Clamped to 0: A and B (0-day gap) chain into one block; C stays separate.
+        Assert.Equal(new[] { "A", "B", "D", "C" }, NamesInPositionOrder(withNegative, allItems));
+
+        // Ground truth: fed the raw -5 with no clamp, ChunkIntoAirBlocks treats every gap - even
+        // the 0-day gap between A and B - as outside the window (0 <= -5 is false), so nothing
+        // chains. This is what -5 would have produced had the clamp not run.
+        var unclampedBlocks = RoundRobinBase.ChunkIntoAirBlocks(franchiseItems, windowDays: -5);
+        Assert.Equal(3, unclampedBlocks.Count);
+    }
+
+    [Fact]
+    public void BuildInterleavedPositions_ClampsHugeAirBlockWindowDaysToMax()
+    {
+        var day0 = new DateTime(2024, 1, 1);
+        var gapBeyondMax = RoundRobinBase.MaxAirBlockWindowDays + 1;
+        var itemA = TestItems.Ep("ShowA", 1, 1, aired: day0, name: "A");
+        var itemB = TestItems.Ep("ShowB", 1, 1, aired: day0.AddDays(gapBeyondMax), name: "B");
+        var itemD = TestItems.Ep("ShowD", 1, 1, aired: day0, name: "D");
+
+        var franchiseItems = new List<BaseItem> { itemA, itemB };
+        var allItems = new List<BaseItem> { itemA, itemB, itemD };
+        var map = TestItems.CollectionMap(("Franchise", [.. franchiseItems]), ("Solo", [itemD]));
+
+        var withHugeValue = RoundRobinBase.BuildInterleavedPositions(
+            allItems, "Collections", OrderKeysAsc, "Test", null, false, map, true, airBlockWindowDays: 99_999);
+
+        // Clamped to MaxAirBlockWindowDays (30): a 31-day gap exceeds it, so A and B stay separate
+        // blocks and Solo's single item interleaves between them.
+        Assert.Equal(new[] { "A", "D", "B" }, NamesInPositionOrder(withHugeValue, allItems));
+
+        // Ground truth: without the clamp, a 31-day gap fits easily inside a 99999-day window and
+        // the two Franchise episodes would chain into a single block instead.
+        var unclampedBlocks = RoundRobinBase.ChunkIntoAirBlocks(franchiseItems, windowDays: 99_999);
+        Assert.Single(unclampedBlocks);
+    }
+
+    // ============================================================================================
+    // The air-block interleave itself (PreComputePositions -> BuildInterleavedPositions block branch)
+    // ============================================================================================
+
+    /// <summary>
+    /// Two collections: Marvel forms a 2-item crossover block plus a solo block (2 blocks total);
+    /// DC forms a single solo block. One WHOLE block is emitted per collection per cycle, the
+    /// crossover pair stays contiguous, DC drops out of the rotation after its one block while
+    /// Marvel keeps rotating, and positions are dense with no gaps or duplicates.
+    /// </summary>
+    [Fact]
+    public void AirBlockInterleave_EmitsOneWholeBlockPerCollectionPerCycle_AndDropsOutCollectionsWithFewerBlocks()
+    {
+        var day1 = new DateTime(2024, 1, 1);
+        var day10 = day1.AddDays(10);
+
+        var showA1 = TestItems.Ep("Alpha", 1, 1, aired: day1, name: "A1");
+        var showB1 = TestItems.Ep("Bravo", 1, 2, aired: day1, name: "B1"); // crossover with A1
+        var showA2 = TestItems.Ep("Alpha", 1, 3, aired: day10, name: "A2"); // too far from A1/B1 to chain
+        var showC1 = TestItems.Ep("Charlie", 1, 1, aired: day1, name: "C1");
+
+        var marvelItems = new BaseItem[] { showA1, showB1, showA2 };
+        var dcItems = new BaseItem[] { showC1 };
+        var items = marvelItems.Concat(dcItems).ToList();
+        var map = TestItems.CollectionMap(("Marvel", marvelItems), ("DC", dcItems));
+
+        var order = new RoundRobinOrder
+        {
+            GroupByField = "Collections",
+            OrderWithinGroupsByAirDate = true,
+            CollectionGroupKeys = map,
+        };
+        order.PreComputePositions(items);
+
+        Assert.Equal(new[] { "C1", "A1", "B1", "A2" }, NamesInPositionOrder(order.ItemPositions, items));
+
+        // The crossover block (A1+B1) stays contiguous.
+        Assert.Equal(order.ItemPositions[showA1.Id] + 1, order.ItemPositions[showB1.Id]);
+
+        // DC contributed only its single block at the first cycle, then dropped out of the
+        // rotation entirely while Marvel kept going for a second cycle (A2).
+        Assert.Equal(0, order.ItemPositions[showC1.Id]);
+        Assert.True(order.ItemPositions[showA2.Id] > order.ItemPositions[showB1.Id]);
+
+        // Positions are dense: 0..n-1, no gaps or duplicates.
+        Assert.Equal(new[] { 0, 1, 2, 3 }, order.ItemPositions.Values.OrderBy(v => v));
+    }
+
+    /// <summary>
+    /// Same shape as above, but DC also gets 2 items (2 blocks, since they're the same show and
+    /// can never chain with each other) so it competes with Marvel across two interleave cycles.
+    /// Contrasted against OrderWithinGroupsByAirDate == false on the SAME input: air-date order
+    /// keeps the crossover block glued together (DC's second item lands AFTER the whole block),
+    /// while plain order interleaves one item at a time (DC's second item lands BETWEEN the
+    /// crossover pair) - that difference is the entire feature.
+    /// </summary>
+    [Fact]
+    public void AirBlockInterleave_KeepsMultiItemBlocksContiguous_ContrastedAgainstPlainPerItemInterleave()
+    {
+        var day1 = new DateTime(2024, 1, 1);
+        var day10 = day1.AddDays(10);
+
+        var showA1 = TestItems.Ep("Alpha", 1, 1, aired: day1, name: "A1");
+        var showB1 = TestItems.Ep("Bravo", 1, 2, aired: day1, name: "B1"); // crossover with A1
+        var showA2 = TestItems.Ep("Alpha", 1, 3, aired: day10, name: "A2"); // too far to chain
+        var showC1 = TestItems.Ep("Charlie", 1, 1, aired: day1, name: "C1");
+        var showC2 = TestItems.Ep("Charlie", 1, 2, aired: day1, name: "C2"); // same show as C1 - never chains with it
+
+        var marvelItems = new BaseItem[] { showA1, showB1, showA2 };
+        var dcItems = new BaseItem[] { showC1, showC2 };
+        var items = marvelItems.Concat(dcItems).ToList();
+        var map = TestItems.CollectionMap(("Marvel", marvelItems), ("DC", dcItems));
+
+        var blockOrder = new RoundRobinOrder
+        {
+            GroupByField = "Collections",
+            OrderWithinGroupsByAirDate = true,
+            CollectionGroupKeys = map,
+        };
+        blockOrder.PreComputePositions(items);
+
+        var plainOrder = new RoundRobinOrder
+        {
+            GroupByField = "Collections",
+            OrderWithinGroupsByAirDate = false,
+            CollectionGroupKeys = map,
+        };
+        plainOrder.PreComputePositions(items);
+
+        Assert.Equal(new[] { "C1", "A1", "B1", "C2", "A2" }, NamesInPositionOrder(blockOrder.ItemPositions, items));
+        Assert.Equal(new[] { "C1", "A1", "C2", "B1", "A2" }, NamesInPositionOrder(plainOrder.ItemPositions, items));
+
+        // Block mode: the crossover pair stays glued together.
+        Assert.Equal(blockOrder.ItemPositions[showA1.Id] + 1, blockOrder.ItemPositions[showB1.Id]);
+
+        // Plain mode: DC's second item is interleaved BETWEEN A1 and B1 - one item at a time.
+        Assert.True(plainOrder.ItemPositions[showA1.Id] < plainOrder.ItemPositions[showC2.Id]);
+        Assert.True(plainOrder.ItemPositions[showC2.Id] < plainOrder.ItemPositions[showB1.Id]);
+
+        foreach (var positions in new[] { blockOrder.ItemPositions, plainOrder.ItemPositions })
+        {
+            Assert.Equal(new[] { 0, 1, 2, 3, 4 }, positions.Values.OrderBy(v => v));
+        }
+    }
+}

--- a/Jellyfin.Plugin.SmartLists.Tests/Core/Orders/RoundRobinAirBlockTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/Orders/RoundRobinAirBlockTests.cs
@@ -29,9 +29,12 @@ namespace Jellyfin.Plugin.SmartLists.Tests.Core.Orders;
 ///
 /// NOTE ON THE TWO GATES: <c>UsesAirBlocks</c> (which tells SmartList whether to prepare block
 /// state) and the internal flag inside <c>BuildInterleavedPositions</c> (which decides whether the
-/// interleave emits blocks) both route through <c>RoundRobinBase.ShouldUseAirBlocks</c>, so they
-/// cannot drift. They previously did: the interleave gated on <c>collectionGroupKeys != null</c>
-/// alone and never inspected the field name. A dedicated test below guards against a regression.
+/// interleave emits blocks) both route through <c>RoundRobinBase.ShouldUseAirBlocks</c>, evaluated
+/// from instance state and from parameters respectively, so they cannot drift. They previously
+/// did: the interleave gated on <c>collectionGroupKeys != null</c> alone and never inspected the
+/// field name, while <c>UsesAirBlocks</c> inspected the field name and ignored the map. Every
+/// condition - including map presence - now lives in the one helper, so <c>UsesAirBlocks</c> can
+/// be trusted on its own. A dedicated test below guards against a regression.
 ///
 /// OUT OF SCOPE (owned by other test files): ExtractGroupKey/CompareWithinGroup/Shuffle in
 /// isolation, the plain non-air-block interleave on its own, and
@@ -58,13 +61,20 @@ public class RoundRobinAirBlockTests
     // ============================================================================================
 
     [Theory]
-    [InlineData("Collections", true, true)] // baseline: all conditions met
-    [InlineData("SeriesName", true, false)] // wrong field
-    [InlineData("Genres", true, false)] // wrong field, another value
-    [InlineData("Collections", false, false)] // no air-date within-group order
-    public void UsesAirBlocks_RequiresCollectionsGroupingAndAirDateOrder(string groupByField, bool orderByAirDate, bool expected)
+    [InlineData("Collections", true, true, true)] // baseline: all conditions met
+    [InlineData("SeriesName", true, true, false)] // wrong field
+    [InlineData("Genres", true, true, false)] // wrong field, another value
+    [InlineData("Collections", false, true, false)] // no air-date within-group order
+    [InlineData("Collections", true, false, false)] // no resolved collection map to group blocks by
+    public void UsesAirBlocks_RequiresCollectionsGroupingAirDateOrderAndAResolvedMap(
+        string groupByField, bool orderByAirDate, bool withMap, bool expected)
     {
-        var order = new RoundRobinOrder { GroupByField = groupByField, OrderWithinGroupsByAirDate = orderByAirDate };
+        var order = new RoundRobinOrder
+        {
+            GroupByField = groupByField,
+            OrderWithinGroupsByAirDate = orderByAirDate,
+            CollectionGroupKeys = withMap ? [] : null,
+        };
 
         Assert.Equal(expected, order.UsesAirBlocks);
     }
@@ -74,13 +84,23 @@ public class RoundRobinAirBlockTests
     {
         // RoundRobinShuffledOrder overrides ShuffleWithinGroups => true; shuffle wins over
         // air-date order even when every other condition for blocks is satisfied.
-        var shuffled = new RoundRobinShuffledOrder { GroupByField = "Collections", OrderWithinGroupsByAirDate = true };
+        var shuffled = new RoundRobinShuffledOrder
+        {
+            GroupByField = "Collections",
+            OrderWithinGroupsByAirDate = true,
+            CollectionGroupKeys = [],
+        };
         Assert.False(shuffled.UsesAirBlocks);
 
         // Contrast: RoundRobinRandomOrder randomizes GROUP order but never overrides
         // ShuffleWithinGroups, so the identical configuration keeps blocks on for it - proving
         // ShuffleWithinGroups specifically (not "any random-flavoured order") is the differentiator.
-        var random = new RoundRobinRandomOrder { GroupByField = "Collections", OrderWithinGroupsByAirDate = true };
+        var random = new RoundRobinRandomOrder
+        {
+            GroupByField = "Collections",
+            OrderWithinGroupsByAirDate = true,
+            CollectionGroupKeys = [],
+        };
         Assert.True(random.UsesAirBlocks);
     }
 
@@ -130,8 +150,13 @@ public class RoundRobinAirBlockTests
         Assert.Equal(NamesInPositionOrder(withoutMap, items), NamesInPositionOrder(withEmptyMap, items));
         Assert.NotEqual(new[] { "Comedy1", "DramaAlpha", "DramaBeta", "Comedy2" }, NamesInPositionOrder(withEmptyMap, items));
 
-        // And the public gate agrees with what the interleave just did.
-        Assert.False(new RoundRobinOrder { GroupByField = "Genres", OrderWithinGroupsByAirDate = true }.UsesAirBlocks);
+        // And the public gate agrees with what the interleave just did, on the same inputs.
+        Assert.False(new RoundRobinOrder
+        {
+            GroupByField = "Genres",
+            OrderWithinGroupsByAirDate = true,
+            CollectionGroupKeys = emptyCollectionMap,
+        }.UsesAirBlocks);
     }
 
     // ============================================================================================
@@ -336,7 +361,11 @@ public class RoundRobinAirBlockTests
     {
         var day = new DateTime(2024, 1, 1);
         var itemA = TestItems.Ep("ShowA", 1, 1, aired: day, name: "A");
-        var itemB = TestItems.Ep("ShowB", 1, 1, aired: day, name: "B"); // same day as A, different show
+        // Episode 2, not 1: A and B share an air date, are both episodes, and both have an empty
+        // SeriesId, so CompareWithinGroupByAirDate returns 0 for the pair on every other tier. A
+        // distinct episode number makes the within-group sort decide the order rather than leaving
+        // it to List<T>.Sort, which is not a stable sort.
+        var itemB = TestItems.Ep("ShowB", 1, 2, aired: day, name: "B"); // same day as A, different show
         var itemC = TestItems.Ep("ShowC", 1, 1, aired: day.AddDays(10), name: "C"); // far away - never chains either way
         var itemD = TestItems.Ep("ShowD", 1, 1, aired: day, name: "D");
 

--- a/Jellyfin.Plugin.SmartLists.Tests/Core/Orders/RoundRobinGroupingTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/Orders/RoundRobinGroupingTests.cs
@@ -1,0 +1,414 @@
+using Jellyfin.Plugin.SmartLists.Core.Orders;
+using Jellyfin.Plugin.SmartLists.Tests.Support;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Audio;
+
+namespace Jellyfin.Plugin.SmartLists.Tests.Core.Orders;
+
+/// <summary>
+/// Covers three static helpers inside <see cref="RoundRobinBase"/> that every round-robin sort
+/// variant (Round Robin Ascending/Descending, Random, Shuffled, Least Recently Watched) shares:
+/// how an item's group key is derived from the configured GroupByField
+/// (<see cref="RoundRobinBase.ExtractGroupKey"/>), how two items in the same group are ordered
+/// before interleaving (<see cref="RoundRobinBase.CompareWithinGroup"/>), and the Fisher-Yates
+/// shuffle used for random group order / random within-group order
+/// (<see cref="RoundRobinBase.Shuffle{T}"/>). Air blocks, air-date comparison, the interleave
+/// itself, and the Least Recently Watched subclass are covered elsewhere.
+///
+/// Two things make these worth pinning at this level rather than trusting the interleave's own
+/// end-to-end behaviour to catch regressions:
+///
+/// 1. ExtractGroupKey's switch has a DEFAULT ARM that falls back to item.Name for any field it
+///    does not recognise. That is convenient when GroupByField is genuinely unset, but it also
+///    means a typo'd field id (or a future field wired into the dropdown but not into this
+///    switch) groups everything by item name SILENTLY - no exception, no log line. The test for
+///    that arm is the regression guard for "I picked Genres and it grouped everything by name".
+/// 2. CompareWithinGroup mixes THREE comparison strategies (season/episode ints, disc/track ints,
+///    and a hand-rolled natural string comparer) behind one method, and a group is not guaranteed
+///    to be single-type - Collections grouping can put a TV show and a movie franchise in the same
+///    collection - so the mixed-type fallback path is the routine path for that field, not a
+///    corner case.
+///
+/// Shuffle is pinned separately because it backs both "random group order" and "shuffle within
+/// group": a Fisher-Yates bug (wrong loop bound, wrong swap index) would silently under-shuffle -
+/// some permutations become unreachable - without ever throwing, so only a fixed-seed,
+/// known-output test catches it.
+/// </summary>
+public class RoundRobinGroupingTests
+{
+    /// <summary>TestItems.Track only accepts a single artist; ExtractGroupKey's "first artist"
+    /// behaviour needs at least two to be a meaningful test.</summary>
+    private static Audio AudioWithArtists(string name, params string[] artists)
+    {
+        var item = new Audio { Id = Guid.NewGuid(), Name = name };
+        item.SortName = item.Name;
+        item.Artists = artists;
+        return item;
+    }
+
+    // =================================================================================
+    // ExtractGroupKey
+    // =================================================================================
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void NullOrEmptyGroupByField_ReturnsEmptyString(string? groupByField)
+    {
+        var movie = TestItems.Mov("Anything");
+
+        Assert.Equal(string.Empty, RoundRobinBase.ExtractGroupKey(movie, groupByField, null));
+    }
+
+    /// <summary>
+    /// Episode grouping reads the denormalized <c>SeriesName</c> field directly, NOT
+    /// <c>episode.Series?.Name</c> resolved through the library manager. Proven by registering a
+    /// Series under a different name than the episode's own SeriesName: if this ever switched to
+    /// reading through Series, the key would silently change to the registered show's name.
+    /// </summary>
+    [Fact]
+    public void SeriesName_Episode_UsesTheDenormalizedSeriesNameProperty_NotTheResolvedSeries()
+    {
+        var show = TestItems.Show("Real Series Name");
+        var episode = TestItems.Ep("Denormalized Name", 1, 1, show: show);
+
+        Assert.Equal("Denormalized Name", RoundRobinBase.ExtractGroupKey(episode, "SeriesName", null));
+    }
+
+    [Fact]
+    public void SeriesName_NonEpisode_FallsBackToItemName()
+    {
+        var movie = TestItems.Mov("Some Movie");
+
+        Assert.Equal("Some Movie", RoundRobinBase.ExtractGroupKey(movie, "SeriesName", null));
+    }
+
+    [Fact]
+    public void AlbumName_ReturnsItemAlbum()
+    {
+        var track = TestItems.Track("Abbey Road", disc: 1, track: 1);
+
+        Assert.Equal("Abbey Road", RoundRobinBase.ExtractGroupKey(track, "AlbumName", null));
+    }
+
+    [Fact]
+    public void AlbumName_ItemWithNoAlbum_ReturnsEmptyString()
+    {
+        var movie = TestItems.Mov("Some Movie");
+
+        Assert.Equal(string.Empty, RoundRobinBase.ExtractGroupKey(movie, "AlbumName", null));
+    }
+
+    [Fact]
+    public void Artist_Audio_ReturnsTheFirstListedArtist()
+    {
+        var track = AudioWithArtists("Track", "Zed Leppelin", "Alpha Guest");
+
+        Assert.Equal("Zed Leppelin", RoundRobinBase.ExtractGroupKey(track, "Artist", null));
+    }
+
+    [Fact]
+    public void Artist_NonAudio_ReturnsEmptyString()
+    {
+        var movie = TestItems.Mov("Some Movie");
+
+        Assert.Equal(string.Empty, RoundRobinBase.ExtractGroupKey(movie, "Artist", null));
+    }
+
+    [Fact]
+    public void Artist_AudioWithNoArtists_ReturnsEmptyString()
+    {
+        var track = TestItems.Track("Album", disc: 1, track: 1); // no artist passed
+
+        Assert.Equal(string.Empty, RoundRobinBase.ExtractGroupKey(track, "Artist", null));
+    }
+
+    [Fact]
+    public void Genres_ReturnsTheFirstGenre()
+    {
+        var movie = TestItems.Mov("Movie", genres: ["Action", "Thriller"]);
+
+        Assert.Equal("Action", RoundRobinBase.ExtractGroupKey(movie, "Genres", null));
+    }
+
+    [Fact]
+    public void Genres_Empty_ReturnsEmptyString()
+    {
+        var movie = TestItems.Mov("Movie");
+
+        Assert.Equal(string.Empty, RoundRobinBase.ExtractGroupKey(movie, "Genres", null));
+    }
+
+    [Fact]
+    public void Studios_ReturnsTheFirstStudio()
+    {
+        var movie = TestItems.Mov("Movie", studios: ["Warner Bros.", "Legendary"]);
+
+        Assert.Equal("Warner Bros.", RoundRobinBase.ExtractGroupKey(movie, "Studios", null));
+    }
+
+    [Fact]
+    public void Studios_Empty_ReturnsEmptyString()
+    {
+        var movie = TestItems.Mov("Movie");
+
+        Assert.Equal(string.Empty, RoundRobinBase.ExtractGroupKey(movie, "Studios", null));
+    }
+
+    [Fact]
+    public void Collections_MapHit_WinsOverTheItemsOwnSeriesName()
+    {
+        var episode = TestItems.Ep("Some Show", 1, 1);
+        var map = TestItems.CollectionMap(("My Collection", new BaseItem[] { episode }));
+
+        Assert.Equal("My Collection", RoundRobinBase.ExtractGroupKey(episode, "Collections", map));
+    }
+
+    [Fact]
+    public void Collections_MapMiss_Episode_FallsBackToSeriesName()
+    {
+        var otherEpisode = TestItems.Ep("Other Show", 1, 1);
+        var episode = TestItems.Ep("Some Show", 2, 3);
+        var map = TestItems.CollectionMap(("Other Collection", new BaseItem[] { otherEpisode }));
+
+        Assert.Equal("Some Show", RoundRobinBase.ExtractGroupKey(episode, "Collections", map));
+    }
+
+    [Fact]
+    public void Collections_MapMiss_NonEpisode_FallsBackToItemName()
+    {
+        var movie = TestItems.Mov("Some Movie");
+        var map = TestItems.CollectionMap();
+
+        Assert.Equal("Some Movie", RoundRobinBase.ExtractGroupKey(movie, "Collections", map));
+    }
+
+    [Fact]
+    public void Collections_NullMap_FallsBackTheSameWayAsAMapMiss()
+    {
+        var episode = TestItems.Ep("Some Show", 1, 1);
+        var movie = TestItems.Mov("Some Movie");
+
+        Assert.Equal("Some Show", RoundRobinBase.ExtractGroupKey(episode, "Collections", null));
+        Assert.Equal("Some Movie", RoundRobinBase.ExtractGroupKey(movie, "Collections", null));
+    }
+
+    /// <summary>
+    /// A typo'd or not-yet-wired field id hits the switch's default arm and groups by item name
+    /// with no error anywhere - the user just sees an unexplained "Name" grouping.
+    /// </summary>
+    [Fact]
+    public void UnrecognisedGroupByField_FallsBackToItemName()
+    {
+        var movie = TestItems.Mov("My Movie");
+
+        Assert.Equal("My Movie", RoundRobinBase.ExtractGroupKey(movie, "NotARealField", null));
+    }
+
+    /// <summary>
+    /// BuildInterleavedPositions groups keys case-insensitively (StringComparer.OrdinalIgnoreCase
+    /// on the Dictionary), but ExtractGroupKey itself must hand back the RAW string - if a future
+    /// change normalised casing here, that dictionary's case-insensitivity would become invisible
+    /// (nothing would change), masking the regression.
+    /// </summary>
+    [Fact]
+    public void ExtractGroupKey_ReturnsTheRawCasing_ItDoesNotNormaliseItItself()
+    {
+        var upper = TestItems.Mov("Movie1", genres: ["Action"]);
+        var lower = TestItems.Mov("Movie2", genres: ["action"]);
+
+        Assert.Equal("Action", RoundRobinBase.ExtractGroupKey(upper, "Genres", null));
+        Assert.Equal("action", RoundRobinBase.ExtractGroupKey(lower, "Genres", null));
+    }
+
+    // =================================================================================
+    // CompareWithinGroup
+    // =================================================================================
+
+    [Fact]
+    public void TwoEpisodes_SeasonNumberDominatesEpisodeNumber()
+    {
+        var lateInSeasonOne = TestItems.Ep("Show", season: 1, episode: 99);
+        var earlyInSeasonTwo = TestItems.Ep("Show", season: 2, episode: 1);
+
+        Assert.True(RoundRobinBase.CompareWithinGroup(lateInSeasonOne, earlyInSeasonTwo) < 0);
+        Assert.True(RoundRobinBase.CompareWithinGroup(earlyInSeasonTwo, lateInSeasonOne) > 0);
+    }
+
+    [Fact]
+    public void TwoAudios_DiscNumberDominatesTrackNumber()
+    {
+        var lateOnDiscOne = TestItems.Track("Album", disc: 1, track: 99);
+        var earlyOnDiscTwo = TestItems.Track("Album", disc: 2, track: 1);
+
+        Assert.True(RoundRobinBase.CompareWithinGroup(lateOnDiscOne, earlyOnDiscTwo) < 0);
+        Assert.True(RoundRobinBase.CompareWithinGroup(earlyOnDiscTwo, lateOnDiscOne) > 0);
+    }
+
+    /// <summary>
+    /// Neither "both Episode" nor "both Audio", so this exercises the natural-string-comparer
+    /// fallback. Names start with digits so the result distinguishes a numeric-aware comparer
+    /// from a plain ordinal one: ordinal compare would put "10 ..." before "2 ..." on the
+    /// '1' &lt; '2' byte, but SharedNaturalComparer parses the leading run of digits and compares
+    /// it as a number, so "2 ..." sorts first.
+    /// </summary>
+    [Fact]
+    public void MixedEpisodeAndMovie_FallsBackToTheNaturalComparerOnSortName()
+    {
+        var episode = TestItems.Ep("Show", season: 1, episode: 1, name: "2 Crossover Night");
+        var movie = TestItems.Mov("10 Crossover Night");
+
+        Assert.True(RoundRobinBase.CompareWithinGroup(episode, movie) < 0);
+        Assert.True(RoundRobinBase.CompareWithinGroup(movie, episode) > 0);
+    }
+
+    [Fact]
+    public void MixedAudioAndMovie_FallsBackToTheNaturalComparerOnSortName()
+    {
+        var track = TestItems.Track("Album", disc: 1, track: 1, name: "2 Crossover Track");
+        var movie = TestItems.Mov("10 Crossover Track");
+
+        Assert.True(RoundRobinBase.CompareWithinGroup(track, movie) < 0);
+        Assert.True(RoundRobinBase.CompareWithinGroup(movie, track) > 0);
+    }
+
+    /// <summary>
+    /// A comparer that isn't its own mirror image (Compare(a,b) != -Compare(b,a)) breaks List.Sort
+    /// in ways that show up as items randomly missing their round-robin turn. Checked across all
+    /// three branches (episode/episode, audio/audio, and the natural-comparer fallback) plus
+    /// reflexivity (an item never outranks itself).
+    /// </summary>
+    [Fact]
+    public void Comparisons_AreSymmetric_AcrossEveryBranch()
+    {
+        var epA = TestItems.Ep("Show", season: 1, episode: 1);
+        var epB = TestItems.Ep("Show", season: 2, episode: 5);
+        var audA = TestItems.Track("Album", disc: 1, track: 1);
+        var audB = TestItems.Track("Album", disc: 2, track: 3);
+        var movA = TestItems.Mov("Alpha");
+        var movB = TestItems.Mov("2 Fast");
+
+        BaseItem[] sample = [epA, epB, audA, audB, movA, movB];
+
+        foreach (var a in sample)
+        {
+            Assert.Equal(0, RoundRobinBase.CompareWithinGroup(a, a));
+
+            foreach (var b in sample)
+            {
+                Assert.Equal(
+                    RoundRobinBase.CompareWithinGroup(a, b),
+                    -RoundRobinBase.CompareWithinGroup(b, a));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Sorts the same six mixed-type items from two different starting arrangements and requires
+    /// an identical result, which only holds if the comparator resolves every pair the same way
+    /// regardless of List.Sort's internal pivot choices - i.e. it is a well-defined total order,
+    /// not just "symmetric for adjacent pairs".
+    /// </summary>
+    [Fact]
+    public void Sorting_ProducesTheSameOrder_RegardlessOfStartingArrangement()
+    {
+        var epA = TestItems.Ep("Show", season: 1, episode: 1);
+        var epB = TestItems.Ep("Show", season: 2, episode: 5);
+        var audA = TestItems.Track("Album", disc: 1, track: 1);
+        var audB = TestItems.Track("Album", disc: 2, track: 3);
+        var movA = TestItems.Mov("Alpha");
+        var movB = TestItems.Mov("2 Fast");
+
+        var forward = new List<BaseItem> { movB, epB, audB, movA, epA, audA };
+        var reversed = new List<BaseItem>(forward);
+        reversed.Reverse();
+
+        forward.Sort((a, b) => RoundRobinBase.CompareWithinGroup(a, b));
+        reversed.Sort((a, b) => RoundRobinBase.CompareWithinGroup(a, b));
+
+        string[] expected = ["2 Fast", "Album D1T01", "Album D2T03", "Alpha", "Show S01E01", "Show S02E05"];
+        Assert.Equal(expected, TestItems.Names(forward));
+        Assert.Equal(expected, TestItems.Names(reversed));
+    }
+
+    // =================================================================================
+    // Shuffle
+    // =================================================================================
+
+    /// <summary>
+    /// Hard-codes the actual output for seed 42 on a 5-element list. This pins the exact
+    /// Fisher-Yates recipe (loop from Count-1 down to 1, swap index rng.Next(i + 1)) - a
+    /// plausible-looking variant (e.g. looping to 0, or rng.Next(i) instead of rng.Next(i + 1))
+    /// would still "shuffle" but produce a different sequence for this seed, so this is the only
+    /// kind of test that catches that class of bug.
+    /// </summary>
+    [Fact]
+    public void FixedSeed_ProducesAnExactReproduciblePermutation()
+    {
+        var list = new List<string> { "A", "B", "C", "D", "E" };
+
+        RoundRobinBase.Shuffle(list, new Random(42));
+
+        Assert.Equal(["C", "B", "E", "A", "D"], list);
+    }
+
+    [Fact]
+    public void SameSeed_ProducesIdenticalResultsFromIndependentRandomInstances()
+    {
+        var first = new List<string> { "A", "B", "C", "D", "E" };
+        var second = new List<string> { "A", "B", "C", "D", "E" };
+
+        RoundRobinBase.Shuffle(first, new Random(42));
+        RoundRobinBase.Shuffle(second, new Random(42));
+
+        Assert.Equal(first, second);
+    }
+
+    /// <summary>Guards against a Shuffle that ignores the passed-in Random entirely (e.g. a fixed
+    /// rotation) and would otherwise pass every other test in this section by accident.</summary>
+    [Fact]
+    public void DifferentSeeds_ProduceDifferentPermutations()
+    {
+        var seed42 = new List<string> { "A", "B", "C", "D", "E" };
+        var seed7 = new List<string> { "A", "B", "C", "D", "E" };
+
+        RoundRobinBase.Shuffle(seed42, new Random(42));
+        RoundRobinBase.Shuffle(seed7, new Random(7));
+
+        Assert.NotEqual(seed42, seed7);
+    }
+
+    [Fact]
+    public void IsAPermutation_PreservesTheMultisetAndCount()
+    {
+        var original = new List<int> { 1, 2, 2, 3, 4, 5, 5, 6, 7, 8 };
+        var shuffled = new List<int>(original);
+
+        RoundRobinBase.Shuffle(shuffled, new Random(123));
+
+        Assert.Equal(original.Count, shuffled.Count);
+        Assert.Equal(original.OrderBy(x => x), shuffled.OrderBy(x => x));
+    }
+
+    [Fact]
+    public void EmptyList_IsANoOp_AndDoesNotThrow()
+    {
+        var list = new List<string>();
+
+        var exception = Record.Exception(() => RoundRobinBase.Shuffle(list, new Random(42)));
+
+        Assert.Null(exception);
+        Assert.Empty(list);
+    }
+
+    [Fact]
+    public void SingleElementList_IsANoOp_AndDoesNotThrow()
+    {
+        var list = new List<string> { "Solo" };
+
+        var exception = Record.Exception(() => RoundRobinBase.Shuffle(list, new Random(42)));
+
+        Assert.Null(exception);
+        Assert.Equal(["Solo"], list);
+    }
+}

--- a/Jellyfin.Plugin.SmartLists.Tests/Core/Orders/RoundRobinInterleaveTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/Orders/RoundRobinInterleaveTests.cs
@@ -1,0 +1,462 @@
+using Jellyfin.Plugin.SmartLists.Core.Orders;
+using Jellyfin.Plugin.SmartLists.Tests.Support;
+using MediaBrowser.Controller.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SmartLists.Tests.Core.Orders;
+
+/// <summary>
+/// Covers the round-robin interleave engine shared by every RoundRobin* order - the non-air-block
+/// path of <c>RoundRobinBase.BuildInterleavedPositions</c>, <c>PreComputePositions</c>,
+/// <c>OrderBy</c> (both overloads) and <c>GetSortKey</c> - plus the four simple group-ordering
+/// strategies: <see cref="RoundRobinOrder"/> (A-Z), <see cref="RoundRobinOrderDesc"/> (Z-A),
+/// <see cref="RoundRobinRandomOrder"/> (random group order, natural order within groups) and
+/// <see cref="RoundRobinShuffledOrder"/> (random group order AND shuffled within groups).
+///
+/// Air blocks (Collections grouping + air-date within-group order),
+/// <c>ExtractGroupKey</c>/<c>CompareWithinGroup</c> in isolation, and
+/// <see cref="RoundRobinLeastRecentlyWatchedOrder"/> are covered by other test files - this file
+/// only relies on them working, it never exercises them directly.
+///
+/// What breaks silently if a test here goes red:
+/// - The interleave loop is "for each level, for each group: emit one item if the group still has
+///   one at that level". Swap the loop nesting and users get "all of show A, then all of show B"
+///   instead of a rotation. Drop the bounds check and an unequal-size library either throws or
+///   silently skips items from the short groups.
+/// - <c>ItemPositions</c> is a FRESH dictionary on every <c>PreComputePositions</c> call, not a
+///   merge - SmartList calls it more than once per refresh (per-group limit passes), so a merge
+///   would leak stale positions into the final order.
+/// - <c>OrderBy</c> (the single-sort fast path) and <c>GetSortKey</c> (multi-sort) must agree, or
+///   the same playlist sorts differently depending on how many sorts the user configured -
+///   SeasonNumberOrder shipped exactly that defect.
+/// </summary>
+public class RoundRobinInterleaveTests
+{
+    // ---------------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Minimal ILogger that records every call, so the "no GroupByField configured" warning can
+    /// be asserted on directly. No mocking library is available in this project, so this is a
+    /// plain interface implementation rather than a generated mock.
+    /// </summary>
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add((logLevel, formatter(state, exception)));
+        }
+    }
+
+    /// <summary>Sets GroupByField to "SeriesName" and runs PreComputePositions once.</summary>
+    private static T Configured<T>(T order, IEnumerable<BaseItem> items, ILogger? logger = null)
+        where T : RoundRobinBase
+    {
+        order.GroupByField = "SeriesName";
+        order.PreComputePositions(items, logger);
+        return order;
+    }
+
+    private static string[] OrderByNames(RoundRobinBase order, IEnumerable<BaseItem> items) =>
+        TestItems.Names(order.OrderBy(items));
+
+    /// <summary>Groups A (4 items), B (2 items), C (1 item) - fed in scrambled order so a
+    /// passthrough sort cannot pass by accident.</summary>
+    private static List<BaseItem> UnequalGroups() =>
+    [
+        TestItems.Ep("C", 1, 1),
+        TestItems.Ep("A", 1, 3),
+        TestItems.Ep("B", 1, 2),
+        TestItems.Ep("A", 1, 1),
+        TestItems.Ep("A", 1, 4),
+        TestItems.Ep("B", 1, 1),
+        TestItems.Ep("A", 1, 2),
+    ];
+
+    /// <summary>3 shows x 3 episodes each, fed in scrambled, non-natural order.</summary>
+    private static List<BaseItem> ThreeGroupsWithOutOfOrderEpisodes() =>
+    [
+        TestItems.Ep("Show A", 1, 3),
+        TestItems.Ep("Show B", 2, 1),
+        TestItems.Ep("Show C", 1, 2),
+        TestItems.Ep("Show A", 1, 1),
+        TestItems.Ep("Show B", 1, 2),
+        TestItems.Ep("Show C", 1, 1),
+        TestItems.Ep("Show A", 1, 2),
+        TestItems.Ep("Show B", 1, 1),
+        TestItems.Ep("Show C", 2, 1),
+    ];
+
+    // ---------------------------------------------------------------------------------
+    // Interleave shape
+    // ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void BuildInterleavedPositions_EqualGroupSizes_ProducesStrictRotation()
+    {
+        var items = new List<BaseItem>
+        {
+            TestItems.Ep("B", 1, 2),
+            TestItems.Ep("A", 1, 1),
+            TestItems.Ep("C", 1, 1),
+            TestItems.Ep("A", 1, 2),
+            TestItems.Ep("C", 1, 2),
+            TestItems.Ep("B", 1, 1),
+        };
+
+        var names = OrderByNames(Configured(new RoundRobinOrder(), items), items);
+
+        Assert.Equal(
+            ["A S01E01", "B S01E01", "C S01E01", "A S01E02", "B S01E02", "C S01E02"],
+            names);
+    }
+
+    /// <summary>
+    /// The `if (level &lt; group.Count)` branch: once B and C run out, A keeps rotating alone
+    /// instead of the loop throwing or skipping A's remaining episodes.
+    /// </summary>
+    [Fact]
+    public void BuildInterleavedPositions_UnequalGroupSizes_ShortGroupsDropOut_ButTheRestKeepRotating()
+    {
+        var items = UnequalGroups();
+
+        var names = OrderByNames(Configured(new RoundRobinOrder(), items), items);
+
+        Assert.Equal(
+            ["A S01E01", "B S01E01", "C S01E01", "A S01E02", "B S01E02", "A S01E03", "A S01E04"],
+            names);
+    }
+
+    [Fact]
+    public void BuildInterleavedPositions_AssignsDenseContiguousPositions_WithNoGapsOrDuplicates()
+    {
+        var items = UnequalGroups();
+
+        var order = Configured(new RoundRobinOrder(), items);
+
+        var positions = order.ItemPositions.Values.OrderBy(p => p).ToList();
+        Assert.Equal(Enumerable.Range(0, items.Count), positions);
+        Assert.Equal(items.Count, order.ItemPositions.Keys.Distinct().Count());
+    }
+
+    /// <summary>
+    /// Group keys are folded case-insensitively (the groups Dictionary is built with
+    /// StringComparer.OrdinalIgnoreCase), so metadata that disagrees only on casing - "Marvel" vs
+    /// "marvel", "Action" vs "action" - is ONE rotation group, not two. Nothing else in the suite
+    /// pins this: ExtractGroupKey deliberately returns the raw casing, so the fold happens only
+    /// here, and swapping the comparer to Ordinal is a silent change that splits a user's rotation
+    /// in half.
+    ///
+    /// The two outcomes are distinguishable by design. Folded: one group of three, emitted in
+    /// natural order (E01, E02, E03). Split: two groups that tie under the case-insensitive
+    /// natural comparer used for group ordering, so they interleave and E03 lands in the middle
+    /// (E01, E03, E02).
+    /// </summary>
+    [Fact]
+    public void GroupKeys_AreFoldedCaseInsensitively_SoCasingDifferencesDoNotSplitAGroup()
+    {
+        var items = new List<BaseItem>
+        {
+            TestItems.Ep("Show", 1, 1),
+            TestItems.Ep("Show", 1, 2),
+            TestItems.Ep("SHOW", 1, 3),
+        };
+
+        var names = OrderByNames(Configured(new RoundRobinOrder(), items), items);
+
+        Assert.Equal(["Show S01E01", "Show S01E02", "SHOW S01E03"], names);
+        // What a case-SENSITIVE grouping would have produced instead.
+        Assert.NotEqual(["Show S01E01", "SHOW S01E03", "Show S01E02"], names);
+    }
+
+    // ---------------------------------------------------------------------------------
+    // Within-group order survives every group-ordering strategy
+    // ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void WithinGroupOrder_IsNaturalSeasonThenEpisode_ForEveryNonShuffledVariant()
+    {
+        var items = ThreeGroupsWithOutOfOrderEpisodes();
+        RoundRobinBase[] orders =
+        [
+            Configured(new RoundRobinOrder(), items),
+            Configured(new RoundRobinOrderDesc(), items),
+            Configured(new RoundRobinRandomOrder(), items),
+        ];
+
+        foreach (var order in orders)
+        {
+            var showB = OrderByNames(order, items).Where(n => n.StartsWith("Show B ", StringComparison.Ordinal)).ToArray();
+            Assert.Equal(["Show B S01E01", "Show B S01E02", "Show B S02E01"], showB);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------
+    // Group order per subclass
+    // ---------------------------------------------------------------------------------
+
+    /// <summary>
+    /// SharedNaturalComparer only treats a LEADING number as numeric (see NameOrderTests), so the
+    /// group keys must start with the digit for this to matter - "2 Show"/"10 Show", not
+    /// "Show 2"/"Show 10" (those have no leading digit, fall back to plain string comparison, and
+    /// would coincidentally land in the same order either way).
+    /// </summary>
+    [Fact]
+    public void RoundRobinOrder_OrdersGroupsAscending_UsingTheNaturalComparer_NotPlainStringSort()
+    {
+        var items = new List<BaseItem>
+        {
+            TestItems.Ep("10 Show", 1, 1),
+            TestItems.Ep("2 Show", 1, 1),
+        };
+
+        var names = OrderByNames(Configured(new RoundRobinOrder(), items), items);
+
+        Assert.Equal(["2 Show S01E01", "10 Show S01E01"], names);
+        // Plain ordinal string sort would put "10 Show" first - the opposite of natural order.
+        Assert.NotEqual(["10 Show S01E01", "2 Show S01E01"], names);
+    }
+
+    /// <summary>
+    /// Every item its own group, so group ordering is the ONLY thing deciding the sequence - and
+    /// pins that descending is the exact reverse of ascending over the same group set.
+    /// </summary>
+    [Fact]
+    public void PreComputePositions_EveryItemInItsOwnGroup_AscendingIsNaturalOrder_DescendingIsTheExactReverse()
+    {
+        var items = new List<BaseItem>
+        {
+            TestItems.Ep("Zulu", 1, 1),
+            TestItems.Ep("Alpha", 1, 1),
+            TestItems.Ep("Mike", 1, 1),
+        };
+
+        var ascending = OrderByNames(Configured(new RoundRobinOrder(), items), items);
+        var descending = OrderByNames(Configured(new RoundRobinOrderDesc(), items), items);
+
+        Assert.Equal(["Alpha S01E01", "Mike S01E01", "Zulu S01E01"], ascending);
+        Assert.Equal(ascending.Reverse().ToArray(), descending);
+    }
+
+    // ---------------------------------------------------------------------------------
+    // Degenerate inputs
+    // ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void PreComputePositions_EmptyItemList_ProducesNoPositionsAndNoWarning()
+    {
+        var logger = new CapturingLogger();
+        var order = new RoundRobinOrder { GroupByField = "SeriesName" };
+
+        order.PreComputePositions(new List<BaseItem>(), logger);
+
+        Assert.Empty(order.ItemPositions);
+        // Distinct from the "missing GroupByField" case below: no items means the count==0 branch
+        // of the guard fires and the warning is never reached at all.
+        Assert.Empty(logger.Entries);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void PreComputePositions_MissingGroupByField_ProducesNoPositions_LogsAWarning_AndOrderByKeepsInputOrder(string? groupByField)
+    {
+        var items = new List<BaseItem>
+        {
+            TestItems.Ep("Z", 1, 1),
+            TestItems.Ep("A", 1, 1),
+        };
+        var logger = new CapturingLogger();
+        var order = new RoundRobinOrder { GroupByField = groupByField };
+
+        order.PreComputePositions(items, logger);
+
+        Assert.Empty(order.ItemPositions);
+        Assert.Contains(
+            logger.Entries,
+            e => e.Level == LogLevel.Warning && e.Message.Contains("no GroupByField configured", StringComparison.Ordinal));
+
+        // ItemPositions.Count == 0 short-circuits OrderBy back to the untouched input sequence.
+        Assert.Equal(TestItems.Names(items), TestItems.Names(order.OrderBy(items)));
+    }
+
+    [Fact]
+    public void PreComputePositions_SingleGroup_ProducesPlainNaturalOrder()
+    {
+        var items = new List<BaseItem>
+        {
+            TestItems.Ep("Show", 1, 3),
+            TestItems.Ep("Show", 1, 1),
+            TestItems.Ep("Show", 1, 2),
+        };
+
+        var names = OrderByNames(Configured(new RoundRobinOrder(), items), items);
+
+        Assert.Equal(["Show S01E01", "Show S01E02", "Show S01E03"], names);
+    }
+
+    // ---------------------------------------------------------------------------------
+    // OrderBy vs GetSortKey agreement
+    // ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void OrderByAndGetSortKey_ProduceTheSameSequence()
+    {
+        var items = UnequalGroups();
+        var order = Configured(new RoundRobinOrder(), items);
+
+        var viaOrderBy = OrderByNames(order, items);
+        var viaGetSortKey = TestItems.Names(items.OrderBy(i => order.GetSortKey(i, TestItems.User, null, null)));
+
+        Assert.Equal(viaOrderBy, viaGetSortKey);
+    }
+
+    /// <summary>
+    /// A miss in ItemPositions falls back to int.MaxValue in both OrderBy and GetSortKey, so an
+    /// item that was never part of the precomputed set sorts last instead of throwing or landing
+    /// at some arbitrary spot.
+    /// </summary>
+    [Fact]
+    public void ItemsAbsentFromPrecomputedPositions_SortLast_ViaBothOrderByAndGetSortKey()
+    {
+        var items = UnequalGroups();
+        var order = Configured(new RoundRobinOrder(), items);
+        var stray = TestItems.Ep("Stray", 1, 1);
+
+        Assert.Equal(int.MaxValue, order.GetSortKey(stray, TestItems.User, null, null));
+
+        var withStray = new List<BaseItem>(items) { stray };
+        var sorted = OrderByNames(order, withStray);
+
+        Assert.Equal("Stray S01E01", sorted[^1]);
+        Assert.Equal(OrderByNames(order, items), sorted[..^1]);
+    }
+
+    // ---------------------------------------------------------------------------------
+    // Stale state
+    // ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void PreComputePositions_SecondCall_ReplacesItemPositions_RatherThanMerging()
+    {
+        // SmartList calls PreComputePositions more than once per refresh (intermediate passes for
+        // per-group limits), so a merge here would let ids from an earlier pass leak into the
+        // final order.
+        var firstBatch = new List<BaseItem> { TestItems.Ep("A", 1, 1), TestItems.Ep("B", 1, 1) };
+        var order = Configured(new RoundRobinOrder(), firstBatch);
+        Assert.Equal(2, order.ItemPositions.Count);
+
+        var secondBatch = new List<BaseItem> { TestItems.Ep("C", 1, 1) };
+        order.PreComputePositions(secondBatch);
+
+        Assert.Equal([secondBatch[0].Id], order.ItemPositions.Keys);
+        Assert.All(firstBatch, item => Assert.False(order.ItemPositions.ContainsKey(item.Id)));
+    }
+
+    // ---------------------------------------------------------------------------------
+    // Random variants - not assertable by exact sequence, so these pin invariants instead.
+    // ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void RoundRobinRandomOrder_GroupOrder_IsActuallyRandomised_AcrossManyRuns()
+    {
+        // 4 single-item groups isolate the group-order signal from within-group order entirely.
+        var items = new List<BaseItem>
+        {
+            TestItems.Ep("Alpha", 1, 1),
+            TestItems.Ep("Bravo", 1, 1),
+            TestItems.Ep("Charlie", 1, 1),
+            TestItems.Ep("Delta", 1, 1),
+        };
+        var order = new RoundRobinRandomOrder { GroupByField = "SeriesName" };
+
+        // 50 runs of a 4-group (4! = 24 arrangements) shuffle: the probability of a genuine
+        // Fisher-Yates shuffle never producing a second distinct arrangement across 50 independent
+        // draws is (1/24)^49 - a false failure here is not realistically possible.
+        var seen = new HashSet<string>();
+        for (var i = 0; i < 50; i++)
+        {
+            order.PreComputePositions(items);
+            seen.Add(string.Join(",", OrderByNames(order, items)));
+        }
+
+        Assert.True(seen.Count > 1, "RoundRobinRandomOrder never produced more than one distinct group ordering across 50 runs.");
+
+        // The permutation invariant (nothing dropped or duplicated) holds on every run too.
+        var lastRun = OrderByNames(order, items);
+        Assert.Equal(TestItems.Names(items).OrderBy(n => n, StringComparer.Ordinal), lastRun.OrderBy(n => n, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void RoundRobinRandomOrder_PreservesWithinGroupNaturalOrder_AcrossManyRuns()
+    {
+        var items = new List<BaseItem>
+        {
+            TestItems.Ep("Show", 1, 3),
+            TestItems.Ep("Other", 1, 2),
+            TestItems.Ep("Show", 2, 1),
+            TestItems.Ep("Show", 1, 1),
+            TestItems.Ep("Other", 1, 1),
+            TestItems.Ep("Show", 1, 2),
+        };
+        var order = new RoundRobinRandomOrder { GroupByField = "SeriesName" };
+
+        for (var i = 0; i < 20; i++)
+        {
+            order.PreComputePositions(items);
+            var showOrder = OrderByNames(order, items).Where(n => n.StartsWith("Show S", StringComparison.Ordinal)).ToArray();
+            Assert.Equal(["Show S01E01", "Show S01E02", "Show S01E03", "Show S02E01"], showOrder);
+        }
+    }
+
+    [Fact]
+    public void RoundRobinShuffledOrder_OutputIsAPermutationOfTheInput()
+    {
+        var items = ThreeGroupsWithOutOfOrderEpisodes();
+        var order = Configured(new RoundRobinShuffledOrder(), items);
+
+        var result = OrderByNames(order, items);
+
+        Assert.Equal(items.Count, result.Length);
+        Assert.Equal(TestItems.Names(items).OrderBy(n => n, StringComparer.Ordinal), result.OrderBy(n => n, StringComparer.Ordinal));
+    }
+
+    /// <summary>
+    /// The whole difference from RoundRobinRandomOrder: if ShuffleWithinGroups were ever dropped,
+    /// RoundRobinShuffledOrder would silently become its base class, and a single group would sort
+    /// in natural order on every run instead of varying.
+    /// </summary>
+    [Fact]
+    public void RoundRobinShuffledOrder_ShufflesWithinGroups_AcrossManyRuns_UnlikeRoundRobinRandomOrder()
+    {
+        // A single group: with only one group, group-order randomisation cannot produce any
+        // variation, so ANY variation seen here can only come from ShuffleWithinGroups.
+        var items = new List<BaseItem>
+        {
+            TestItems.Ep("Show", 1, 1),
+            TestItems.Ep("Show", 1, 2),
+            TestItems.Ep("Show", 1, 3),
+            TestItems.Ep("Show", 1, 4),
+        };
+        var order = new RoundRobinShuffledOrder { GroupByField = "SeriesName" };
+
+        // 50 runs of a 4-item (4! = 24 arrangements) shuffle: probability of never seeing a second
+        // arrangement under a genuine shuffle is (1/24)^49 - not realistically reachable by chance.
+        var seen = new HashSet<string>();
+        for (var i = 0; i < 50; i++)
+        {
+            order.PreComputePositions(items);
+            seen.Add(string.Join(",", OrderByNames(order, items)));
+        }
+
+        Assert.True(seen.Count > 1, "RoundRobinShuffledOrder never varied the within-group order across 50 runs - ShuffleWithinGroups may have been dropped.");
+    }
+}

--- a/Jellyfin.Plugin.SmartLists.Tests/Core/Orders/RoundRobinLeastRecentlyWatchedTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/Orders/RoundRobinLeastRecentlyWatchedTests.cs
@@ -214,7 +214,12 @@ public class RoundRobinLeastRecentlyWatchedTests
     private static List<string> InvokeOrderGroupKeys(RoundRobinLeastRecentlyWatchedOrder order, IEnumerable<string> keys)
     {
         var method = typeof(RoundRobinLeastRecentlyWatchedOrder).GetMethod(
-            "OrderGroupKeys", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            "OrderGroupKeys", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        // Named failure instead of a bare NullReferenceException if the method is ever renamed -
+        // reflection turns what would be a compile error into a runtime one, so say which member.
+        Assert.NotNull(method);
+
         return (List<string>)method.Invoke(order, [keys])!;
     }
 
@@ -306,8 +311,7 @@ public class RoundRobinLeastRecentlyWatchedTests
         {
             (Func<RefreshQueueService.RefreshCache, BaseItem[], BaseItem>)((cache, children) =>
             {
-                var season = new Season { Id = Guid.NewGuid(), Name = "Aggregate Season" };
-                season.SortName = season.Name;
+                var season = TestItems.SeasonOf("Aggregate Season");
                 cache.SeasonEpisodes[(season.Id, TestItems.User.Id)] = children;
                 return season;
             })
@@ -316,8 +320,7 @@ public class RoundRobinLeastRecentlyWatchedTests
         {
             (Func<RefreshQueueService.RefreshCache, BaseItem[], BaseItem>)((cache, children) =>
             {
-                var album = new MusicAlbum { Id = Guid.NewGuid(), Name = "Aggregate Album" };
-                album.SortName = album.Name;
+                var album = TestItems.Album("Aggregate Album");
                 cache.AlbumTracks[(album.Id, TestItems.User.Id)] = children;
                 return album;
             })

--- a/Jellyfin.Plugin.SmartLists.Tests/Core/Orders/RoundRobinLeastRecentlyWatchedTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/Orders/RoundRobinLeastRecentlyWatchedTests.cs
@@ -1,0 +1,667 @@
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SmartLists.Core.Orders;
+using Jellyfin.Plugin.SmartLists.Services.Shared;
+using Jellyfin.Plugin.SmartLists.Tests.Support;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Library;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SmartLists.Tests.Core.Orders;
+
+/// <summary>
+/// Covers <see cref="RoundRobinLeastRecentlyWatchedOrder"/>: the sort that makes a rotation
+/// "continue where the user left off" with NO persisted state - group order is derived entirely,
+/// on every refresh, from per-user <c>LastPlayedDate</c> data. Three things pinned here:
+///
+/// 1. <c>OrderGroupKeys</c> - least recently watched first, never-watched groups first of all,
+///    alphabetical (natural, numeric-aware) tie-break, and a group in <c>HeldGroups</c> is treated
+///    as MinValue (never-watched tier) regardless of how recently it was actually watched.
+/// 2. <c>BuildGroupRecencyAndHoldState</c> - builds <c>GroupRecency</c> (and, when air blocks are
+///    active, the hold's raw watch-state) for one user from the unfiltered item pool. The single
+///    most load-bearing rule here: only FULLY PLAYED items advance the rotation, because Jellyfin
+///    stamps <c>LastPlayedDate</c> on any playback (including a half-watched one).
+/// 3. <c>ApplyMidBlockHold</c> (and the <c>PreComputePositions</c> override that calls it before
+///    the base interleave runs) - the collections+air-date special case: a group whose most
+///    recently played item sits in an air block that still has an unwatched, visible item stays
+///    at the front of the rotation until that block is finished.
+///
+/// OUT OF SCOPE (owned by other test files, see RoundRobinGroupingTests / RoundRobinAirBlockTests /
+/// RoundRobinInterleaveTests): ExtractGroupKey/CompareWithinGroup/Shuffle in isolation, the plain
+/// interleave mechanics, and ChunkIntoAirBlocks/CompareWithinGroupByAirDate in isolation. This file
+/// relies on all of those working and only exercises them through the Least Recently Watched
+/// subclass's own logic.
+///
+/// THREE GUARDS THIS FILE DELIBERATELY DOES NOT TEST, because they are unreachable through the
+/// public/internal surface given how <c>ApplyMidBlockHold</c> and <c>BuildGroupRecencyAndHoldState</c>
+/// are wired together today (see the report for the full reasoning):
+/// - The Id-based anchor tie-break (third tier, after LastPlayed and air date). Two items tied on
+///   BOTH LastPlayed and air date are always chained into the SAME air block by
+///   <c>ChunkIntoAirBlocks</c> (same date, within any non-negative window), so whichever one
+///   "wins" as anchor, the hold check inspects the same block either way - the outcome of
+///   <c>HeldGroups</c> never changes.
+/// - "items with no timestamp never anchor" (<c>if (lastPlayed == DateTime.MinValue) continue;</c>).
+///   Any item that reaches the anchor loop with a real timestamp always outranks a MinValue one in
+///   the primary comparison, and a group made up ENTIRELY of no-timestamp items never gets a
+///   <c>GroupRecency</c> entry in the first place (that requires <c>lastPlayed &gt; DateTime.MinValue</c>),
+///   so <c>ApplyMidBlockHold</c>'s own <c>!GroupRecency.ContainsKey(...)</c> guard already skips it.
+/// - The <c>bestAir == DateTime.MinValue</c> "no dated watch history" bail-out. An anchor with no
+///   air date can never chain with anything in <c>ChunkIntoAirBlocks</c> (chaining requires
+///   <c>date &gt; DateTime.MinValue</c>), so its block is always a singleton containing only the
+///   (watched) anchor - there is never an unwatched companion in it to find either way.
+/// </summary>
+public class RoundRobinLeastRecentlyWatchedTests
+{
+    // ---------------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Minimal ILogger that records every call, matching the pattern used by the sibling
+    /// RoundRobin* test files. No mocking library is available in this project.
+    /// </summary>
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add((logLevel, formatter(state, exception)));
+        }
+    }
+
+    public enum CompanionState { Watched, InProgress }
+
+    /// <summary>
+    /// A two-episode "crossover night": Show A (the anchor - watched, most recently played) and
+    /// Show B (a same-air-date companion whose watch state the caller controls), both mapped into
+    /// the "Crossover Night" collection and pre-processed through BuildGroupRecencyAndHoldState.
+    /// Callers build their own filteredItems list from the returned episodes to control who is
+    /// visible to the playlist.
+    /// </summary>
+    private static (RoundRobinLeastRecentlyWatchedOrder Order, Episode Anchor, Episode Companion) SetUpCrossoverNight(
+        RefreshQueueService.RefreshCache cache, CompanionState companionState)
+    {
+        var showA = TestItems.Show("Show A");
+        var showB = TestItems.Show("Show B");
+        var airDate = new DateTime(2024, 1, 1);
+        var anchor = TestItems.Ep("Show A", 1, 1, aired: airDate, show: showA);
+        var companion = TestItems.Ep("Show B", 1, 1, aired: airDate, show: showB);
+
+        TestItems.SeedUserData(cache, anchor, TestItems.User, played: true, lastPlayed: new DateTime(2024, 6, 1));
+        if (companionState == CompanionState.Watched)
+        {
+            TestItems.SeedUserData(cache, companion, TestItems.User, played: true, lastPlayed: new DateTime(2024, 6, 1));
+        }
+        else
+        {
+            // In-progress: LastPlayedDate set but Played still false - this is what makes the
+            // companion show up in the block topology (via WatchedByGroup) while still counting
+            // as unwatched (via UnwatchedCollectionItemIds).
+            TestItems.SeedUserData(cache, companion, TestItems.User, played: false, lastPlayed: new DateTime(2024, 5, 1));
+        }
+
+        var order = new RoundRobinLeastRecentlyWatchedOrder
+        {
+            GroupByField = "Collections",
+            OrderWithinGroupsByAirDate = true,
+            CollectionGroupKeys = TestItems.CollectionMap(("Crossover Night", new BaseItem[] { anchor, companion })),
+        };
+
+        order.BuildGroupRecencyAndHoldState(new BaseItem[] { anchor, companion }, TestItems.User, TestItems.ThrowingUserData(), cache, logger: null);
+
+        return (order, anchor, companion);
+    }
+
+    // =================================================================================
+    // OrderGroupKeys
+    // =================================================================================
+
+    [Fact]
+    public void OrderGroupKeys_SortsAscendingByRecency_LeastRecentlyWatchedFirst()
+    {
+        var showA = TestItems.Mov("Show A");
+        var showB = TestItems.Mov("Show B");
+        var showC = TestItems.Mov("Show C");
+
+        var order = new RoundRobinLeastRecentlyWatchedOrder { GroupByField = "SeriesName" };
+        order.GroupRecency["Show A"] = new DateTime(2024, 1, 1);
+        order.GroupRecency["Show B"] = new DateTime(2024, 1, 15);
+        order.GroupRecency["Show C"] = new DateTime(2024, 1, 8);
+
+        order.PreComputePositions(new BaseItem[] { showA, showB, showC });
+
+        Assert.Equal(["Show A", "Show C", "Show B"], TestItems.Names(order.OrderBy(new BaseItem[] { showA, showB, showC })));
+    }
+
+    [Fact]
+    public void OrderGroupKeys_GroupAbsentFromRecency_IsTreatedAsNeverWatched_AndSortsFirst()
+    {
+        var watched = TestItems.Mov("Watched Show");
+        var neverWatched = TestItems.Mov("Never Watched Show");
+
+        var order = new RoundRobinLeastRecentlyWatchedOrder { GroupByField = "SeriesName" };
+        order.GroupRecency["Watched Show"] = new DateTime(2024, 1, 1);
+        // "Never Watched Show" deliberately absent from GroupRecency.
+
+        order.PreComputePositions(new BaseItem[] { watched, neverWatched });
+
+        Assert.Equal(["Never Watched Show", "Watched Show"], TestItems.Names(order.OrderBy(new BaseItem[] { watched, neverWatched })));
+    }
+
+    /// <summary>
+    /// "Show 2" vs "Show 10" is deliberate: a plain ordinal string compare puts "Show 10" first
+    /// (the '1' in "10" &lt; the '2' in "2"), but the natural comparer only special-cases a number at
+    /// the very START of the string, so the group names have to lead with the digit ("2 Show" /
+    /// "10 Show", not "Show 2" / "Show 10") for the numeric path to even be reachable. Covers both
+    /// tie tiers - equal real dates, and the shared MinValue tier when both groups are never watched.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void OrderGroupKeys_TiesBreakAlphabetically_UsingTheNaturalNumericAwareComparer(bool tiedOnARealDate)
+    {
+        var show2 = TestItems.Mov("2 Show");
+        var show10 = TestItems.Mov("10 Show");
+
+        var order = new RoundRobinLeastRecentlyWatchedOrder { GroupByField = "SeriesName" };
+        if (tiedOnARealDate)
+        {
+            var tie = new DateTime(2024, 1, 1);
+            order.GroupRecency["2 Show"] = tie;
+            order.GroupRecency["10 Show"] = tie;
+        }
+
+        order.PreComputePositions(new BaseItem[] { show10, show2 });
+        var result = TestItems.Names(order.OrderBy(new BaseItem[] { show10, show2 }));
+
+        Assert.Equal(["2 Show", "10 Show"], result);
+        Assert.NotEqual(["10 Show", "2 Show"], result);
+    }
+
+    /// <summary>
+    /// A held group sorts as MinValue REGARDLESS of its real recency - not merely "before" a
+    /// never-watched group by virtue of an earlier date, but genuinely TIED with it and decided
+    /// only by the alphabetical tie-break. "Aaa Held Show" carries a very recent real date but is
+    /// held; "Zzz Unwatched Show" is absent from GroupRecency entirely. If HeldGroups were ignored,
+    /// the held show's real (very recent) date would push it to sort AFTER the absent one instead.
+    ///
+    /// This calls the protected OrderGroupKeys directly via reflection rather than going through
+    /// PreComputePositions: PreComputePositions runs ApplyMidBlockHold first, which unconditionally
+    /// clears HeldGroups (by design - see the ApplyMidBlockHold tests below) before recomputing it,
+    /// so a HeldGroups entry seeded by hand here would just be wiped out before OrderGroupKeys ever
+    /// saw it. Reflection isolates the one piece under test.
+    /// </summary>
+    [Fact]
+    public void OrderGroupKeys_HeldGroup_TiesWithTheNeverWatchedTier_RatherThanUsingItsRealRecency()
+    {
+        var order = new RoundRobinLeastRecentlyWatchedOrder { GroupByField = "SeriesName" };
+        order.GroupRecency["Aaa Held Show"] = new DateTime(2026, 1, 1); // very recent
+        order.HeldGroups.Add("Aaa Held Show");
+        // "Zzz Unwatched Show" absent from GroupRecency -> never-watched tier (MinValue).
+
+        var result = InvokeOrderGroupKeys(order, ["Zzz Unwatched Show", "Aaa Held Show"]);
+
+        Assert.Equal(["Aaa Held Show", "Zzz Unwatched Show"], result);
+    }
+
+    private static List<string> InvokeOrderGroupKeys(RoundRobinLeastRecentlyWatchedOrder order, IEnumerable<string> keys)
+    {
+        var method = typeof(RoundRobinLeastRecentlyWatchedOrder).GetMethod(
+            "OrderGroupKeys", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        return (List<string>)method.Invoke(order, [keys])!;
+    }
+
+    // =================================================================================
+    // BuildGroupRecencyAndHoldState
+    // =================================================================================
+
+    [Fact]
+    public void BuildGroupRecencyAndHoldState_TakesTheMaximumLastPlayedDateAcrossItemsInAGroup()
+    {
+        var cache = new RefreshQueueService.RefreshCache();
+        var earlyEpisode = TestItems.Ep("Show A", 1, 1);
+        var laterEpisode = TestItems.Ep("Show A", 1, 2);
+        TestItems.SeedUserData(cache, earlyEpisode, TestItems.User, played: true, lastPlayed: new DateTime(2024, 1, 1));
+        TestItems.SeedUserData(cache, laterEpisode, TestItems.User, played: true, lastPlayed: new DateTime(2024, 6, 1));
+
+        var order = new RoundRobinLeastRecentlyWatchedOrder { GroupByField = "SeriesName" };
+        order.BuildGroupRecencyAndHoldState(new BaseItem[] { earlyEpisode, laterEpisode }, TestItems.User, TestItems.ThrowingUserData(), cache, logger: null);
+
+        Assert.Equal(new DateTime(2024, 6, 1), order.GroupRecency["Show A"]);
+    }
+
+    /// <summary>
+    /// THE single most valuable assertion in this file. Jellyfin stamps LastPlayedDate on ANY
+    /// playback, so a half-watched episode (Played == false) carries a real, possibly very recent,
+    /// timestamp. If that timestamp were allowed to advance recency, stopping partway through an
+    /// episode would send the whole show to the BACK of the rotation instead of leaving it at the
+    /// front where an unfinished show belongs.
+    /// </summary>
+    [Fact]
+    public void BuildGroupRecencyAndHoldState_OnlyFullyPlayedItems_AdvanceRecency()
+    {
+        var cache = new RefreshQueueService.RefreshCache();
+        var oldButFullyWatched = TestItems.Ep("Show A", 1, 1);
+        var recentButHalfWatched = TestItems.Ep("Show B", 1, 1);
+
+        TestItems.SeedUserData(cache, oldButFullyWatched, TestItems.User, played: true, lastPlayed: new DateTime(2020, 1, 1));
+        // A very recent timestamp, but Played is still false - the user stopped partway through.
+        TestItems.SeedUserData(cache, recentButHalfWatched, TestItems.User, played: false, lastPlayed: new DateTime(2026, 1, 1));
+
+        var order = new RoundRobinLeastRecentlyWatchedOrder { GroupByField = "SeriesName" };
+        order.BuildGroupRecencyAndHoldState(new BaseItem[] { oldButFullyWatched, recentButHalfWatched }, TestItems.User, TestItems.ThrowingUserData(), cache, logger: null);
+
+        Assert.Equal(new DateTime(2020, 1, 1), order.GroupRecency["Show A"]);
+        // If the Played check were dropped, "Show B" would appear here with the 2026 date instead
+        // of being absent (never-watched tier, sorts at the FRONT).
+        Assert.False(order.GroupRecency.ContainsKey("Show B"));
+    }
+
+    /// <summary>
+    /// Series/Season/MusicAlbum use the aggregate date over their cached children (mirroring
+    /// LastPlayedOrderBase) INSTEAD of their own user-data row - and that aggregate counts even
+    /// when the child itself is only half-watched, because it is read straight off LastPlayedDate
+    /// with no Played gate (folder Played flags are unreliable, so this path never trusted one to
+    /// begin with). The container's own row is a negative cache hit, proving the date comes
+    /// entirely from the children.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ContainerCases))]
+    public void BuildGroupRecencyAndHoldState_ContainerItems_UseTheAggregateDateOverCachedChildren(
+        Func<RefreshQueueService.RefreshCache, BaseItem[], BaseItem> buildContainerAndSeedChildren)
+    {
+        var cache = new RefreshQueueService.RefreshCache();
+        var child = TestItems.Ep("Ignored", 1, 1, name: "Child Episode");
+        var childDate = new DateTime(2023, 5, 1);
+        TestItems.SeedUserData(cache, child, TestItems.User, played: false, lastPlayed: childDate);
+
+        var container = buildContainerAndSeedChildren(cache, new BaseItem[] { child });
+        TestItems.SeedNoUserData(cache, container, TestItems.User);
+
+        var order = new RoundRobinLeastRecentlyWatchedOrder { GroupByField = "SeriesName" };
+        order.BuildGroupRecencyAndHoldState(new BaseItem[] { container }, TestItems.User, TestItems.ThrowingUserData(), cache, logger: null);
+
+        Assert.Equal(childDate, order.GroupRecency[container.Name!]);
+    }
+
+    public static IEnumerable<object[]> ContainerCases()
+    {
+        yield return new object[]
+        {
+            (Func<RefreshQueueService.RefreshCache, BaseItem[], BaseItem>)((cache, children) =>
+            {
+                var series = TestItems.Show("Aggregate Series");
+                cache.SeriesEpisodes[(series.Id, TestItems.User.Id)] = children;
+                return series;
+            })
+        };
+        yield return new object[]
+        {
+            (Func<RefreshQueueService.RefreshCache, BaseItem[], BaseItem>)((cache, children) =>
+            {
+                var season = new Season { Id = Guid.NewGuid(), Name = "Aggregate Season" };
+                season.SortName = season.Name;
+                cache.SeasonEpisodes[(season.Id, TestItems.User.Id)] = children;
+                return season;
+            })
+        };
+        yield return new object[]
+        {
+            (Func<RefreshQueueService.RefreshCache, BaseItem[], BaseItem>)((cache, children) =>
+            {
+                var album = new MusicAlbum { Id = Guid.NewGuid(), Name = "Aggregate Album" };
+                album.SortName = album.Name;
+                cache.AlbumTracks[(album.Id, TestItems.User.Id)] = children;
+                return album;
+            })
+        };
+    }
+
+    [Fact]
+    public void BuildGroupRecencyAndHoldState_IsPerUser_SoTheSameItemProducesDifferentRecencyForADifferentUser()
+    {
+        var cache = new RefreshQueueService.RefreshCache();
+        var movie = TestItems.Mov("Show A");
+        TestItems.SeedUserData(cache, movie, TestItems.User, played: true, lastPlayed: new DateTime(2024, 1, 1));
+        TestItems.SeedUserData(cache, movie, TestItems.OtherUser, played: true, lastPlayed: new DateTime(2024, 6, 1));
+
+        var order = new RoundRobinLeastRecentlyWatchedOrder { GroupByField = "SeriesName" };
+
+        order.BuildGroupRecencyAndHoldState(new BaseItem[] { movie }, TestItems.User, TestItems.ThrowingUserData(), cache, logger: null);
+        Assert.Equal(new DateTime(2024, 1, 1), order.GroupRecency["Show A"]);
+
+        order.BuildGroupRecencyAndHoldState(new BaseItem[] { movie }, TestItems.OtherUser, TestItems.ThrowingUserData(), cache, logger: null);
+        Assert.Equal(new DateTime(2024, 6, 1), order.GroupRecency["Show A"]);
+    }
+
+    [Fact]
+    public void BuildGroupRecencyAndHoldState_MissingGroupByField_LeavesRecencyEmpty_AndLogsAWarning()
+    {
+        var order = new RoundRobinLeastRecentlyWatchedOrder(); // GroupByField never set
+        var logger = new CapturingLogger();
+
+        order.BuildGroupRecencyAndHoldState(new BaseItem[] { TestItems.Mov("Whatever") }, TestItems.User, TestItems.ThrowingUserData(), new RefreshQueueService.RefreshCache(), logger);
+
+        Assert.Empty(order.GroupRecency);
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning);
+    }
+
+    [Fact]
+    public void BuildGroupRecencyAndHoldState_NullUserDataManager_LeavesRecencyEmpty_AndLogsAWarning()
+    {
+        var order = new RoundRobinLeastRecentlyWatchedOrder { GroupByField = "SeriesName" };
+        var logger = new CapturingLogger();
+
+        order.BuildGroupRecencyAndHoldState(new BaseItem[] { TestItems.Mov("Whatever") }, TestItems.User, null, new RefreshQueueService.RefreshCache(), logger);
+
+        Assert.Empty(order.GroupRecency);
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning);
+    }
+
+    [Fact]
+    public void BuildGroupRecencyAndHoldState_NullUser_LeavesRecencyEmpty_AndLogsAWarning()
+    {
+        var order = new RoundRobinLeastRecentlyWatchedOrder { GroupByField = "SeriesName" };
+        var logger = new CapturingLogger();
+
+        order.BuildGroupRecencyAndHoldState(new BaseItem[] { TestItems.Mov("Whatever") }, null!, TestItems.ThrowingUserData(), new RefreshQueueService.RefreshCache(), logger);
+
+        Assert.Empty(order.GroupRecency);
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning);
+    }
+
+    /// <summary>
+    /// Each item's work is wrapped in its own try/catch specifically so one bad item (a cache
+    /// miss that reaches a throwing manager, a reflection failure, ...) cannot blank out recency
+    /// for every other group in the same refresh. "Show B" has no cache entry at all (neither
+    /// positive nor negative), so the cache-first lookup genuinely falls through to the manager -
+    /// which is the throwing stub - forcing an honest exception instead of a stubbed one.
+    /// </summary>
+    [Fact]
+    public void BuildGroupRecencyAndHoldState_AnItemThatThrows_IsSkipped_ButOtherItemsStillProcess()
+    {
+        var cache = new RefreshQueueService.RefreshCache();
+        var okItem = TestItems.Mov("Show A");
+        var badItem = TestItems.Mov("Show B"); // deliberately not seeded: genuine cache miss
+        TestItems.SeedUserData(cache, okItem, TestItems.User, played: true, lastPlayed: new DateTime(2024, 3, 1));
+        var logger = new CapturingLogger();
+
+        var order = new RoundRobinLeastRecentlyWatchedOrder { GroupByField = "SeriesName" };
+        var exception = Record.Exception(() =>
+            order.BuildGroupRecencyAndHoldState(new BaseItem[] { okItem, badItem }, TestItems.User, TestItems.ThrowingUserData(), cache, logger));
+
+        Assert.Null(exception);
+        Assert.Equal(new DateTime(2024, 3, 1), order.GroupRecency["Show A"]);
+        Assert.False(order.GroupRecency.ContainsKey("Show B"));
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning);
+    }
+
+    [Fact]
+    public void BuildGroupRecencyAndHoldState_ResetsEverything_OnEveryCall_EvenWhenTheFirstCallUsedAirBlocks()
+    {
+        var cache = new RefreshQueueService.RefreshCache();
+        var showA = TestItems.Show("Show A");
+        var epA = TestItems.Ep("Show A", 1, 1, aired: new DateTime(2024, 1, 1), show: showA);
+        TestItems.SeedUserData(cache, epA, TestItems.User, played: true, lastPlayed: new DateTime(2024, 1, 2));
+
+        var order = new RoundRobinLeastRecentlyWatchedOrder
+        {
+            GroupByField = "Collections",
+            OrderWithinGroupsByAirDate = true,
+            CollectionGroupKeys = TestItems.CollectionMap(("Franchise", new BaseItem[] { epA })),
+        };
+
+        order.BuildGroupRecencyAndHoldState(new BaseItem[] { epA }, TestItems.User, TestItems.ThrowingUserData(), cache, logger: null);
+        Assert.NotNull(order.WatchedByGroup);
+        Assert.NotNull(order.UnwatchedCollectionItemIds);
+        Assert.True(order.GroupRecency.ContainsKey("Franchise"));
+
+        // Second call: an unrelated group, no air blocks. Every piece of prior state must vanish.
+        order.GroupByField = "SeriesName";
+        order.OrderWithinGroupsByAirDate = false;
+        var showB = TestItems.Mov("Show B");
+        TestItems.SeedUserData(cache, showB, TestItems.User, played: true, lastPlayed: new DateTime(2024, 3, 1));
+
+        order.BuildGroupRecencyAndHoldState(new BaseItem[] { showB }, TestItems.User, TestItems.ThrowingUserData(), cache, logger: null);
+
+        Assert.Null(order.WatchedByGroup);
+        Assert.Null(order.UnwatchedCollectionItemIds);
+        Assert.False(order.GroupRecency.ContainsKey("Franchise"));
+        Assert.True(order.GroupRecency.ContainsKey("Show B"));
+    }
+
+    /// <summary>
+    /// "Unwatched" for the hold mirrors the Playback Status rule: Played unset means unwatched, so
+    /// an imported watch state with NO timestamp (Played == true, LastPlayedDate == null) still
+    /// counts as watched - it is not "unwatched because it has no timestamp".
+    /// </summary>
+    [Fact]
+    public void BuildGroupRecencyAndHoldState_UnwatchedSemantics_PlayedFlagUnsetMeansUnwatched_ExceptAnImportedWatchWithNoTimestamp()
+    {
+        var cache = new RefreshQueueService.RefreshCache();
+        var neverPlayed = TestItems.Ep("Show A", 1, 1);
+        var importedNoTimestamp = TestItems.Ep("Show A", 1, 2);
+        TestItems.SeedUserData(cache, neverPlayed, TestItems.User, played: false, lastPlayed: null);
+        TestItems.SeedUserData(cache, importedNoTimestamp, TestItems.User, played: true, lastPlayed: null);
+
+        var order = new RoundRobinLeastRecentlyWatchedOrder
+        {
+            GroupByField = "Collections",
+            OrderWithinGroupsByAirDate = true,
+            CollectionGroupKeys = TestItems.CollectionMap(("Group", new BaseItem[] { neverPlayed, importedNoTimestamp })),
+        };
+
+        order.BuildGroupRecencyAndHoldState(new BaseItem[] { neverPlayed, importedNoTimestamp }, TestItems.User, TestItems.ThrowingUserData(), cache, logger: null);
+
+        Assert.Contains(neverPlayed.Id, order.UnwatchedCollectionItemIds!);
+        Assert.DoesNotContain(importedNoTimestamp.Id, order.UnwatchedCollectionItemIds!);
+    }
+
+    /// <summary>
+    /// The exception to the Played-flag rule above: folder items (Series/Season/...) count as
+    /// watched when they have ANY aggregate activity, even with no reliable Played flag of their
+    /// own - but with NO aggregate activity, a folder is still unwatched like anything else.
+    /// </summary>
+    [Fact]
+    public void BuildGroupRecencyAndHoldState_UnwatchedSemantics_FolderItems_CountAsWatchedOnlyWhenTheyHaveAggregateActivity()
+    {
+        var cache = new RefreshQueueService.RefreshCache();
+        var activeSeries = TestItems.Show("Active Series");
+        var idleSeries = TestItems.Show("Idle Series");
+        TestItems.SeedNoUserData(cache, activeSeries, TestItems.User);
+        TestItems.SeedNoUserData(cache, idleSeries, TestItems.User);
+
+        var activeChild = TestItems.Ep("Ignored", 1, 1, name: "Active Child");
+        TestItems.SeedUserData(cache, activeChild, TestItems.User, played: false, lastPlayed: new DateTime(2023, 1, 1));
+        cache.SeriesEpisodes[(activeSeries.Id, TestItems.User.Id)] = new BaseItem[] { activeChild };
+        // idleSeries has no cached children at all -> no aggregate activity.
+
+        var order = new RoundRobinLeastRecentlyWatchedOrder
+        {
+            GroupByField = "Collections",
+            OrderWithinGroupsByAirDate = true,
+            CollectionGroupKeys = TestItems.CollectionMap(("Group", new BaseItem[] { activeSeries, idleSeries })),
+        };
+
+        order.BuildGroupRecencyAndHoldState(new BaseItem[] { activeSeries, idleSeries }, TestItems.User, TestItems.ThrowingUserData(), cache, logger: null);
+
+        Assert.DoesNotContain(activeSeries.Id, order.UnwatchedCollectionItemIds!);
+        Assert.Contains(idleSeries.Id, order.UnwatchedCollectionItemIds!);
+    }
+
+    // =================================================================================
+    // ApplyMidBlockHold
+    // =================================================================================
+
+    [Fact]
+    public void ApplyMidBlockHold_NoWatchState_NeverHolds()
+    {
+        var order = new RoundRobinLeastRecentlyWatchedOrder { GroupByField = "Collections" };
+        // BuildGroupRecencyAndHoldState never called: WatchedByGroup stays null.
+
+        order.ApplyMidBlockHold(new List<BaseItem> { TestItems.Mov("Anything") }, logger: null);
+
+        Assert.Empty(order.HeldGroups);
+    }
+
+    [Fact]
+    public void ApplyMidBlockHold_CollectionGroupKeysMissing_NeverHolds()
+    {
+        var cache = new RefreshQueueService.RefreshCache();
+        var (order, anchor, companion) = SetUpCrossoverNight(cache, CompanionState.InProgress);
+        // Simulate CollectionGroupKeys becoming unavailable between the recency pass and the hold pass.
+        order.CollectionGroupKeys = null;
+
+        order.ApplyMidBlockHold(new List<BaseItem> { anchor, companion }, logger: null);
+
+        Assert.Empty(order.HeldGroups);
+    }
+
+    [Fact]
+    public void ApplyMidBlockHold_NothingFromTheGroupIsVisible_NeverHolds()
+    {
+        var cache = new RefreshQueueService.RefreshCache();
+        var (order, _, _) = SetUpCrossoverNight(cache, CompanionState.InProgress);
+
+        order.ApplyMidBlockHold(new List<BaseItem> { TestItems.Mov("Unrelated Item") }, logger: null);
+
+        Assert.Empty(order.HeldGroups);
+    }
+
+    /// <summary>
+    /// The three cases that decide whether a hold fires, tested as near-misses so a broken
+    /// "visible AND unwatched" condition (e.g. dropping either half) is caught precisely:
+    /// watched-but-visible does not hold (nothing left to watch), unwatched-but-hidden does not
+    /// hold (the playlist can't actually play it), and only unwatched-AND-visible holds.
+    /// </summary>
+    [Theory]
+    [InlineData(CompanionState.Watched, true, false)]
+    [InlineData(CompanionState.InProgress, false, false)]
+    [InlineData(CompanionState.InProgress, true, true)]
+    public void ApplyMidBlockHold_FiresOnlyWhenTheAnchorsBlockHasAnUnwatchedAndVisibleItem(
+        CompanionState companionState, bool companionVisible, bool expectHold)
+    {
+        var cache = new RefreshQueueService.RefreshCache();
+        var (order, anchor, companion) = SetUpCrossoverNight(cache, companionState);
+        var filtered = companionVisible
+            ? new List<BaseItem> { anchor, companion }
+            : new List<BaseItem> { anchor };
+
+        order.ApplyMidBlockHold(filtered, logger: null);
+
+        Assert.Equal(expectHold, order.HeldGroups.Contains("Crossover Night"));
+    }
+
+    /// <summary>
+    /// Block topology is the UNION of filtered items and watched items, not just filtered items:
+    /// the anchor itself (watched, so hidden by e.g. a "Playback Status is Unwatched" rule) must
+    /// still be found and still anchor its block, purely via WatchedByGroup. If topology were
+    /// built from "visible" alone, the anchor would never appear in any block and the hold could
+    /// never fire even though the companion is genuinely unwatched and visible.
+    /// </summary>
+    [Fact]
+    public void ApplyMidBlockHold_BlockTopologyIsTheUnionOfFilteredAndWatchedItems_SoAHiddenWatchedAnchorStillAnchors()
+    {
+        var cache = new RefreshQueueService.RefreshCache();
+        var (order, _, companion) = SetUpCrossoverNight(cache, CompanionState.InProgress);
+
+        // Only the companion is visible; the anchor is hidden from the playlist entirely.
+        order.ApplyMidBlockHold(new List<BaseItem> { companion }, logger: null);
+
+        Assert.Contains("Crossover Night", order.HeldGroups);
+    }
+
+    /// <summary>
+    /// Both X and Y were (bulk-)marked played at the exact same moment, so the primary
+    /// "most recently played" comparison ties. The tie-break must fall to the LATEST air date -
+    /// Y's block - or this inspects the wrong block (X's, which has no unwatched member) and the
+    /// hold never fires. X is processed first, so a broken tie-break that just keeps the
+    /// first-seen candidate would silently reproduce this exact failure mode.
+    /// </summary>
+    [Fact]
+    public void ApplyMidBlockHold_AnchorTieBreak_FallsBackToTheLatestAirDate_WhenLastPlayedIsEqual()
+    {
+        var cache = new RefreshQueueService.RefreshCache();
+        var showA = TestItems.Show("Show A");
+        var showB = TestItems.Show("Show B");
+        var showC = TestItems.Show("Show C");
+
+        var x = TestItems.Ep("Show A", 1, 1, aired: new DateTime(2024, 1, 1), show: showA);  // earlier air date
+        var y = TestItems.Ep("Show B", 1, 1, aired: new DateTime(2024, 2, 1), show: showB);  // later air date - should win the tie
+        var z = TestItems.Ep("Show C", 1, 1, aired: new DateTime(2024, 2, 2), show: showC);  // chains into Y's block
+
+        // Deterministic Ids where Y's Id loses an Id-based comparison against X's: this makes the
+        // assertion fail reliably if the air-date tier were ever dropped and the comparison fell
+        // through to the (still-present) Id tier instead - rather than passing or failing at
+        // random depending on Guid.NewGuid()'s output for this run.
+        x.Id = Guid.Parse("ffffffff-ffff-ffff-ffff-ffffffffffff");
+        y.Id = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+        var tiedLastPlayed = new DateTime(2024, 6, 1);
+        TestItems.SeedUserData(cache, x, TestItems.User, played: true, lastPlayed: tiedLastPlayed);
+        TestItems.SeedUserData(cache, y, TestItems.User, played: true, lastPlayed: tiedLastPlayed);
+        TestItems.SeedNoUserData(cache, z, TestItems.User); // unwatched
+
+        var order = new RoundRobinLeastRecentlyWatchedOrder
+        {
+            GroupByField = "Collections",
+            OrderWithinGroupsByAirDate = true,
+            CollectionGroupKeys = TestItems.CollectionMap(("Marvel Night", new BaseItem[] { x, y, z })),
+        };
+
+        order.BuildGroupRecencyAndHoldState(new BaseItem[] { x, y, z }, TestItems.User, TestItems.ThrowingUserData(), cache, logger: null);
+        order.ApplyMidBlockHold(new List<BaseItem> { x, y, z }, logger: null);
+
+        Assert.Contains("Marvel Night", order.HeldGroups);
+    }
+
+    [Fact]
+    public void HeldGroups_IsRecomputedOnEveryCall_SoAPriorHoldNeverLeaksIntoALaterPass()
+    {
+        var cache = new RefreshQueueService.RefreshCache();
+        var (order, anchor, companion) = SetUpCrossoverNight(cache, CompanionState.InProgress);
+
+        order.ApplyMidBlockHold(new List<BaseItem> { anchor, companion }, logger: null);
+        Assert.Contains("Crossover Night", order.HeldGroups);
+
+        // Companion no longer visible: this pass should NOT hold, and must not simply keep the
+        // previous pass's result around.
+        order.ApplyMidBlockHold(new List<BaseItem> { anchor }, logger: null);
+
+        Assert.DoesNotContain("Crossover Night", order.HeldGroups);
+    }
+
+    /// <summary>
+    /// End-to-end through the public entry point: PreComputePositions must run the hold BEFORE
+    /// computing interleave positions. Without the hold, "Old Watched Show" (2023) is less
+    /// recently watched than "Crossover Night" (2024, from the anchor) and would rotate first; the
+    /// hold must override that and put the held group's anchor first instead.
+    /// </summary>
+    [Fact]
+    public void PreComputePositions_AppliesTheHoldBeforeComputingPositions()
+    {
+        var cache = new RefreshQueueService.RefreshCache();
+        var (order, anchor, companion) = SetUpCrossoverNight(cache, CompanionState.InProgress);
+
+        var oldShow = TestItems.Show("Old Watched Show");
+        var oldEpisode = TestItems.Ep("Old Watched Show", 1, 1, aired: new DateTime(2000, 1, 1), show: oldShow);
+        TestItems.SeedUserData(cache, oldEpisode, TestItems.User, played: true, lastPlayed: new DateTime(2023, 1, 1));
+
+        var allItems = new List<BaseItem> { anchor, companion, oldEpisode };
+        // Rebuild recency/hold-state over the full pool now that "Old Watched Show" is in play -
+        // mirrors production, where this always runs before PreComputePositions.
+        order.BuildGroupRecencyAndHoldState(allItems, TestItems.User, TestItems.ThrowingUserData(), cache, logger: null);
+
+        order.PreComputePositions(allItems);
+
+        var firstItem = allItems.OrderBy(i => order.ItemPositions[i.Id]).First();
+        Assert.Equal(anchor.Id, firstItem.Id);
+    }
+}

--- a/Jellyfin.Plugin.SmartLists.Tests/Support/TestItems.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Support/TestItems.cs
@@ -144,6 +144,25 @@ public static class TestItems
         return item;
     }
 
+    /// <summary>
+    /// A Season - a container whose recency is aggregated over cached children rather than read
+    /// from its own user-data row.
+    /// </summary>
+    public static Season SeasonOf(string name)
+    {
+        var season = new Season { Id = Guid.NewGuid(), Name = name };
+        season.SortName = name;
+        return season;
+    }
+
+    /// <summary>A MusicAlbum - the audio equivalent of <see cref="SeasonOf"/>.</summary>
+    public static MusicAlbum Album(string name)
+    {
+        var album = new MusicAlbum { Id = Guid.NewGuid(), Name = name };
+        album.SortName = name;
+        return album;
+    }
+
     /// <summary>An Audio track. Disc is ParentIndexNumber, track is IndexNumber.</summary>
     public static Audio Track(string album, int disc, int track, string? name = null, string? artist = null)
     {

--- a/Jellyfin.Plugin.SmartLists.Tests/Support/TestItems.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Support/TestItems.cs
@@ -1,0 +1,236 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SmartLists.Services.Shared;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Library;
+using Movie = MediaBrowser.Controller.Entities.Movies.Movie;
+
+namespace Jellyfin.Plugin.SmartLists.Tests.Support;
+
+/// <summary>
+/// Stand-in for the server's ILibraryManager, needed because <c>Episode.Series</c> is not a stored
+/// property - its getter calls <c>BaseItem.LibraryManager.GetItemById(SeriesId)</c>, which throws
+/// <see cref="NullReferenceException"/> when no library manager has been installed.
+///
+/// That matters for real coverage, not convenience: RoundRobinBase.CompareWithinGroupByAirDate
+/// reads <c>episode.Series?.SortName</c> to break same-day ties between episodes of DIFFERENT
+/// series - the crossover-night ordering users get by editing a series' Sort Title. Without a
+/// library manager that comparison throws, so every air-block test would have to avoid the exact
+/// case air blocks exist for.
+///
+/// Only <c>GetItemById(Guid)</c> is implemented. Every other member throws
+/// <see cref="NotSupportedException"/> on purpose: if production code under test ever starts
+/// depending on more of the library manager, these tests must fail loudly rather than quietly
+/// sort against a default-valued stub.
+/// </summary>
+public class TestLibraryManager : DispatchProxy
+{
+    /// <summary>
+    /// Id → item, for <c>GetItemById</c>. Process-wide and never cleared - ids are GUIDs, so
+    /// entries from different test classes cannot collide, and leaving them in place keeps the
+    /// stub safe under xUnit's parallel test collections.
+    /// </summary>
+    internal static readonly ConcurrentDictionary<Guid, BaseItem> Items = new();
+
+    protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+    {
+        if (targetMethod?.Name == "GetItemById" && args is { Length: 1 } && args[0] is Guid id)
+        {
+            return Items.TryGetValue(id, out var item) ? item : null;
+        }
+
+        throw new NotSupportedException(
+            $"TestLibraryManager: {targetMethod?.Name} is not stubbed. Add it deliberately - see Support/TestItems.cs.");
+    }
+}
+
+/// <summary>
+/// An <see cref="IUserDataManager"/> that throws on every call.
+///
+/// Production reads user data through <c>UserDataCacheHelper.GetCachedUserData</c>, which checks
+/// <c>RefreshCache.UserDataCache</c> first and only falls through to the manager on a miss. Tests
+/// seed the cache instead (see <see cref="TestItems.SeedUserData"/>), so a throwing manager both
+/// avoids stubbing a 13-member interface AND proves the cache-first path is the one being taken -
+/// a silent regression to per-item DB round-trips would fail the test rather than slow production
+/// down unnoticed.
+///
+/// The manager reference itself still has to be non-null: RoundRobinLeastRecentlyWatchedOrder
+/// .BuildGroupRecencyAndHoldState bails out early (groups fall back to alphabetical) when it is
+/// null, which would make the recency tests vacuous.
+/// </summary>
+public class ThrowingUserDataManager : DispatchProxy
+{
+    protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+    {
+        throw new NotSupportedException(
+            $"ThrowingUserDataManager: {targetMethod?.Name} was called - the RefreshCache user-data cache should have answered instead.");
+    }
+}
+
+/// <summary>
+/// Builders for the item shapes the round-robin orders group and interleave.
+///
+/// Two Jellyfin traps these builders exist to close, both of which throw
+/// <see cref="NullReferenceException"/> rather than failing an assertion, and both of which have
+/// already cost a debugging session:
+///
+/// 1. Reading <c>item.SortName</c> that was never assigned throws. Every builder assigns it.
+/// 2. Assigning <c>Name</c> RESETS the cached sort name, so <c>Name</c> must be set BEFORE
+///    <c>SortName</c>. The object-initializer-then-assign shape below is deliberate.
+/// </summary>
+public static class TestItems
+{
+    /// <summary>Installs the library manager stub once per test process, before any test runs.</summary>
+    [ModuleInitializer]
+    internal static void InstallLibraryManager()
+    {
+        BaseItem.LibraryManager = DispatchProxy.Create<ILibraryManager, TestLibraryManager>();
+    }
+
+    public static readonly User User = new("tester", "authProviderId", "pwResetProviderId");
+
+    /// <summary>A second user, for asserting that per-user state is actually keyed by user.</summary>
+    public static readonly User OtherUser = new("other", "authProviderId", "pwResetProviderId");
+
+    public static IUserDataManager ThrowingUserData() => DispatchProxy.Create<IUserDataManager, ThrowingUserDataManager>();
+
+    /// <summary>
+    /// A Series registered with the library manager stub, so episodes pointing at it can resolve
+    /// <c>episode.Series</c>. <paramref name="sortName"/> is the custom Sort Title users edit to
+    /// order a crossover night; it defaults to the name.
+    /// </summary>
+    public static Series Show(string name, string? sortName = null)
+    {
+        var series = new Series { Id = Guid.NewGuid(), Name = name };
+        series.SortName = sortName ?? name;
+        TestLibraryManager.Items[series.Id] = series;
+        return series;
+    }
+
+    /// <summary>
+    /// An Episode. Pass <paramref name="show"/> to attach it to a registered Series (needed for
+    /// the same-day cross-series tie-break); otherwise only the denormalized SeriesName is set,
+    /// which is what <c>ExtractGroupKey</c> groups on.
+    /// </summary>
+    public static Episode Ep(
+        string seriesName,
+        int season,
+        int episode,
+        DateTime? aired = null,
+        string? name = null,
+        Series? show = null)
+    {
+        var item = new Episode
+        {
+            Id = Guid.NewGuid(),
+            Name = name ?? $"{seriesName} S{season:00}E{episode:00}",
+            SeriesName = seriesName,
+            ParentIndexNumber = season,
+            IndexNumber = episode,
+            PremiereDate = aired,
+        };
+
+        item.SortName = item.Name;
+
+        if (show != null)
+        {
+            item.SeriesId = show.Id;
+        }
+
+        return item;
+    }
+
+    /// <summary>An Audio track. Disc is ParentIndexNumber, track is IndexNumber.</summary>
+    public static Audio Track(string album, int disc, int track, string? name = null, string? artist = null)
+    {
+        var item = new Audio
+        {
+            Id = Guid.NewGuid(),
+            Name = name ?? $"{album} D{disc}T{track:00}",
+            Album = album,
+            ParentIndexNumber = disc,
+            IndexNumber = track,
+        };
+
+        item.SortName = item.Name;
+
+        if (artist != null)
+        {
+            item.Artists = [artist];
+        }
+
+        return item;
+    }
+
+    /// <summary>A Movie - the generic non-episode, non-audio item.</summary>
+    public static Movie Mov(string name, DateTime? aired = null, string? sortName = null, string[]? genres = null, string[]? studios = null)
+    {
+        var item = new Movie { Id = Guid.NewGuid(), Name = name, PremiereDate = aired };
+        item.SortName = sortName ?? name;
+
+        if (genres != null)
+        {
+            item.Genres = genres;
+        }
+
+        if (studios != null)
+        {
+            item.Studios = studios;
+        }
+
+        return item;
+    }
+
+    public static string[] Names(IEnumerable<BaseItem> items) => items.Select(i => i.Name).ToArray();
+
+    /// <summary>
+    /// Seeds one item's per-user watch state into the refresh cache, the way a real refresh would
+    /// after its first read. <paramref name="lastPlayed"/> null means "no timestamp".
+    /// </summary>
+    public static void SeedUserData(
+        RefreshQueueService.RefreshCache cache,
+        BaseItem item,
+        User user,
+        bool played = false,
+        DateTime? lastPlayed = null)
+    {
+        cache.UserDataCache[(item.Id, user.Id)] = new UserItemData
+        {
+            Key = item.Id.ToString("N"),
+            Played = played,
+            LastPlayedDate = lastPlayed,
+        };
+    }
+
+    /// <summary>
+    /// Records that an item has no user-data row at all, which is distinct from having a row with
+    /// Played=false: production memoizes the miss in a separate negative cache.
+    /// </summary>
+    public static void SeedNoUserData(RefreshQueueService.RefreshCache cache, BaseItem item, User user)
+    {
+        cache.UserDataNegativeCache[(item.Id, user.Id)] = 0;
+    }
+
+    /// <summary>
+    /// Builds the item id → collection name map SmartList hands the order for "Collections"
+    /// grouping. Items not passed here are absent from the map on purpose - production falls back
+    /// to series-name grouping for them.
+    /// </summary>
+    public static Dictionary<Guid, string> CollectionMap(params (string Collection, BaseItem[] Items)[] groups)
+    {
+        var map = new Dictionary<Guid, string>();
+        foreach (var (collection, items) in groups)
+        {
+            foreach (var item in items)
+            {
+                map[item.Id] = collection;
+            }
+        }
+
+        return map;
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs
@@ -69,7 +69,16 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
         /// within-group order (shuffle wins over air-date order, so shuffled variants never
         /// use blocks). Single source of the gate shared by SmartList and the interleave.
         /// </summary>
-        internal bool UsesAirBlocks => GroupByField == "Collections" && OrderWithinGroupsByAirDate && !ShuffleWithinGroups;
+        internal bool UsesAirBlocks => ShouldUseAirBlocks(GroupByField, OrderWithinGroupsByAirDate, ShuffleWithinGroups);
+
+        /// <summary>
+        /// The air-block gate itself, in one place. <see cref="UsesAirBlocks"/> reads it from
+        /// instance state; <see cref="BuildInterleavedPositions"/> reads it from its parameters.
+        /// Both must agree on whether a refresh uses blocks - if they drift, SmartList prepares
+        /// state for one mode while the interleave runs the other.
+        /// </summary>
+        internal static bool ShouldUseAirBlocks(string? groupByField, bool airDateWithinGroups, bool shuffleWithinGroups) =>
+            groupByField == "Collections" && airDateWithinGroups && !shuffleWithinGroups;
 
         /// <summary>
         /// Pre-computed interleave positions for each item.
@@ -196,7 +205,10 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
 
             // Air blocks apply only to collection grouping with air-date order; the plain
             // per-item interleave stays allocation-free for every other round-robin variant.
-            bool useAirBlocks = collectionGroupKeys != null && airDateWithinGroups && !shuffleWithinGroups;
+            // The field name is part of the gate (via ShouldUseAirBlocks) so this cannot diverge
+            // from UsesAirBlocks; the map check stays because block grouping is only meaningful
+            // once collection membership has actually been resolved.
+            bool useAirBlocks = ShouldUseAirBlocks(groupByField, airDateWithinGroups, shuffleWithinGroups) && collectionGroupKeys != null;
             if (!useAirBlocks)
             {
                 int maxGroupSize = groups.Values.Max(g => g.Count);

--- a/Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Orders/RoundRobinOrder.cs
@@ -65,20 +65,23 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
         protected virtual bool ShuffleWithinGroups => false;
 
         /// <summary>
-        /// True when this order interleaves air blocks: Collections grouping with air-date
-        /// within-group order (shuffle wins over air-date order, so shuffled variants never
-        /// use blocks). Single source of the gate shared by SmartList and the interleave.
+        /// True when this refresh interleaves air blocks: Collections grouping with air-date
+        /// within-group order (shuffle wins over air-date order, so shuffled variants never use
+        /// blocks) AND a resolved collection map, without which block grouping has nothing to
+        /// group by. Answers exactly the question <see cref="BuildInterleavedPositions"/> asks,
+        /// so a caller can trust this alone.
         /// </summary>
-        internal bool UsesAirBlocks => ShouldUseAirBlocks(GroupByField, OrderWithinGroupsByAirDate, ShuffleWithinGroups);
+        internal bool UsesAirBlocks => ShouldUseAirBlocks(GroupByField, OrderWithinGroupsByAirDate, ShuffleWithinGroups, CollectionGroupKeys);
 
         /// <summary>
         /// The air-block gate itself, in one place. <see cref="UsesAirBlocks"/> reads it from
         /// instance state; <see cref="BuildInterleavedPositions"/> reads it from its parameters.
         /// Both must agree on whether a refresh uses blocks - if they drift, SmartList prepares
-        /// state for one mode while the interleave runs the other.
+        /// state for one mode while the interleave runs the other. Every condition lives here,
+        /// including the map presence, so there is no "and also check X" for callers to forget.
         /// </summary>
-        internal static bool ShouldUseAirBlocks(string? groupByField, bool airDateWithinGroups, bool shuffleWithinGroups) =>
-            groupByField == "Collections" && airDateWithinGroups && !shuffleWithinGroups;
+        internal static bool ShouldUseAirBlocks(string? groupByField, bool airDateWithinGroups, bool shuffleWithinGroups, Dictionary<Guid, string>? collectionGroupKeys) =>
+            groupByField == "Collections" && airDateWithinGroups && !shuffleWithinGroups && collectionGroupKeys != null;
 
         /// <summary>
         /// Pre-computed interleave positions for each item.
@@ -205,10 +208,9 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
 
             // Air blocks apply only to collection grouping with air-date order; the plain
             // per-item interleave stays allocation-free for every other round-robin variant.
-            // The field name is part of the gate (via ShouldUseAirBlocks) so this cannot diverge
-            // from UsesAirBlocks; the map check stays because block grouping is only meaningful
-            // once collection membership has actually been resolved.
-            bool useAirBlocks = ShouldUseAirBlocks(groupByField, airDateWithinGroups, shuffleWithinGroups) && collectionGroupKeys != null;
+            // Same gate as UsesAirBlocks, evaluated from parameters instead of instance state,
+            // so the two cannot diverge.
+            bool useAirBlocks = ShouldUseAirBlocks(groupByField, airDateWithinGroups, shuffleWithinGroups, collectionGroupKeys);
             if (!useAirBlocks)
             {
                 int maxGroupSize = groups.Values.Max(g => g.Count);
@@ -591,7 +593,9 @@ namespace Jellyfin.Plugin.SmartLists.Core.Orders
                 return;
             }
 
-            var collectHoldState = UsesAirBlocks && CollectionGroupKeys != null;
+            // UsesAirBlocks already requires CollectionGroupKeys, so the null-forgiving uses of it
+            // below are safe.
+            var collectHoldState = UsesAirBlocks;
             if (collectHoldState)
             {
                 WatchedByGroup = new Dictionary<string, List<(BaseItem Item, DateTime LastPlayed, DateTime Air)>>(StringComparer.OrdinalIgnoreCase);


### PR DESCRIPTION
## Why

`Core/Orders/RoundRobinOrder.cs` is 787 lines backing **five registered sorts** and had zero behavioural tests. It carries mutable per-refresh state, which is exactly the shape of code that breaks silently — the previous Orders test pass (#489) turned up four such defects (#490).

Continues the coverage work from #487/#489. **931 → 1030 tests**, still ~2s.

## What's covered

| Area | Pinned behaviour |
|---|---|
| `ExtractGroupKey` | Every documented field, plus the **default arm** — a typo'd or not-yet-wired field id silently groups everything by item name, with no error anywhere |
| `CompareWithinGroup` | Season→episode, disc→track, and the natural-comparer fallback that Collections grouping makes a routine path, not a corner case |
| `Shuffle` | Fixed-seed known output, so a wrong Fisher-Yates loop bound (which still "shuffles" but can't reach every permutation) is detectable |
| Interleave | Exact rotation sequences for equal/unequal group sizes, dense `0..n-1` positions, `OrderBy`/`GetSortKey` agreement, replace-not-merge on repeat `PreComputePositions` calls |
| Air blocks | Item-to-item chaining, same-show dedup, undated items, window clamping, the tiered air-date comparator including the series Sort Title tie-break |
| Least Recently Watched | Recency tiering and held groups, and the ~120-line mid-block hold: anchor selection with its tie-breaks, and the visible-AND-unwatched condition that decides whether a group is pinned |

The random variants are pinned by invariants (permutation, within-group preservation) plus a repeat-run check that the randomisation is real rather than a no-op — with the false-failure probability stated in a comment.

## The fix

`UsesAirBlocks` gated on `GroupByField == "Collections"`; `BuildInterleavedPositions` gated on `collectionGroupKeys != null` and never inspected the field name. Grouping by any field got full air-block chunking the moment a non-null map was supplied — even an empty one — gluing a same-day cross-show pair into a contiguous block.

Not reachable in production today: `SmartList.cs` only ever assigns `CollectionGroupKeys` for Collections grouping. Nothing enforced that, and `BuildGroupRecencyAndHoldState` already re-checked both conditions rather than trusting either gate alone. Both now route through `ShouldUseAirBlocks`, which strictly narrows behaviour and is a no-op for every configuration `SmartList` can currently produce.

## Verification

Green is not the bar — a passing suite proves nothing on its own. I ran **18 mutations** against `RoundRobinOrder.cs`: inverted every comparator tier, dropped the show-dedup and the window clamp, swapped the interleave loop nesting, made half-watched items advance recency, dropped `HeldGroups.Clear()`, flipped the anchor to pick oldest-instead-of-newest, and reverted the gate fix. All caught, each by a test whose name describes the broken behaviour. A deliberate no-op control stayed green, confirming the harness reports signal rather than noise.

One mutation initially **survived**: swapping the group dictionary to `StringComparer.Ordinal` left the suite fully green, so nothing detected that `"Marvel"` and `"marvel"` are one rotation group rather than two. Closed by `GroupKeys_AreFoldedCaseInsensitively_...`, then re-run to confirm it's caught.

Both ABIs build clean (net9.0 / net10.0), 0 warnings.

## Test infrastructure

`Support/TestItems.cs` — no mocking library is used or added. Two Jellyfin constraints made this possible offline:

- **`episode.Series` is not stored.** Its getter calls `BaseItem.LibraryManager.GetItemById`, which throws `NullReferenceException` with no server — and `CompareWithinGroupByAirDate` reads it on every same-day cross-series tie, i.e. exactly the air-block case. A `DispatchProxy`-based `ILibraryManager` stub is installed once via `[ModuleInitializer]`; only `GetItemById` is implemented and everything else throws, so a new dependency surfaces loudly instead of silently sorting against defaults.
- **`UserDataCacheHelper` reads `RefreshCache.UserDataCache` before consulting the user data manager.** Seeding the cache and passing a *throwing* `IUserDataManager` avoids stubbing a 13-member interface, and a throw proves the cache-first path is live rather than degrading to per-item DB reads.

## Deliberately not changed

- **`SharedNaturalComparer` is numeric-aware only on a *leading* digit**, so `"Show 2"`/`"Show 10"` sort ordinally. This backs every name-based sort in the plugin, so changing it would reorder existing playlists for every user — a product decision with a changelog entry, not a defect fix to bundle here.
- **Three defensive branches in `ApplyMidBlockHold` are unreachable** (the Id tie-break, the no-timestamp guard, the `bestAir == MinValue` bail-out), verified by mutation. Their unreachability holds only because of how `ChunkIntoAirBlocks` chains, so deleting them would buy six lines against a latent wrong-anchor bug the next time chunking changes. Documented in the test file instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9FFji6MP136o3bq298BWJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved round-robin ordering so air-block behavior activates only with compatible grouping and air-date settings.
  * Ensured collection data is available before applying air-block interleaving.
  * Improved handling of group ordering, natural sorting, shuffling, missing values, and recently watched items.

* **Tests**
  * Added extensive coverage for round-robin interleaving, grouping, air blocks, shuffle behavior, and watch-history ordering.
  * Added test utilities covering episodes, audio, movies, collections, and user data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->