### PR TITLE
fix: match tags, studios and genres from every ancestor (#495)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -19,10 +19,10 @@ If `$ARGUMENTS` is `major`, stop and explain: the Major/Minor segments are pinne
 
 **If `$ARGUMENTS` is empty**, present this prompt and wait for the user's answer before proceeding:
 
-```
+```text
 What type of release do you want to create?
 
-  stable — Stable release (tagged on main, e.g. v12.0.1.0)
+  stable — Stable release (tagged on 12-release, e.g. v12.0.1.0)
   rc     — Release candidate (tagged on main, e.g. v12.0.0.3-rc)
 ```
 
@@ -41,11 +41,16 @@ There is a single `12.x` release line (see "Release Line" in `CLAUDE.md`). The c
 - `rc` → must be on `main`.
 - `stable` → must be on `12-release`, which tracks the last stable and is fast-forwarded to `main` at release time.
 
-The old `10.11-release` branch is retired; never tag from it.
+If the current branch is `10.11-release`, **hard stop** — no confirmation prompt. That line is retired and a tag on it would publish a manifest entry that sorts below the `12.x` line and reaches nobody:
 
-If on the wrong branch, warn and ask for confirmation before continuing:
-
+```text
+10.11-release is retired — releases are no longer cut from it.
+Switch to 'main' (rc) or '12-release' (stable) and re-run.
 ```
+
+For any other wrong branch, warn and ask for confirmation before continuing:
+
+```text
 You are on branch '<current>' but <rc/stable> releases are tagged from '<expected>'.
 Continue anyway? (yes / no)
 ```
@@ -80,12 +85,18 @@ git rev-parse --short HEAD origin/main
 - **Non-empty** → this is the set of changes the stable will ship. Carry it into the step-7 summary. Because `12-release` sits at the previous stable tag, this range is the same one the changelog is generated from in step 3 — compute it once, show it once, don't prompt twice.
 - **Empty** → `12-release` already equals `main`; there is nothing new to release. Warn and ask before continuing, since re-tagging an identical tree is almost always a mistake:
 
-  ```
+  ```text
   12-release is already up to date with main — this release would contain no new commits.
   Re-tag the same tree anyway? (yes / no)
   ```
 
-**Releasing a subset of `main`:** if the user wants to ship only part of what's on `main` (e.g. a feature merged but not yet smoke-tested should wait), fast-forward to a specific commit rather than main's tip — `git merge --ff-only <sha>` in step 8, with the delta and changelog computed against that `<sha>` instead of `origin/main` throughout. Ask for the target commit and confirm the reduced set.
+**Releasing a subset of `main`:** if the user wants to ship only part of what's on `main` (e.g. a feature merged but not yet smoke-tested should wait), fast-forward to a specific commit rather than main's tip. Ask for the target commit, then **validate it is actually on `origin/main`** before confirming or merging:
+
+```bash
+git merge-base --is-ancestor <sha> origin/main || echo "NOT_ON_MAIN"
+```
+
+`git merge --ff-only <sha>` alone only proves `<sha>` descends from `12-release` — it would happily publish a local commit that was never pushed to `main`. Reject anything that is not an ancestor of `origin/main`. Compute the delta and changelog against the validated `<sha>` throughout, and use it in place of `origin/main` in step 8.
 
 Then check for uncommitted changes:
 
@@ -95,7 +106,7 @@ git status --porcelain
 
 If there are uncommitted changes, show the user a summary and ask:
 
-```
+```text
 You have uncommitted changes:
   <list of changed files>
 
@@ -120,7 +131,9 @@ Determine the changelog base tag depending on release type:
 git tag --list 'v12.*' --sort=-v:refname | head -1
 
 # stable: highest stable v12.*.0 tag — exclude RCs, since the changelog for a
-# stable covers everything since the previous STABLE, not since the last RC
+# stable covers everything since the previous STABLE, not since the last RC.
+# NOTE: this is the CHANGELOG base only. The VERSION base in step 4 is the
+# highest v12.* tag of ANY kind (RCs included) — see the warning there.
 git tag --list 'v12.*.0' --sort=-v:refname | grep -v -- '-rc$' | head -1
 ```
 
@@ -161,10 +174,23 @@ The version scheme is .NET's four-part `Major.Minor.Build.Revision`. Ordering is
 - If the base is a stable v12 tag (a future state, once Jellyfin 12 has shipped and this line has stable releases), start a new RC cycle: bump Build, set Revision to 1: `v12.0.1.0` → `v12.0.2.1-rc`.
 - If there is no `v12.*` tag yet, ask the user for the starting Major.Minor before proceeding — this skill has no basis to guess it.
 
-**`stable`**: base = highest stable `v12.*.0` tag (RCs excluded — see step 3).
-- Bump Build, Revision resets to 0. From the highest `v12.*` tag *of any kind*: `v12.0.0.3-rc` → `v12.0.1.0`; `v12.0.1.0` → `v12.0.2.0`.
+**`stable`**: base = highest `v12.*` tag of **any** kind — RCs included.
+
+> **Two different bases, do not confuse them.** The *changelog* base (step 3) is the last **stable** tag, so the release notes span everything since the previous stable. The *version* base here is the highest tag of **any** kind, including RCs. Using the changelog base to compute the version produces a version that sorts **below** the RCs it supersedes.
+
+- Bump Build, reset Revision to 0: `v12.0.2.2-rc` → `v12.0.3.0`; `v12.0.1.0` → `v12.0.2.0`.
 - Never put a hotfix counter in Revision — Revision is reserved exclusively for RC numbers.
-- If no stable `v12.*.0` tag exists yet, the first stable closes out the current RC cycle: take the highest `v12.*-rc` tag, bump Build, set Revision to 0.
+
+Why any-kind: suppose the last stable is `v12.0.1.0` and the RC cycle since then produced `v12.0.2.1-rc` and `v12.0.2.2-rc`. Bumping Build from the last *stable* gives `v12.0.2.0`, whose manifest version `12.0.2.0` sorts **below** `12.0.2.2` — every RC user is already on a higher version and would never be offered the stable. Bumping from the highest tag of any kind gives `v12.0.3.0`, which sorts above the whole cycle and pulls RC users onto it.
+
+**Sanity check before tagging** — the new version must sort above every existing `v12.*` tag:
+
+```bash
+printf '%s\n%s\n' "$(git tag --list 'v12.*' --sort=-v:refname | head -1 | sed 's/-rc$//')" "<new-version>" \
+  | sort -V | tail -1
+```
+
+This must print `<new-version>`. If it prints the existing tag instead, the version is too low — stop and recompute.
 
 ### 5. Generate changelog
 
@@ -181,7 +207,7 @@ Guidelines:
 - The changelog is shown to end users (GitHub release + Jellyfin plugin catalog), so keep the wording non-technical and focused on what changed for them.
 
 Format:
-```
+```text
 Features:
 - ...
 
@@ -200,7 +226,7 @@ The release workflow reads the changelog with `git tag -l --format='%(contents:b
 
 This means the tag message must be structured as:
 
-```
+```text
 Release <version>
 
 <changelog body from step 5>
@@ -214,7 +240,7 @@ The first line and the blank line beneath it are stripped before publishing — 
 
 Display to the user:
 
-```
+```text
 New tag:    <new-version>
 Previous:   <changelog-base-tag> (or "none")
 Commits:    <count> commit(s) since previous tag
@@ -229,7 +255,7 @@ Ready to create and push this tag? (yes / no / edit)
 
 **For `stable` releases**, insert the branch move above the changelog — this is the substantive part of the confirmation, since advancing `12-release` is what decides the release contents *and* what the docs site will serve:
 
-```
+```text
 Branch:     12-release <old-sha> -> <new-sha> (fast-forward to main, <count> commits)
             will be pushed, so the mkdocs Cloudflare Worker picks up the new docs
 ```

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,29 +1,29 @@
 ---
 name: release
-description: Create and push a release tag for the SmartLists plugin with a changelog in the annotated tag message. Project-specific version scheme — RC number lives in the Revision segment with a bare -rc suffix (e.g. v12.0.0.3-rc); stable releases bump the Build segment (e.g. v10.11.31.0). Use when the user wants to tag a release or create an RC.
+description: Create and push a release tag for the SmartLists plugin with a changelog in the annotated tag message. Project-specific version scheme — RC number lives in the Revision segment with a bare -rc suffix (e.g. v12.0.0.3-rc); stable releases bump the Build segment and reset Revision to 0 (e.g. v12.0.1.0). Use when the user wants to tag a release or create an RC.
 argument-hint: stable|rc
 allowed-tools: Bash
 ---
 
 # Release Skill
 
-Create a new git version tag with a changelog generated from commits and PR titles since the last relevant tag, then push it to the remote. This plugin uses .NET's four-part `Major.Minor.Build.Revision` version scheme, not SemVer, and currently ships two parallel release lines while Jellyfin 12 is in RC — this skill handles both.
+Create a new git version tag with a changelog generated from commits and PR titles since the last relevant tag, then push it to the remote. This plugin uses .NET's four-part `Major.Minor.Build.Revision` version scheme, not SemVer, and ships a single `12.x` release line: RCs are tagged on `main`, stables on `12-release`.
 
 ## Steps
 
 ### 1. Validate input
 
-`$ARGUMENTS` must be `stable` or `rc`. `patch` and `minor` are accepted as synonyms for `stable` — the four-part scheme doesn't distinguish bump sizes, since the plugin version tracks the Jellyfin version line, not the size of the change.
+`$ARGUMENTS` must be `stable` or `rc`. `patch` and `minor` are accepted as synonyms for `stable` — the four-part scheme doesn't distinguish bump sizes, so every stable is a Build bump regardless of how large the change is.
 
-If `$ARGUMENTS` is `major`, stop and explain: the Major/Minor segments of the version track the target Jellyfin version line, and only change when that target changes. That's a manual decision made when a new Jellyfin release lands, not something this skill infers from a bump type.
+If `$ARGUMENTS` is `major`, stop and explain: the Major/Minor segments are pinned to the `12.x` line and only move as a deliberate manual decision, not something this skill infers from a bump type.
 
 **If `$ARGUMENTS` is empty**, present this prompt and wait for the user's answer before proceeding:
 
 ```
 What type of release do you want to create?
 
-  stable — Final release for the current Jellyfin 10.11 line (tagged on 10.11-release, e.g. v10.11.31.0)
-  rc     — Release candidate for the upcoming Jellyfin 12 line (tagged on main, e.g. v12.0.0.3-rc)
+  stable — Stable release (tagged on main, e.g. v12.0.1.0)
+  rc     — Release candidate (tagged on main, e.g. v12.0.0.3-rc)
 ```
 
 Use the user's answer as `$ARGUMENTS` and continue. If `$ARGUMENTS` is present but doesn't match `stable`, `patch`, `minor`, or `rc`, stop and tell the user: "Usage: /release stable|rc".
@@ -36,9 +36,12 @@ First check the current branch:
 git branch --show-current
 ```
 
-The correct branch depends on release type:
+There is a single `12.x` release line (see "Release Line" in `CLAUDE.md`). The correct branch depends on release type:
+
 - `rc` → must be on `main`.
-- `stable` → must be on `10.11-release` (the current stable line while Jellyfin 12 is in RC).
+- `stable` → must be on `12-release`, which tracks the last stable and is fast-forwarded to `main` at release time.
+
+The old `10.11-release` branch is retired; never tag from it.
 
 If on the wrong branch, warn and ask for confirmation before continuing:
 
@@ -49,13 +52,21 @@ Continue anyway? (yes / no)
 
 Run `git pull` to bring the local branch up to date, then `git fetch --tags --prune-tags --force` so the local tag list matches the remote (a plain `git pull` doesn't reliably sync new or deleted tags, and a stale tag list would corrupt the version calculation). If the pull fails, stop and show the error — do not proceed with a stale or diverged branch.
 
-For `stable` releases specifically, also verify `main` has been merged in:
+**For `stable` releases**, fast-forward `12-release` up to `main` before tagging:
+
+```bash
+git merge --ff-only origin/main
+```
+
+`--ff-only` is deliberate — `12-release` must never carry commits of its own. If this fails, the branch has diverged: stop, show the error, and do not attempt a merge commit. Report it to the user, since recovering means resetting `12-release` back onto a `main` commit.
+
+Then confirm there is nothing left behind:
 
 ```bash
 git log HEAD..origin/main --oneline
 ```
 
-If this returns any commits, warn the user that `main` has unmerged work and point them at the promotion flow documented in `CLAUDE.md`: merge `main` into `10.11-release`, merge back so the trees converge, then smoke test with `JELLYFIN_ABI=10.11.0 ./build-local.sh`. Ask whether to continue anyway despite the gap.
+This must be empty. If it is not, the fast-forward did not take — stop rather than tagging a partial release.
 
 Then check for uncommitted changes:
 
@@ -89,8 +100,9 @@ Determine the changelog base tag depending on release type:
 # rc: highest v12.* tag of any kind (stable or RC)
 git tag --list 'v12.*' --sort=-v:refname | head -1
 
-# stable: highest v10.11.* tag of any kind (hotfix revisions included)
-git tag --list 'v10.11.*' --sort=-v:refname | head -1
+# stable: highest stable v12.*.0 tag — exclude RCs, since the changelog for a
+# stable covers everything since the previous STABLE, not since the last RC
+git tag --list 'v12.*.0' --sort=-v:refname | grep -v -- '-rc$' | head -1
 ```
 
 Then collect commits and PR titles since that base:
@@ -130,11 +142,10 @@ The version scheme is .NET's four-part `Major.Minor.Build.Revision`. Ordering is
 - If the base is a stable v12 tag (a future state, once Jellyfin 12 has shipped and this line has stable releases), start a new RC cycle: bump Build, set Revision to 1: `v12.0.1.0` → `v12.0.2.1-rc`.
 - If there is no `v12.*` tag yet, ask the user for the starting Major.Minor before proceeding — this skill has no basis to guess it.
 
-**`stable`**: base = highest stable `v10.11.*.0` tag.
-- Bump Build, Revision stays 0: `v10.11.30.0` → `v10.11.31.0`.
-- Never put a hotfix counter in Revision — Revision is reserved exclusively for RC numbers on the v12 line.
-
-**Future note**: when Jellyfin 12 final ships, the first `v12.0.X.0` stable release is cut from `main`, it sorts above both existing lines, all users converge onto it, and the split-line scheme described here ends. Update this skill at that point.
+**`stable`**: base = highest stable `v12.*.0` tag (RCs excluded — see step 3).
+- Bump Build, Revision resets to 0. From the highest `v12.*` tag *of any kind*: `v12.0.0.3-rc` → `v12.0.1.0`; `v12.0.1.0` → `v12.0.2.0`.
+- Never put a hotfix counter in Revision — Revision is reserved exclusively for RC numbers.
+- If no stable `v12.*.0` tag exists yet, the first stable closes out the current RC cycle: take the highest `v12.*-rc` tag, bump Build, set Revision to 0.
 
 ### 5. Generate changelog
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -52,21 +52,40 @@ Continue anyway? (yes / no)
 
 Run `git pull` to bring the local branch up to date, then `git fetch --tags --prune-tags --force` so the local tag list matches the remote (a plain `git pull` doesn't reliably sync new or deleted tags, and a stale tag list would corrupt the version calculation). If the pull fails, stop and show the error — do not proceed with a stale or diverged branch.
 
-**For `stable` releases**, fast-forward `12-release` up to `main` before tagging:
+#### For `stable` releases: work out what will ship
+
+`12-release` sits at the previous stable and has to be fast-forwarded to `main` so the release actually contains the new work. **Do not fast-forward yet** — compute the delta here, show it, and only move the branch after the user confirms in step 7. Nothing destructive happens before that gate.
+
+`git pull` while standing on `12-release` updates `12-release`, **not** `origin/main`, so fetch main explicitly or the delta is computed against a stale ref:
 
 ```bash
-git merge --ff-only origin/main
+git fetch origin main
 ```
 
-`--ff-only` is deliberate — `12-release` must never carry commits of its own. If this fails, the branch has diverged: stop, show the error, and do not attempt a merge commit. Report it to the user, since recovering means resetting `12-release` back onto a `main` commit.
-
-Then confirm there is nothing left behind:
+Check a fast-forward is even possible:
 
 ```bash
-git log HEAD..origin/main --oneline
+git merge-base --is-ancestor HEAD origin/main && echo FF_OK || echo DIVERGED
 ```
 
-This must be empty. If it is not, the fast-forward did not take — stop rather than tagging a partial release.
+`DIVERGED` means `12-release` has commits of its own and is no longer a pointer at a `main` commit. **Stop.** Do not merge, do not force. Report it — recovery means resetting `12-release` back onto a `main` commit, which is the user's call.
+
+Then compute what the release will newly contain:
+
+```bash
+git log HEAD..origin/main --oneline --no-merges
+git rev-parse --short HEAD origin/main
+```
+
+- **Non-empty** → this is the set of changes the stable will ship. Carry it into the step-7 summary. Because `12-release` sits at the previous stable tag, this range is the same one the changelog is generated from in step 3 — compute it once, show it once, don't prompt twice.
+- **Empty** → `12-release` already equals `main`; there is nothing new to release. Warn and ask before continuing, since re-tagging an identical tree is almost always a mistake:
+
+  ```
+  12-release is already up to date with main — this release would contain no new commits.
+  Re-tag the same tree anyway? (yes / no)
+  ```
+
+**Releasing a subset of `main`:** if the user wants to ship only part of what's on `main` (e.g. a feature merged but not yet smoke-tested should wait), fast-forward to a specific commit rather than main's tip — `git merge --ff-only <sha>` in step 8, with the delta and changelog computed against that `<sha>` instead of `origin/main` throughout. Ask for the target commit and confirm the reduced set.
 
 Then check for uncommitted changes:
 
@@ -208,13 +227,29 @@ Changelog:
 Ready to create and push this tag? (yes / no / edit)
 ```
 
+**For `stable` releases**, insert the branch move above the changelog — this is the substantive part of the confirmation, since advancing `12-release` is what decides the release contents *and* what the docs site will serve:
+
+```
+Branch:     12-release <old-sha> -> <new-sha> (fast-forward to main, <count> commits)
+            will be pushed, so the mkdocs Cloudflare Worker picks up the new docs
+```
+
 - **yes** → proceed to step 8
 - **no** → abort, inform the user no tag was created
 - **edit** → ask the user to provide the revised changelog, then re-show the summary and ask again
 
 ### 8. Create and push the tag
 
-Write the changelog text to a temporary file and use `-F` — passing a multi-line message with embedded quotes/backticks through `-m "..."` is a shell-quoting accident waiting to happen:
+**For `stable` releases, advance and push `12-release` first**, so the tag lands on the released commit and the docs site follows:
+
+```bash
+git merge --ff-only origin/main     # or the specific <sha> if releasing a subset
+git push origin 12-release
+```
+
+Pushing the branch is **not optional**. The mkdocs Cloudflare Worker publishes from `12-release`; if the branch moves only locally, the tag ships but the docs site keeps serving the previous release's content with no visible error. If either command fails, stop before tagging — a tag on an unadvanced branch would point at the old tree.
+
+Then write the changelog text to a temporary file and use `-F` — passing a multi-line message with embedded quotes/backticks through `-m "..."` is a shell-quoting accident waiting to happen:
 
 ```bash
 # Write tag message to a temp file
@@ -236,3 +271,5 @@ git push origin <new-version>
 Confirm success: "✓ Tagged and pushed <new-version>"
 
 If any command fails, show the error output and stop — do not attempt to clean up automatically. If the tag was created locally but the push failed, tell the user the tag exists locally and can be removed with `git tag -d <new-version>` or pushed manually once the issue is resolved.
+
+For `stable`, if the branch push succeeded but the tag push failed, say so explicitly: `12-release` is already published at the new commit, so the docs site has updated but no release was cut. Re-pushing the tag is all that is needed — do not roll the branch back.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,17 +125,37 @@ The `-rc` suffix on the git tag is only a workflow marker — it routes the buil
 
 Ordering always holds: `12.0.0.1 < 12.0.0.2 < 12.0.1.0` — so RC users auto-update through RCs and into the final stable release. Because Revision is reserved for RC numbers, stable releases always bump the **Build** component (never use Revision for stable).
 
-### Release Lines (current, while Jellyfin 12 is in RC)
+### Release Line — single `12.x` line (decided 2026-08-14)
 
-Every tag builds **both** ABIs (`TARGETS` in release.yml: 10.11.0/net9.0 and 12.0.0/net10.0) and writes both `targetAbi` entries to the manifest. The manifest branch (stable = main, unstable) is the release *channel*; git branches only anchor where tags are cut.
+**All version numbers are `v12.x.y.z`.** The old split scheme (RCs on `main`, `v10.11.X.0` stables on `10.11-release`) is **retired** — no further stable releases will be cut on the `10.11-release` branch. It is kept only as history; never tag from it.
 
-- **RCs** are tagged on `main` and MUST use `v12.x.y.z-rc` numbering. The unstable manifest already carries ABI-10.11 entries at version `12.x` from past RCs, so a lower-numbered RC tag (e.g. `v10.11.x.y-rc`) would sort below them and never be offered to existing RC users.
-- **Stable releases** (until Jellyfin 12 final) are tagged on `10.11-release` as `v10.11.X.0`, keeping the plugin-version-follows-Jellyfin convention prod users expect. Promotion flow:
-  1. Merge `main` into `10.11-release` (never fast-forward assumptions — the branch carries its own commits), and merge back so the trees converge.
-  2. Smoke test against a real 10.11 container: `JELLYFIN_ABI=10.11.0 ./build-local.sh`.
-  3. Tag `v10.11.X.0` on `10.11-release`.
-- Known cosmetic trade-off: RC users don't auto-roll into a `10.11.X.0` stable (it sorts below `12.x` RC versions); they stay on the byte-identical RC build until the next RC.
-- **When Jellyfin 12 final ships**: cut the first `v12.0.X.0` stable from `main` — it sorts above both lines, all users converge, and the split-line scheme ends.
+Every tag still builds **both** ABIs (`TARGETS` in release.yml: 10.11.0/net9.0 and 12.0.0/net10.0) and writes both `targetAbi` entries to the manifest. The manifest branch (stable = main, unstable) is the release *channel*; git branches only anchor where tags are cut.
+
+**Jellyfin 10.11 users keep receiving updates.** Support is unchanged — the plugin still multi-targets `net9.0` and every release still publishes an ABI-10.11 entry. Only the *version number* they see changed: updates now arrive as `12.x.y.z` instead of `10.11.x.0`. The plugin version no longer tracks the Jellyfin version line.
+
+#### Branches
+
+| Branch | Role |
+|---|---|
+| `main` | Trunk. All development lands here. **RCs are tagged here.** |
+| `12-release` | Tracks the **last stable release**. Fast-forwarded to `main` at each stable. **Stables are tagged here.** The mkdocs Cloudflare Worker publishes from this branch, so the docs site shows released state rather than unreleased trunk. |
+| `10.11-release` | Historical only. Do not tag, do not merge into. |
+
+#### Cutting a release
+
+- **RC** — on `main`: tag `v12.x.y.z-rc` → unstable manifest, GitHub prerelease. Revision *is* the RC number.
+- **Stable** — fast-forward `12-release` up to `main`, then tag there:
+
+  ```bash
+  git checkout 12-release && git merge --ff-only main
+  git tag -a v12.0.X.0 -m "..."   # Build bumps; Revision stays 0
+  ```
+
+  `--ff-only` is deliberate: `12-release` must never carry commits of its own, or it stops being a pointer at a `main` commit and the next fast-forward fails. This is the key difference from `10.11-release`, which did carry its own commits and needed merging both ways.
+
+Bump the **Build** segment for stables; Revision is reserved exclusively for RC numbers. Ordering holds across the whole line, so RC users now roll straight into stables — the old trade-off where a `10.11.X.0` stable sorted *below* the `12.x` RCs and was never offered to RC users is gone with the split.
+
+Smoke testing the 10.11 ABI before a stable is still worthwhile since it is still shipped: `JELLYFIN_ABI=10.11.0 ./build-local.sh`.
 
 ## When Making Changes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,8 +147,11 @@ Every tag still builds **both** ABIs (`TARGETS` in release.yml: 10.11.0/net9.0 a
 - **Stable** — fast-forward `12-release` up to `main`, then tag there:
 
   ```bash
-  git checkout 12-release && git merge --ff-only main
-  git tag -a v12.0.X.0 -m "..."   # Build bumps; Revision stays 0
+  git checkout 12-release
+  git fetch origin main
+  git merge --ff-only origin/main   # origin/main, not local main — a stale local ref ships old code
+  git push origin 12-release        # the docs Worker publishes from this branch
+  git tag -a v12.0.X.0 -m "..."     # Build bumps; Revision resets to 0
   ```
 
   `--ff-only` is deliberate: `12-release` must never carry commits of its own, or it stops being a pointer at a `main` commit and the next fast-forward fails. This is the key difference from `10.11-release`, which did carry its own commits and needed merging both ways.

--- a/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/AncestorWalkTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/AncestorWalkTests.cs
@@ -287,10 +287,55 @@ public class AncestorWalkTests
         Assert.Contains("foldertag", values.Tags);
         Assert.DoesNotContain("roottag", values.Tags);
 
-        // An item hanging directly off the boundary inherits nothing at all - and gets the shared
-        // Empty singleton rather than a fresh allocation.
+        // An item hanging directly off the boundary inherits nothing from the chain - and with no
+        // library registered for it, gets the shared Empty singleton rather than a fresh allocation.
         var direct = TestItems.Under(TestItems.Mov("Directly Under Root"), root);
         Assert.Same(AncestorValues.Empty, Resolve(direct));
+    }
+
+    /// <summary>
+    /// "No walkable ancestors" must not mean "no library". <c>GetCollectionFolders</c> resolves
+    /// independently of the parent chain, so an item sitting directly under the boundary still
+    /// belongs to a library and must still inherit its values. Returning Empty here would drop
+    /// library values the same way the old one-level extractors dropped season values in #495.
+    /// </summary>
+    [Fact]
+    public void Resolve_ItemDirectlyUnderBoundary_StillInheritsLibraryValues()
+    {
+        var root = new AggregateFolder { Id = Guid.NewGuid(), Name = "root" };
+        root.SortName = "root";
+
+        var movie = TestItems.Under(TestItems.Mov("Rootless Movie"), root);
+
+        var library = TestItems.PhysicalFolder("Filmer", "movielibtag");
+        TestLibraryManager.CollectionFolders[movie.Id] = [library];
+
+        var values = Resolve(movie);
+
+        Assert.Contains("movielibtag", values.Tags);
+    }
+
+    /// <summary>
+    /// Same principle for an unresolvable parent: <c>ParentId</c> is set but the item it points at
+    /// is gone from the library (deleted mid-refresh, stale reference), so both <c>GetParent()</c>
+    /// and <c>GetOwner()</c> return null. The library lookup does not depend on that reference and
+    /// must still contribute.
+    /// </summary>
+    [Fact]
+    public void Resolve_UnresolvableParent_StillInheritsLibraryValues()
+    {
+        var orphan = TestItems.Mov("Orphaned Movie");
+        orphan.ParentId = Guid.NewGuid();          // points at an id that was never registered
+        TestLibraryManager.Items[orphan.Id] = orphan;
+
+        Assert.Null(orphan.GetParent());
+
+        var library = TestItems.PhysicalFolder("Filmer", "orphanlibtag");
+        TestLibraryManager.CollectionFolders[orphan.Id] = [library];
+
+        var values = Resolve(orphan);
+
+        Assert.Contains("orphanlibtag", values.Tags);
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/AncestorWalkTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/AncestorWalkTests.cs
@@ -1,0 +1,524 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Text.Json;
+using Jellyfin.Plugin.SmartLists.Core;
+using Jellyfin.Plugin.SmartLists.Core.Models;
+using Jellyfin.Plugin.SmartLists.Core.QueryEngine;
+using Jellyfin.Plugin.SmartLists.Services.Shared;
+using Jellyfin.Plugin.SmartLists.Tests.Support;
+using MediaBrowser.Controller.Entities;
+
+namespace Jellyfin.Plugin.SmartLists.Tests.Core.QueryEngine;
+
+/// <summary>
+/// Covers <see cref="AncestorValueResolver"/> - the memoized walk that replaced six one-level
+/// "parent series" / "parent album" extractors - plus the two compile-time gates that decide
+/// whether it runs at all.
+///
+/// The fixtures here are deliberately built with <c>ParentId</c> links (TestItems.Under) rather
+/// than <c>SeriesId</c>. That is the whole point of issue #495: the old extractor resolved an
+/// episode's <c>SeriesId</c> and read only that Series' Tags, jumping clean over the Season in
+/// between, and never reaching the library at all. Several tests below are written so that they
+/// FAIL against a SeriesId-based implementation - see
+/// <see cref="Resolve_FindsTagSetOnTheSeason_TheLevelTheOldCodeSkipped"/>.
+/// </summary>
+public class AncestorWalkTests
+{
+    private static ConcurrentDictionary<Guid, AncestorValues> NewMemo() => new();
+
+    private static AncestorValues Resolve(BaseItem item, ConcurrentDictionary<Guid, AncestorValues>? memo = null)
+        => AncestorValueResolver.Resolve(item, BaseItem.LibraryManager, memo ?? NewMemo(), null);
+
+    // ---------------------------------------------------------------------------------------
+    // The walk itself
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Issue #495 proper. The tag lives on the SEASON - the level the old
+    /// <c>ExtractParentSeriesTags</c> skipped by resolving <c>episode.SeriesId</c> straight to
+    /// the Series. The episode here carries a valid <c>SeriesId</c> on purpose, so a regression
+    /// back to that shortcut compiles and runs but returns the Series' tags only, and this test
+    /// goes red.
+    /// </summary>
+    [Fact]
+    public void Resolve_FindsTagSetOnTheSeason_TheLevelTheOldCodeSkipped()
+    {
+        var top = TestItems.PhysicalFolder("shows");
+        var series = TestItems.Show("The IT Crowd");
+        series.Tags = ["seriestag01"];
+        var season = TestItems.SeasonOf("Season 1");
+        season.Tags = ["seasontag99"];
+        var episode = TestItems.Ep("The IT Crowd", 1, 1, show: series);
+
+        TestItems.Under(series, top);
+        TestItems.Under(season, series);
+        TestItems.Under(episode, season);
+
+        var values = Resolve(episode);
+
+        // The shortcut the old code took IS available on this fixture - and is still wrong.
+        Assert.Equal(series.Id, episode.SeriesId);
+        Assert.NotEqual(series.Id, episode.ParentId);
+
+        Assert.Contains("seasontag99", values.Tags);
+        Assert.Contains("seriestag01", values.Tags);
+    }
+
+    /// <summary>
+    /// A Jellyfin library (CollectionFolder) is NEVER in the ParentId chain - it hangs off the
+    /// UserRootFolder as a sibling structure - so the walk has to union
+    /// <c>GetCollectionFolders(chainTop)</c> on top of the parent chain. Drop that half and a
+    /// library-level tag is invisible, which is the second symptom reported in #495.
+    /// </summary>
+    [Fact]
+    public void Resolve_UnionsLibraryFolderValues_NotReachableViaParentChain()
+    {
+        var library = TestItems.PhysicalFolder("Serier", "librarytag01");
+        var top = TestItems.PhysicalFolder("shows");
+        TestLibraryManager.CollectionFolders[top.Id] = [library];
+
+        var series = TestItems.Show("The IT Crowd");
+        var season = TestItems.SeasonOf("Season 1");
+        var episode = TestItems.Ep("The IT Crowd", 1, 1, show: series);
+
+        TestItems.Under(series, top);
+        TestItems.Under(season, series);
+        TestItems.Under(episode, season);
+
+        // Nothing points at the library: a parents-only walk terminates at `top` and can never
+        // see it. This is what makes the assertion below load-bearing.
+        Assert.Equal(Guid.Empty, top.ParentId);
+
+        var values = Resolve(episode);
+
+        Assert.Contains("librarytag01", values.Tags);
+    }
+
+    /// <summary>
+    /// Tags, Studios and Genres are collected in ONE pass, from different levels of the same
+    /// chain - that single pass is what replaced six separate extractors.
+    /// </summary>
+    [Fact]
+    public void Resolve_CollectsTagsStudiosAndGenresInOneWalk()
+    {
+        var top = TestItems.PhysicalFolder("shows");
+        top.Genres = ["Documentary"];
+        var series = TestItems.Show("The IT Crowd");
+        series.Studios = ["Channel 4"];
+        var season = TestItems.SeasonOf("Season 1");
+        season.Tags = ["seasontag99"];
+        var episode = TestItems.Ep("The IT Crowd", 1, 1, show: series);
+
+        TestItems.Under(series, top);
+        TestItems.Under(season, series);
+        TestItems.Under(episode, season);
+
+        var values = Resolve(episode);
+
+        Assert.Contains("seasontag99", values.Tags);
+        Assert.Contains("Channel 4", values.Studios);
+        Assert.Contains("Documentary", values.Genres);
+    }
+
+    /// <summary>
+    /// The memo is keyed on the item's raw <c>ParentId</c> Guid and consulted BEFORE any parent
+    /// is materialized, so a hit costs one dictionary lookup and ZERO ILibraryManager calls.
+    /// Materializing the parent first (the obvious way to write this) would cost one
+    /// <c>GetItemById</c> round-trip per ITEM instead of per container.
+    /// </summary>
+    [Fact]
+    public void Resolve_MemoHitCostsNoLibraryCalls()
+    {
+        var top = TestItems.PhysicalFolder("shows");
+        var series = TestItems.Show("The IT Crowd");
+        var season = TestItems.SeasonOf("Season 1");
+        season.Tags = ["seasontag99"];
+        var first = TestItems.Ep("The IT Crowd", 1, 1, show: series);
+        var second = TestItems.Ep("The IT Crowd", 1, 2, show: series);
+
+        TestItems.Under(series, top);
+        TestItems.Under(season, series);
+        TestItems.Under(first, season);
+        TestItems.Under(second, season);
+
+        var memo = NewMemo();
+        Resolve(first, memo);
+
+        var before = TestLibraryManager.CallsFor(season.Id, series.Id, top.Id, second.Id);
+        var values = Resolve(second, memo);
+        var after = TestLibraryManager.CallsFor(season.Id, series.Id, top.Id, second.Id);
+
+        Assert.Equal(before, after);
+        Assert.Contains("seasontag99", values.Tags);
+    }
+
+    /// <summary>
+    /// Memo entries are keyed by ANCESTOR NODE id, never by item id, so ten thousand episodes of
+    /// five hundred seasons produce five hundred-ish entries, not ten thousand.
+    /// </summary>
+    [Fact]
+    public void Resolve_MemoizesOneEntryPerAncestorNode()
+    {
+        var top = TestItems.PhysicalFolder("shows");
+        var series = TestItems.Show("The IT Crowd");
+        var season = TestItems.SeasonOf("Season 1");
+        season.Tags = ["seasontag99"];
+        var first = TestItems.Ep("The IT Crowd", 1, 1, show: series);
+        var second = TestItems.Ep("The IT Crowd", 1, 2, show: series);
+
+        TestItems.Under(series, top);
+        TestItems.Under(season, series);
+        TestItems.Under(first, season);
+        TestItems.Under(second, season);
+
+        var memo = NewMemo();
+        Resolve(first, memo);
+        Resolve(second, memo);
+
+        Assert.Equal(3, memo.Count);
+        Assert.Contains(season.Id, memo.Keys);
+        Assert.Contains(series.Id, memo.Keys);
+        Assert.Contains(top.Id, memo.Keys);
+        Assert.DoesNotContain(first.Id, memo.Keys);
+        Assert.DoesNotContain(second.Id, memo.Keys);
+    }
+
+    /// <summary>
+    /// A ParentId cycle terminates instead of hanging, and writes NOTHING to the memo: a
+    /// truncated walk is missing the top of the chain, so caching it would make later results
+    /// depend on which item happened to warm the cache first.
+    /// </summary>
+    [Fact]
+    public void Resolve_CycleTerminatesAndWritesNoMemoEntries()
+    {
+        var a = TestItems.PhysicalFolder("cycle-a", "atag");
+        var b = TestItems.PhysicalFolder("cycle-b", "btag");
+        TestItems.Under(a, b);
+        TestItems.Under(b, a);
+
+        var item = TestItems.Under(TestItems.Mov("Caught In A Loop"), a);
+
+        var memo = NewMemo();
+        var values = Resolve(item, memo);
+
+        Assert.Empty(memo);
+        Assert.Contains("atag", values.Tags);
+        Assert.Contains("btag", values.Tags);
+    }
+
+    /// <summary>
+    /// On the depth-cap path the library values are STILL resolved, from the deepest node the
+    /// walk reached. <c>GetCollectionFolders</c> walks independently of the chain, so dropping it
+    /// on truncation would silently reproduce the exact bug this change fixes.
+    /// </summary>
+    [Fact]
+    public void Resolve_TruncatedWalkStillReturnsLibraryValues()
+    {
+        // The cap is 20; build 25 levels so it definitely binds.
+        var folders = new List<Folder>();
+        for (var i = 0; i < 25; i++)
+        {
+            folders.Add(TestItems.PhysicalFolder("deep-" + i, "tag" + i));
+        }
+
+        for (var i = 0; i < folders.Count - 1; i++)
+        {
+            TestItems.Under(folders[i], folders[i + 1]);
+        }
+
+        // The walk stops after collecting 20 nodes, so folders[19] is the deepest node reached
+        // and therefore the anchor GetCollectionFolders is asked about.
+        var library = TestItems.PhysicalFolder("Deep Library", "librarytag-deep");
+        TestLibraryManager.CollectionFolders[folders[19].Id] = [library];
+
+        var item = TestItems.Under(TestItems.Mov("Very Deep Movie"), folders[0]);
+
+        var memo = NewMemo();
+        var values = Resolve(item, memo);
+
+        Assert.Contains("librarytag-deep", values.Tags);
+        Assert.Contains("tag0", values.Tags);
+        Assert.Contains("tag19", values.Tags);
+        Assert.DoesNotContain("tag20", values.Tags);
+        Assert.Empty(memo);
+    }
+
+    /// <summary>
+    /// Extras have an empty <c>ParentId</c> and an <c>OwnerId</c> pointing at the item they belong
+    /// to, so the walk falls back to <c>GetOwner()</c> - the same fallback core's own
+    /// <c>GetCollectionFolders</c> uses.
+    /// </summary>
+    [Fact]
+    public void Resolve_ExtraWithNoParentResolvesViaOwner()
+    {
+        var top = TestItems.PhysicalFolder("shows");
+        var series = TestItems.Show("Modern Family");
+        series.Tags = ["ownertag"];
+        TestItems.Under(series, top);
+
+        var extra = TestItems.Mov("Gag reel season 1");
+        extra.OwnerId = series.Id;
+        TestLibraryManager.Items[extra.Id] = extra;
+
+        Assert.Equal(Guid.Empty, extra.ParentId);
+
+        var values = Resolve(extra);
+
+        Assert.Contains("ownertag", values.Tags);
+    }
+
+    /// <summary>
+    /// The walk stops BEFORE AggregateFolder/UserRootFolder/UserView. Those are server plumbing,
+    /// not user-facing containers, and climbing into them would leak values across libraries.
+    /// </summary>
+    [Fact]
+    public void Resolve_StopsAtWalkBoundary_DoesNotClimbIntoAggregateFolder()
+    {
+        var root = new AggregateFolder { Id = Guid.NewGuid(), Name = "root" };
+        root.SortName = "root";
+        root.Tags = ["roottag"];
+
+        var top = TestItems.PhysicalFolder("shows", "foldertag");
+        TestItems.Under(top, root);
+
+        var movie = TestItems.Under(TestItems.Mov("Boundary Movie"), top);
+        var values = Resolve(movie);
+
+        Assert.Contains("foldertag", values.Tags);
+        Assert.DoesNotContain("roottag", values.Tags);
+
+        // An item hanging directly off the boundary inherits nothing at all - and gets the shared
+        // Empty singleton rather than a fresh allocation.
+        var direct = TestItems.Under(TestItems.Mov("Directly Under Root"), root);
+        Assert.Same(AncestorValues.Empty, Resolve(direct));
+    }
+
+    /// <summary>
+    /// De-duplication across levels is Ordinal, NOT OrdinalIgnoreCase (which is what core's
+    /// GetInheritedTags uses). Six of the seven operators are case-insensitive so the difference
+    /// is invisible to them, but MatchRegex is case-SENSITIVE, and case-insensitive dedup could
+    /// discard the only casing a pattern would have matched.
+    /// </summary>
+    [Fact]
+    public void Resolve_DedupesOrdinallyAcrossLevels()
+    {
+        var library = TestItems.PhysicalFolder("Serier", "Series01");
+        var top = TestItems.PhysicalFolder("shows");
+        TestLibraryManager.CollectionFolders[top.Id] = [library];
+
+        var series = TestItems.Show("The IT Crowd");
+        var season = TestItems.SeasonOf("Season 1");
+        season.Tags = ["series01"];
+        var episode = TestItems.Ep("The IT Crowd", 1, 1, show: series);
+
+        TestItems.Under(series, top);
+        TestItems.Under(season, series);
+        TestItems.Under(episode, season);
+
+        var values = Resolve(episode);
+
+        Assert.Contains("Series01", values.Tags);
+        Assert.Contains("series01", values.Tags);
+        Assert.Equal(2, values.Tags.Count);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Walk output fed through the compiled rule
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Negative operators AND-fold, so a WIDER ancestor set can only REMOVE items. An episode
+    /// whose season carries the tag is excluded by "Tags NotEqual &lt;tag&gt;"; its sibling in an
+    /// untagged season survives.
+    /// </summary>
+    [Fact]
+    public void CompileRule_TagsNotEqual_AcrossTwoLevelWalk_ExcludesWhenAnyAncestorMatches()
+    {
+        var top = TestItems.PhysicalFolder("shows");
+        var series = TestItems.Show("The IT Crowd");
+        TestItems.Under(series, top);
+
+        var tagged = TestItems.SeasonOf("Season 1");
+        tagged.Tags = ["seasontag99"];
+        TestItems.Under(tagged, series);
+
+        var clean = TestItems.SeasonOf("Season 2");
+        TestItems.Under(clean, series);
+
+        var taggedEpisode = TestItems.Under(TestItems.Ep("The IT Crowd", 1, 1, show: series), tagged);
+        var cleanEpisode = TestItems.Under(TestItems.Ep("The IT Crowd", 2, 1, show: series), clean);
+
+        var memo = NewMemo();
+        var rule = Engine.CompileRule<Operand>(
+            new Expression("Tags", "NotEqual", "seasontag99") { IncludeParentTags = true },
+            string.Empty);
+
+        Assert.False(rule(new Operand("tagged") { ParentTags = Resolve(taggedEpisode, memo).Tags }));
+        Assert.True(rule(new Operand("clean") { ParentTags = Resolve(cleanEpisode, memo).Tags }));
+    }
+
+    /// <summary>
+    /// MatchRegex is the one operator for which an EMPTY list and a NULL list differ: an empty
+    /// list is tested against <c>string.Empty</c>, so <c>^$</c> matches "has no values here".
+    /// That is why Operand's parent lists are initialized to <c>[]</c> and why the resolver never
+    /// returns null.
+    /// </summary>
+    [Fact]
+    public void CompileRule_TagsMatchRegexEmptyPattern_WithAndWithoutAncestorValues()
+    {
+        var onlyParent = Engine.CompileRule<Operand>(
+            new Expression("Tags", "MatchRegex", "^$") { OnlyParentTags = true, IncludeParentTags = true },
+            string.Empty);
+
+        // No inherited tags -> the pattern is tested against string.Empty and matches, regardless
+        // of what the item itself carries.
+        Assert.True(onlyParent(new Operand("item") { Tags = ["Anime"], ParentTags = [] }));
+
+        // Any inherited value at all switches to per-element matching, and "Anime" is not "".
+        Assert.False(onlyParent(new Operand("item") { ParentTags = ["Anime"] }));
+
+        // With the item's own field folded in, the two terms OR: an empty ancestor list alone is
+        // enough to satisfy ^$ even when the item is tagged.
+        var includeParent = Engine.CompileRule<Operand>(
+            new Expression("Tags", "MatchRegex", "^$") { IncludeParentTags = true },
+            string.Empty);
+
+        Assert.True(includeParent(new Operand("item") { Tags = ["Anime"], ParentTags = [] }));
+        Assert.False(includeParent(new Operand("item") { Tags = ["Anime"], ParentTags = ["Comedy"] }));
+    }
+
+    /// <summary>
+    /// Engine reaches Operand through <c>Expression.PropertyOrField(param, "&lt;literal&gt;")</c>,
+    /// so a spelling mismatch between Engine's string literals and Operand's property names
+    /// compiles clean and only throws <see cref="ArgumentException"/> at rule-compile time - once
+    /// per refresh, in production. This is the build-time-equivalent guard.
+    /// </summary>
+    [Fact]
+    public void CompileRule_UsingNewParentFields_DoesNotThrowArgumentException()
+    {
+        var tags = Engine.CompileRule<Operand>(
+            new Expression("Tags", "Equal", "Anime") { IncludeParentTags = true }, string.Empty);
+        var studios = Engine.CompileRule<Operand>(
+            new Expression("Studios", "Equal", "Channel 4") { IncludeParentStudios = true }, string.Empty);
+        var genres = Engine.CompileRule<Operand>(
+            new Expression("Genres", "Equal", "Jazz") { IncludeParentGenres = true }, string.Empty);
+
+        Assert.True(tags(new Operand("item") { ParentTags = ["Anime"] }));
+        Assert.True(studios(new Operand("item") { ParentStudios = ["Channel 4"] }));
+        Assert.True(genres(new Operand("item") { ParentGenres = ["Jazz"] }));
+
+        // The only-parent variants resolve a different field list; exercise them too.
+        var onlyTags = Engine.CompileRule<Operand>(
+            new Expression("Tags", "Equal", "Anime") { OnlyParentTags = true, IncludeParentTags = true }, string.Empty);
+        Assert.True(onlyTags(new Operand("item") { ParentTags = ["Anime"] }));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // The gates that decide whether the walk runs at all
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// THE silent-failure mode. Tags/Studios/Genres are registered as CHEAP fields, so
+    /// <c>FieldRegistry.IsExpensiveField("Tags")</c> is false and this hardcoded predicate is the
+    /// ONLY thing that promotes a parent-aware rule to the expensive tier. Miss it and the rule is
+    /// evaluated in Phase 1 against an operand whose ParentTags the Factory reset to <c>[]</c>,
+    /// matching nothing - with no exception and no log line.
+    /// </summary>
+    [Fact]
+    public void IsNonExpensiveExpression_ClassifiesParentAwareTagsRuleAsExpensive()
+    {
+        var method = typeof(SmartList).GetMethod(
+            "IsNonExpensiveExpression",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        bool IsNonExpensive(Expression expression) => (bool)method.Invoke(null, [expression])!;
+
+        Assert.True(IsNonExpensive(new Expression("Tags", "Equal", "Anime")));
+
+        Assert.False(IsNonExpensive(new Expression("Tags", "Equal", "Anime") { IncludeParentTags = true }));
+        Assert.False(IsNonExpensive(new Expression("Tags", "Equal", "Anime") { OnlyParentTags = true }));
+        Assert.False(IsNonExpensive(new Expression("Studios", "Equal", "Channel 4") { IncludeParentStudios = true }));
+        Assert.False(IsNonExpensive(new Expression("Genres", "Equal", "Jazz") { IncludeParentGenres = true }));
+
+        // Lists saved by older builds carry only the legacy keys. They must promote too, or a
+        // pre-upgrade list silently stops matching after the upgrade.
+        Assert.False(IsNonExpensive(new Expression("Tags", "Equal", "Anime") { IncludeParentSeriesTags = true }));
+        Assert.False(IsNonExpensive(new Expression("Tags", "Equal", "Anime") { IncludeParentAlbumTags = true }));
+        Assert.False(IsNonExpensive(new Expression("Studios", "Equal", "Channel 4") { IncludeParentSeriesStudios = true }));
+        Assert.False(IsNonExpensive(new Expression("Genres", "Equal", "Jazz") { IncludeParentAlbumGenres = true }));
+    }
+
+    /// <summary>
+    /// The compiled-rule cache is process-static, holds 1000 entries and cleans up no more often
+    /// than every five minutes, so a rule-set hash that ignores a compilation-affecting flag
+    /// produces a stale-rule bug that does NOT self-heal without a Jellyfin restart.
+    /// </summary>
+    [Fact]
+    public void GenerateRuleSetHash_DiffersWhenIncludeParentTagsToggles()
+    {
+        var plain = Hash(new Expression("Tags", "Equal", "Anime"));
+        var withParent = Hash(new Expression("Tags", "Equal", "Anime") { IncludeParentTags = true });
+        var withLegacySeries = Hash(new Expression("Tags", "Equal", "Anime") { IncludeParentSeriesTags = true });
+
+        Assert.NotEqual(plain, withParent);
+
+        // The fold is a total function of behaviour: the legacy flag compiles to exactly the same
+        // expression tree, so sharing a cache entry is correct, not a collision.
+        Assert.Equal(withParent, withLegacySeries);
+
+        Assert.NotEqual(
+            Hash(new Expression("Studios", "Equal", "Channel 4")),
+            Hash(new Expression("Studios", "Equal", "Channel 4") { IncludeParentStudios = true }));
+        Assert.NotEqual(
+            Hash(new Expression("Genres", "Equal", "Jazz")),
+            Hash(new Expression("Genres", "Equal", "Jazz") { IncludeParentGenres = true }));
+        Assert.NotEqual(
+            withParent,
+            Hash(new Expression("Tags", "Equal", "Anime") { IncludeParentTags = true, OnlyParentTags = true }));
+    }
+
+    private static string Hash(Expression expression)
+    {
+        var dto = new SmartPlaylistDto
+        {
+            Id = "ancestor-walk-hash-test",
+            Name = "ancestor-walk-hash-test",
+            ExpressionSets = [new ExpressionSet { Expressions = [expression] }],
+        };
+
+        var method = typeof(SmartList).GetMethod(
+            "GenerateRuleSetHash",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        return (string)method.Invoke(new SmartList(dto), new object?[] { null })!;
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // On-disk back-compat
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Reading the legacy keys is permanent: lists saved by older builds still carry them, and
+    /// every refresh re-serializes the whole DTO, so anything the model cannot read is ERASED
+    /// from disk rather than merely ignored. New saves write only the new key, and the computed
+    /// folds must never be serialized.
+    /// </summary>
+    [Fact]
+    public void Expression_LegacyAlbumFlagFoldsIntoIncludeParentTagsEffective()
+    {
+        const string Json =
+            """{"MemberName":"Tags","Operator":"Contains","TargetValue":"seasontag99","IncludeParentAlbumTags":true}""";
+
+        var expr = JsonSerializer.Deserialize<Expression>(Json, SmartListFileSystem.SharedJsonOptions)!;
+
+        Assert.True(expr.IncludeParentAlbumTags);
+        Assert.Null(expr.IncludeParentTags);
+        Assert.True(expr.IncludeParentTagsEffective);
+
+        var roundTripped = JsonSerializer.Serialize(expr, SmartListFileSystem.SharedJsonOptions);
+
+        Assert.Contains("IncludeParentAlbumTags", roundTripped, StringComparison.Ordinal);
+        Assert.DoesNotContain("Effective", roundTripped, StringComparison.Ordinal);
+        Assert.DoesNotContain("IncludeParentTags", roundTripped, StringComparison.Ordinal);
+    }
+}

--- a/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/EngineOperatorTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/EngineOperatorTests.cs
@@ -895,32 +895,33 @@ public class EngineOperatorTests
     // ---------------------------------------------------------------------------------------
 
     /// <summary>
-    /// With a parent source enabled, POSITIVE operators OR the item field with the parent field:
-    /// an episode with no tags of its own inherits a match from its series.
+    /// With the parent option enabled, POSITIVE operators OR the item field with the ancestor
+    /// field: an episode with no tags of its own inherits a match from anywhere above it
+    /// (season, series, folder, library).
     /// </summary>
     [Fact]
-    public void CompileRule_TagsIncludingParentSeries_OrsItemAndParentForPositiveOperators()
+    public void CompileRule_TagsIncludingParent_OrsItemAndParentForPositiveOperators()
     {
-        var rule = Compile(new Expression("Tags", "Equal", "Anime") { IncludeParentSeriesTags = true });
+        var rule = Compile(new Expression("Tags", "Equal", "Anime") { IncludeParentTags = true });
 
-        Assert.True(rule(new Operand("item") { ParentSeriesTags = ["Anime"] }));
+        Assert.True(rule(new Operand("item") { ParentTags = ["Anime"] }));
         Assert.True(rule(new Operand("item") { Tags = ["Anime"] }));
-        Assert.False(rule(new Operand("item") { Tags = ["Drama"], ParentSeriesTags = ["Comedy"] }));
+        Assert.False(rule(new Operand("item") { Tags = ["Drama"], ParentTags = ["Comedy"] }));
     }
 
     /// <summary>
     /// NEGATIVE operators (NotEqual/NotContains/IsNotIn) AND the per-field results instead, so a
-    /// match on EITHER the item or its parent excludes the item. Anything else would let a
+    /// match on EITHER the item or its ancestors excludes the item. Anything else would let a
     /// "not tagged Anime" rule leak in episodes of an Anime-tagged series.
     /// </summary>
     [Fact]
-    public void CompileRule_TagsIncludingParentSeries_AndsItemAndParentForNegativeOperators()
+    public void CompileRule_TagsIncludingParent_AndsItemAndParentForNegativeOperators()
     {
-        var rule = Compile(new Expression("Tags", "NotEqual", "Anime") { IncludeParentSeriesTags = true });
+        var rule = Compile(new Expression("Tags", "NotEqual", "Anime") { IncludeParentTags = true });
 
         Assert.False(rule(new Operand("item") { Tags = ["Anime"] }));
-        Assert.False(rule(new Operand("item") { ParentSeriesTags = ["Anime"] }));
-        Assert.True(rule(new Operand("item") { Tags = ["Drama"], ParentSeriesTags = ["Comedy"] }));
+        Assert.False(rule(new Operand("item") { ParentTags = ["Anime"] }));
+        Assert.True(rule(new Operand("item") { Tags = ["Drama"], ParentTags = ["Comedy"] }));
         Assert.True(rule(new Operand("item")));
     }
 
@@ -928,16 +929,16 @@ public class EngineOperatorTests
     /// OnlyParent skips the item's own tags entirely.
     /// </summary>
     [Fact]
-    public void CompileRule_TagsOnlyParentSeries_IgnoresTheItemsOwnTags()
+    public void CompileRule_TagsOnlyParent_IgnoresTheItemsOwnTags()
     {
         var rule = Compile(new Expression("Tags", "Equal", "Anime")
         {
             OnlyParentTags = true,
-            IncludeParentSeriesTags = true,
+            IncludeParentTags = true,
         });
 
         Assert.False(rule(new Operand("item") { Tags = ["Anime"] }));
-        Assert.True(rule(new Operand("item") { ParentSeriesTags = ["Anime"] }));
+        Assert.True(rule(new Operand("item") { ParentTags = ["Anime"] }));
     }
 
     /// <summary>
@@ -950,19 +951,19 @@ public class EngineOperatorTests
         var rule = Compile(new Expression("Tags", "Equal", "Anime") { OnlyParentTags = true });
 
         Assert.False(rule(new Operand("item") { Tags = ["Anime"] }));
-        Assert.False(rule(new Operand("item") { ParentSeriesTags = ["Anime"] }));
+        Assert.False(rule(new Operand("item") { ParentTags = ["Anime"] }));
     }
 
     /// <summary>
-    /// Genres behaves the same way as Tags, including for the album-parent source (music).
+    /// Genres behaves the same way as Tags, including for music (album / artist folder / library).
     /// </summary>
     [Fact]
-    public void CompileRule_GenresIncludingParentAlbum_OrsItemAndParent()
+    public void CompileRule_GenresIncludingParent_OrsItemAndParent()
     {
-        var rule = Compile(new Expression("Genres", "Contains", "jazz") { IncludeParentAlbumGenres = true });
+        var rule = Compile(new Expression("Genres", "Contains", "jazz") { IncludeParentGenres = true });
 
-        Assert.True(rule(new Operand("item") { ParentAlbumGenres = ["Smooth Jazz"] }));
-        Assert.False(rule(new Operand("item") { Genres = ["Rock"], ParentAlbumGenres = ["Blues"] }));
+        Assert.True(rule(new Operand("item") { ParentGenres = ["Smooth Jazz"] }));
+        Assert.False(rule(new Operand("item") { Genres = ["Rock"], ParentGenres = ["Blues"] }));
     }
 
     // ---------------------------------------------------------------------------------------

--- a/Jellyfin.Plugin.SmartLists.Tests/Support/TestItems.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Support/TestItems.cs
@@ -22,10 +22,10 @@ namespace Jellyfin.Plugin.SmartLists.Tests.Support;
 /// library manager that comparison throws, so every air-block test would have to avoid the exact
 /// case air blocks exist for.
 ///
-/// Only <c>GetItemById(Guid)</c> is implemented. Every other member throws
-/// <see cref="NotSupportedException"/> on purpose: if production code under test ever starts
-/// depending on more of the library manager, these tests must fail loudly rather than quietly
-/// sort against a default-valued stub.
+/// Only <c>GetItemById(Guid)</c> and the one-argument <c>GetCollectionFolders(BaseItem)</c> are
+/// implemented. Every other member throws <see cref="NotSupportedException"/> on purpose: if
+/// production code under test ever starts depending on more of the library manager, these tests
+/// must fail loudly rather than quietly sort against a default-valued stub.
 /// </summary>
 public class TestLibraryManager : DispatchProxy
 {
@@ -36,11 +36,39 @@ public class TestLibraryManager : DispatchProxy
     /// </summary>
     internal static readonly ConcurrentDictionary<Guid, BaseItem> Items = new();
 
+    /// <summary>
+    /// Answers <c>GetCollectionFolders(BaseItem)</c>, keyed by the id of the item the resolver
+    /// passes as the anchor - i.e. the CHAIN-TOP folder, deliberately NOT the leaf item id.
+    ///
+    /// This arm exists because a Jellyfin library (a <c>CollectionFolder</c>) is never in an
+    /// item's <c>ParentId</c> chain: it hangs off the UserRootFolder as a sibling structure.
+    /// A parents-only walk therefore finds season tags but never library tags, so without this
+    /// stub the library half of the ancestor walk could not be tested at all.
+    /// </summary>
+    internal static readonly ConcurrentDictionary<Guid, List<Folder>> CollectionFolders = new();
+
+    /// <summary>
+    /// Per-id <c>GetItemById</c> call counter. Keyed by id rather than being a single total so
+    /// it stays meaningful under xUnit's parallel test collections: ids are freshly generated
+    /// per test, so no other class can perturb the count for the ids one test cares about.
+    /// </summary>
+    internal static readonly ConcurrentDictionary<Guid, int> GetItemByIdCalls = new();
+
+    /// <summary>Total <c>GetItemById</c> calls recorded for the given ids.</summary>
+    internal static int CallsFor(params Guid[] ids)
+        => ids.Sum(id => GetItemByIdCalls.TryGetValue(id, out var count) ? count : 0);
+
     protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
     {
         if (targetMethod?.Name == "GetItemById" && args is { Length: 1 } && args[0] is Guid id)
         {
+            GetItemByIdCalls.AddOrUpdate(id, 1, (_, count) => count + 1);
             return Items.TryGetValue(id, out var item) ? item : null;
+        }
+
+        if (targetMethod?.Name == "GetCollectionFolders" && args is { Length: 1 } && args[0] is BaseItem anchor)
+        {
+            return CollectionFolders.TryGetValue(anchor.Id, out var folders) ? folders : new List<Folder>();
         }
 
         throw new NotSupportedException(
@@ -153,6 +181,42 @@ public static class TestItems
         var season = new Season { Id = Guid.NewGuid(), Name = name };
         season.SortName = name;
         return season;
+    }
+
+    /// <summary>
+    /// Links <paramref name="child"/> to <paramref name="parent"/> through <c>ParentId</c> - the
+    /// only link the ancestor walk follows - and registers BOTH with the library-manager stub so
+    /// <c>GetParent()</c> can resolve them.
+    ///
+    /// Deliberately does NOT touch <c>SeriesId</c>/<c>SeasonId</c>: those drift from the real
+    /// tree, and reaching for them instead of the parent chain is exactly what issue #495 was.
+    /// </summary>
+    public static T Under<T>(T child, BaseItem parent)
+        where T : BaseItem
+    {
+        child.ParentId = parent.Id;
+        TestLibraryManager.Items[child.Id] = child;
+        TestLibraryManager.Items[parent.Id] = parent;
+        return child;
+    }
+
+    /// <summary>
+    /// A plain physical folder - the <c>/shows</c> or <c>/movies</c> level of the tree, and the
+    /// stand-in for a library's CollectionFolder. Returned UNREGISTERED: <see cref="Under{T}"/>
+    /// registers it when it is linked into a chain, and library folders are reached through
+    /// <see cref="TestLibraryManager.CollectionFolders"/> rather than through <c>GetItemById</c>.
+    /// </summary>
+    public static Folder PhysicalFolder(string name, params string[] tags)
+    {
+        var folder = new Folder { Id = Guid.NewGuid(), Name = name };
+        folder.SortName = name;
+
+        if (tags.Length > 0)
+        {
+            folder.Tags = tags;
+        }
+
+        return folder;
     }
 
     /// <summary>A MusicAlbum - the audio equivalent of <see cref="SeasonOf"/>.</summary>

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
@@ -2939,7 +2939,7 @@
             SmartLists.updateAllFieldSelects(page);
         }
 
-        // Update visibility of parent series options based on media types
+        // Update visibility of parent metadata options
         if (SmartLists.updateAllTagsOptionsVisibility) {
             SmartLists.updateAllTagsOptionsVisibility(page);
         }

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -1650,17 +1650,15 @@
                             playlistsInfo = ' (playlist only)';
                         }
 
-                        // Add Tags configuration info
+                        // Add Tags configuration info. The legacy IncludeParentSeries*/IncludeParentAlbum*
+                        // keys are still read here (permanently): rules saved by older builds carry
+                        // only those, and would otherwise lose their suffix on the card.
                         let tagsInfo = '';
                         if (rule.MemberName === 'Tags') {
                             if (rule.OnlyParentTags === true) {
-                                tagsInfo = ' (only parent series/album tags)';
-                            } else if (rule.IncludeParentSeriesTags === true && rule.IncludeParentAlbumTags === true) {
-                                tagsInfo = ' (including parent series/album tags)';
-                            } else if (rule.IncludeParentAlbumTags === true) {
-                                tagsInfo = ' (including parent album tags)';
-                            } else if (rule.IncludeParentSeriesTags === true) {
-                                tagsInfo = ' (including parent series tags)';
+                                tagsInfo = ' (only parent tags)';
+                            } else if (rule.IncludeParentTags === true || rule.IncludeParentSeriesTags === true || rule.IncludeParentAlbumTags === true) {
+                                tagsInfo = ' (including parent tags)';
                             }
                         }
 
@@ -1668,29 +1666,19 @@
                         let studiosInfo = '';
                         if (rule.MemberName === 'Studios') {
                             if (rule.OnlyParentStudios === true) {
-                                studiosInfo = ' (only parent series/album studios)';
-                            } else if (rule.IncludeParentSeriesStudios === true && rule.IncludeParentAlbumStudios === true) {
-                                studiosInfo = ' (including parent series/album studios)';
-                            } else if (rule.IncludeParentAlbumStudios === true) {
-                                studiosInfo = ' (including parent album studios)';
-                            } else if (rule.IncludeParentSeriesStudios === true) {
-                                studiosInfo = ' (including parent series studios)';
+                                studiosInfo = ' (only parent studios)';
+                            } else if (rule.IncludeParentStudios === true || rule.IncludeParentSeriesStudios === true || rule.IncludeParentAlbumStudios === true) {
+                                studiosInfo = ' (including parent studios)';
                             }
                         }
 
                         // Add Genres configuration info
                         let genresInfo = '';
                         if (rule.MemberName === 'Genres') {
-                            const includesParentSeriesGenres = rule.IncludeParentSeriesGenres === true;
-                            const includesParentAlbumGenres = rule.IncludeParentAlbumGenres === true;
                             if (rule.OnlyParentGenres === true) {
-                                genresInfo = ' (only parent series/album genres)';
-                            } else if (includesParentSeriesGenres && includesParentAlbumGenres) {
-                                genresInfo = ' (including parent series/album genres)';
-                            } else if (includesParentAlbumGenres) {
-                                genresInfo = ' (including parent album genres)';
-                            } else if (includesParentSeriesGenres) {
-                                genresInfo = ' (including parent series genres)';
+                                genresInfo = ' (only parent genres)';
+                            } else if (rule.IncludeParentGenres === true || rule.IncludeParentSeriesGenres === true || rule.IncludeParentAlbumGenres === true) {
+                                genresInfo = ' (including parent genres)';
                             }
                         }
 

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-rules.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-rules.js
@@ -1207,8 +1207,8 @@
             '</label>' +
             '<select is="emby-select" class="emby-select rule-tags-select" style="width: 100%;">' +
             '<option value="false">No - Only check item tags</option>' +
-            '<option value="true">Yes - Also check tags from parent series/album</option>' +
-            '<option value="only">Yes - Only check tags from parent series/album</option>' +
+            '<option value="true">Yes - Also check parent tags (season, series, album, folder, library)</option>' +
+            '<option value="only">Yes - Only check parent tags (season, series, album, folder, library)</option>' +
             '</select>' +
             '</div>' +
             '<div class="rule-studios-options" style="display: none; margin-bottom: 0.75em; padding: 0.5em; background: var(--jf-palette-background-paper); border: 1px solid var(--jf-palette-divider); border-radius: 4px;">' +
@@ -1217,8 +1217,8 @@
             '</label>' +
             '<select is="emby-select" class="emby-select rule-studios-select" style="width: 100%;">' +
             '<option value="false">No - Only check item studios</option>' +
-            '<option value="true">Yes - Also check studios from parent series/album</option>' +
-            '<option value="only">Yes - Only check studios from parent series/album</option>' +
+            '<option value="true">Yes - Also check parent studios (season, series, album, folder, library)</option>' +
+            '<option value="only">Yes - Only check parent studios (season, series, album, folder, library)</option>' +
             '</select>' +
             '</div>' +
             '<div class="rule-genres-options" style="display: none; margin-bottom: 0.75em; padding: 0.5em; background: var(--jf-palette-background-paper); border: 1px solid var(--jf-palette-divider); border-radius: 4px;">' +
@@ -1227,8 +1227,8 @@
             '</label>' +
             '<select is="emby-select" class="emby-select rule-genres-select" style="width: 100%;">' +
             '<option value="false">No - Only check item genres</option>' +
-            '<option value="true">Yes - Also check parent genres</option>' +
-            '<option value="only">Yes - Only check genres from parent series/album</option>' +
+            '<option value="true">Yes - Also check parent genres (season, series, album, folder, library)</option>' +
+            '<option value="only">Yes - Only check parent genres (season, series, album, folder, library)</option>' +
             '</select>' +
             '</div>' +
             '<div class="rule-audiolanguages-options" style="display: none; margin-bottom: 0.75em; padding: 0.5em; background: var(--jf-palette-background-paper); border: 1px solid var(--jf-palette-divider); border-radius: 4px;">' +
@@ -1622,25 +1622,30 @@
                 expression.IncludePlaylistOnly = true;
             }
         }
+        // Must emit exactly what collectRulesFromForm emits, or a cloned rule round-trips
+        // differently from a saved one.
         if (fieldValue === 'Tags') {
             if (tagsValue === 'only') {
                 expression.OnlyParentTags = true;
+                expression.IncludeParentTags = true;
             } else if (tagsValue === 'true') {
-                expression.IncludeParentSeriesTags = true;
+                expression.IncludeParentTags = true;
             }
         }
         if (fieldValue === 'Studios') {
             if (studiosValue === 'only') {
                 expression.OnlyParentStudios = true;
+                expression.IncludeParentStudios = true;
             } else if (studiosValue === 'true') {
-                expression.IncludeParentSeriesStudios = true;
+                expression.IncludeParentStudios = true;
             }
         }
         if (fieldValue === 'Genres') {
             if (genresValue === 'only') {
                 expression.OnlyParentGenres = true;
+                expression.IncludeParentGenres = true;
             } else if (genresValue === 'true') {
-                expression.IncludeParentSeriesGenres = true;
+                expression.IncludeParentGenres = true;
             }
         }
         if (fieldValue === 'AudioLanguages' && audioLanguagesValue === 'true') {
@@ -2448,143 +2453,41 @@
         }
     };
 
+    // The parent options apply to every media type - ancestors are resolved by walking the
+    // item tree (season, series, album, folder, library), not by media type. The page
+    // parameter is unused but must stay: updateAllRules always passes it.
     SmartLists.updateTagsOptionsVisibility = function (ruleRow, fieldValue, page) {
-        const isTagsField = fieldValue === 'Tags';
         const tagsOptionsDiv = ruleRow.querySelector('.rule-tags-options');
-
         if (tagsOptionsDiv) {
-            // Get selected media types to check if Episode or Audio is selected
-            const ruleScope = SmartLists.getRowScope(ruleRow);
-            const selectedMediaTypes = page ? SmartLists.getSelectedMediaTypes(page, ruleScope) : [];
-            const hasEpisode = selectedMediaTypes.indexOf('Episode') !== -1;
-            const hasAudio = selectedMediaTypes.indexOf('Audio') !== -1;
-
-            const label = tagsOptionsDiv.querySelector('label');
-            const select = tagsOptionsDiv.querySelector('.rule-tags-select');
-            if (label && select && select.options.length >= 3) {
-                if (hasEpisode && hasAudio) {
-                    label.textContent = 'Include parent series/album tags:';
-                    select.options[0].textContent = 'No - Only check item tags';
-                    select.options[1].textContent = 'Yes - Also check tags from parent series/album';
-                    select.options[2].textContent = 'Yes - Only check tags from parent series/album';
-                } else if (hasAudio) {
-                    label.textContent = 'Include parent album tags:';
-                    select.options[0].textContent = 'No - Only check track tags';
-                    select.options[1].textContent = 'Yes - Also check tags from parent album';
-                    select.options[2].textContent = 'Yes - Only check tags from parent album';
-                } else {
-                    label.textContent = 'Include parent series tags:';
-                    select.options[0].textContent = 'No - Only check episode tags';
-                    select.options[1].textContent = 'Yes - Also check tags from parent series';
-                    select.options[2].textContent = 'Yes - Only check tags from parent series';
-                }
-            }
-
-            // Show only if Tags field is selected AND Episode or Audio media type is selected
-            if (isTagsField && (hasEpisode || hasAudio)) {
-                tagsOptionsDiv.style.display = 'block';
-            } else {
-                // Hide but preserve user's selection - don't reset value
-                tagsOptionsDiv.style.display = 'none';
-            }
+            tagsOptionsDiv.style.display = fieldValue === 'Tags' ? 'block' : 'none';
         }
     };
 
-    // Update visibility of Tags options for all rules when media types change
+    // Update visibility of Tags options for all rules
     SmartLists.updateAllTagsOptionsVisibility = function (page) {
         SmartLists.updateAllRules(page, SmartLists.updateTagsOptionsVisibility);
     };
 
     SmartLists.updateStudiosOptionsVisibility = function (ruleRow, fieldValue, page) {
-        const isStudiosField = fieldValue === 'Studios';
         const studiosOptionsDiv = ruleRow.querySelector('.rule-studios-options');
-
         if (studiosOptionsDiv) {
-            // Get selected media types to check if Episode or Audio is selected
-            const ruleScope = SmartLists.getRowScope(ruleRow);
-            const selectedMediaTypes = page ? SmartLists.getSelectedMediaTypes(page, ruleScope) : [];
-            const hasEpisode = selectedMediaTypes.indexOf('Episode') !== -1;
-            const hasAudio = selectedMediaTypes.indexOf('Audio') !== -1;
-
-            const label = studiosOptionsDiv.querySelector('label');
-            const select = studiosOptionsDiv.querySelector('.rule-studios-select');
-            if (label && select && select.options.length >= 3) {
-                if (hasEpisode && hasAudio) {
-                    label.textContent = 'Include parent series/album studios:';
-                    select.options[0].textContent = 'No - Only check item studios';
-                    select.options[1].textContent = 'Yes - Also check studios from parent series/album';
-                    select.options[2].textContent = 'Yes - Only check studios from parent series/album';
-                } else if (hasAudio) {
-                    label.textContent = 'Include parent album studios:';
-                    select.options[0].textContent = 'No - Only check track studios';
-                    select.options[1].textContent = 'Yes - Also check studios from parent album';
-                    select.options[2].textContent = 'Yes - Only check studios from parent album';
-                } else {
-                    label.textContent = 'Include parent series studios:';
-                    select.options[0].textContent = 'No - Only check episode studios';
-                    select.options[1].textContent = 'Yes - Also check studios from parent series';
-                    select.options[2].textContent = 'Yes - Only check studios from parent series';
-                }
-            }
-
-            // Show only if Studios field is selected AND Episode or Audio media type is selected
-            if (isStudiosField && (hasEpisode || hasAudio)) {
-                studiosOptionsDiv.style.display = 'block';
-            } else {
-                // Hide but preserve user's selection - don't reset value
-                studiosOptionsDiv.style.display = 'none';
-            }
+            studiosOptionsDiv.style.display = fieldValue === 'Studios' ? 'block' : 'none';
         }
     };
 
-    // Update visibility of Studios options for all rules when media types change
+    // Update visibility of Studios options for all rules
     SmartLists.updateAllStudiosOptionsVisibility = function (page) {
         SmartLists.updateAllRules(page, SmartLists.updateStudiosOptionsVisibility);
     };
 
     SmartLists.updateGenresOptionsVisibility = function (ruleRow, fieldValue, page) {
-        const isGenresField = fieldValue === 'Genres';
         const genresOptionsDiv = ruleRow.querySelector('.rule-genres-options');
-
         if (genresOptionsDiv) {
-            // Get selected media types to check if Episode or Audio is selected
-            const ruleScope = SmartLists.getRowScope(ruleRow);
-            const selectedMediaTypes = page ? SmartLists.getSelectedMediaTypes(page, ruleScope) : [];
-            const hasEpisode = selectedMediaTypes.indexOf('Episode') !== -1;
-            const hasAudio = selectedMediaTypes.indexOf('Audio') !== -1;
-
-            const label = genresOptionsDiv.querySelector('label');
-            const select = genresOptionsDiv.querySelector('.rule-genres-select');
-            if (label && select && select.options.length >= 3) {
-                if (hasEpisode && hasAudio) {
-                    label.textContent = 'Include parent series/album genres:';
-                    select.options[0].textContent = 'No - Only check item genres';
-                    select.options[1].textContent = 'Yes - Also check genres from parent series/album';
-                    select.options[2].textContent = 'Yes - Only check genres from parent series/album';
-                } else if (hasAudio) {
-                    label.textContent = 'Include parent album genres:';
-                    select.options[0].textContent = 'No - Only check track genres';
-                    select.options[1].textContent = 'Yes - Also check genres from parent album';
-                    select.options[2].textContent = 'Yes - Only check genres from parent album';
-                } else {
-                    label.textContent = 'Include parent series genres:';
-                    select.options[0].textContent = 'No - Only check episode genres';
-                    select.options[1].textContent = 'Yes - Also check genres from parent series';
-                    select.options[2].textContent = 'Yes - Only check genres from parent series';
-                }
-            }
-
-            // Show only if Genres field is selected AND Episode or Audio media type is selected
-            if (isGenresField && (hasEpisode || hasAudio)) {
-                genresOptionsDiv.style.display = 'block';
-            } else {
-                // Hide but preserve user's selection - don't reset value
-                genresOptionsDiv.style.display = 'none';
-            }
+            genresOptionsDiv.style.display = fieldValue === 'Genres' ? 'block' : 'none';
         }
     };
 
-    // Update visibility of Genres options for all rules when media types change
+    // Update visibility of Genres options for all rules
     SmartLists.updateAllGenresOptionsVisibility = function (page) {
         SmartLists.updateAllRules(page, SmartLists.updateGenresOptionsVisibility);
     };
@@ -2799,7 +2702,6 @@
         if (!container) { return expressionSets; }
         const selectedMediaTypes = SmartLists.getSelectedMediaTypes(page, scope);
         const hasEpisode = selectedMediaTypes.indexOf('Episode') !== -1;
-        const hasAudio = selectedMediaTypes.indexOf('Audio') !== -1;
         const hasAudioCapable = selectedMediaTypes.some(function (type) {
             return SmartLists.AUDIO_CAPABLE_TYPES.indexOf(type) !== -1;
         });
@@ -2926,47 +2828,44 @@
                         }
                     }
 
-                    // Handle Tags-specific options (only if Episode or Audio is selected)
+                    // Handle Tags-specific options (all media types - ancestors are resolved
+                    // by walking the item tree, not by media type). Only the current keys are
+                    // written; the legacy IncludeParentSeriesTags/IncludeParentAlbumTags keys
+                    // are still READ when repopulating an older rule, but never written.
                     const tagsSelect = rule.querySelector('.rule-tags-select');
-                    if (tagsSelect && memberName === 'Tags' && (hasEpisode || hasAudio)) {
+                    if (tagsSelect && memberName === 'Tags') {
                         const tagsSelectValue = tagsSelect.value;
                         if (tagsSelectValue === 'only') {
                             expression.OnlyParentTags = true;
-                            if (hasEpisode) expression.IncludeParentSeriesTags = true;
-                            if (hasAudio) expression.IncludeParentAlbumTags = true;
+                            expression.IncludeParentTags = true;
                         } else if (tagsSelectValue === 'true') {
-                            if (hasEpisode) expression.IncludeParentSeriesTags = true;
-                            if (hasAudio) expression.IncludeParentAlbumTags = true;
+                            expression.IncludeParentTags = true;
                         }
                         // If 'false' (default), don't include the parameter to save space
                     }
 
-                    // Handle Studios-specific options (only if Episode or Audio is selected)
+                    // Handle Studios-specific options (all media types)
                     const studiosSelect = rule.querySelector('.rule-studios-select');
-                    if (studiosSelect && memberName === 'Studios' && (hasEpisode || hasAudio)) {
+                    if (studiosSelect && memberName === 'Studios') {
                         const studiosSelectValue = studiosSelect.value;
                         if (studiosSelectValue === 'only') {
                             expression.OnlyParentStudios = true;
-                            if (hasEpisode) expression.IncludeParentSeriesStudios = true;
-                            if (hasAudio) expression.IncludeParentAlbumStudios = true;
+                            expression.IncludeParentStudios = true;
                         } else if (studiosSelectValue === 'true') {
-                            if (hasEpisode) expression.IncludeParentSeriesStudios = true;
-                            if (hasAudio) expression.IncludeParentAlbumStudios = true;
+                            expression.IncludeParentStudios = true;
                         }
                         // If 'false' (default), don't include the parameter to save space
                     }
 
-                    // Handle Genres-specific options (only if Episode or Audio is selected)
+                    // Handle Genres-specific options (all media types)
                     const genresSelect = rule.querySelector('.rule-genres-select');
-                    if (genresSelect && memberName === 'Genres' && (hasEpisode || hasAudio)) {
+                    if (genresSelect && memberName === 'Genres') {
                         const genresSelectValue = genresSelect.value;
                         if (genresSelectValue === 'only') {
                             expression.OnlyParentGenres = true;
-                            if (hasEpisode) expression.IncludeParentSeriesGenres = true;
-                            if (hasAudio) expression.IncludeParentAlbumGenres = true;
+                            expression.IncludeParentGenres = true;
                         } else if (genresSelectValue === 'true') {
-                            if (hasEpisode) expression.IncludeParentSeriesGenres = true;
-                            if (hasAudio) expression.IncludeParentAlbumGenres = true;
+                            expression.IncludeParentGenres = true;
                         }
                         // If 'false' (default), don't include the parameter to save space
                     }
@@ -3199,7 +3098,7 @@
                     let includeValue = 'false';
                     if (expression.OnlyParentTags === true) {
                         includeValue = 'only';
-                    } else if (expression.IncludeParentSeriesTags === true || expression.IncludeParentAlbumTags === true) {
+                    } else if (expression.IncludeParentTags === true || expression.IncludeParentSeriesTags === true || expression.IncludeParentAlbumTags === true) {
                         includeValue = 'true';
                     }
                     tagsSelect.value = includeValue;
@@ -3211,7 +3110,7 @@
                     let includeValue = 'false';
                     if (expression.OnlyParentStudios === true) {
                         includeValue = 'only';
-                    } else if (expression.IncludeParentSeriesStudios === true || expression.IncludeParentAlbumStudios === true) {
+                    } else if (expression.IncludeParentStudios === true || expression.IncludeParentSeriesStudios === true || expression.IncludeParentAlbumStudios === true) {
                         includeValue = 'true';
                     }
                     studiosSelect.value = includeValue;
@@ -3223,7 +3122,7 @@
                     let includeValue = 'false';
                     if (expression.OnlyParentGenres === true) {
                         includeValue = 'only';
-                    } else if (expression.IncludeParentSeriesGenres === true || expression.IncludeParentAlbumGenres === true) {
+                    } else if (expression.IncludeParentGenres === true || expression.IncludeParentSeriesGenres === true || expression.IncludeParentAlbumGenres === true) {
                         includeValue = 'true';
                     }
                     genresSelect.value = includeValue;

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/AncestorValueResolver.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/AncestorValueResolver.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Jellyfin.Extensions;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
+{
+    /// <summary>
+    /// Ancestor-inherited Tags/Studios/Genres for one node of the item tree.
+    /// IMMUTABLE: instances are shared across operands via the per-refresh memo and are
+    /// assigned to Operand properties BY REFERENCE. Members are IReadOnlyList so that
+    /// mutation is a compile error rather than a comment-enforced convention — Empty is a
+    /// process-lifetime singleton and a stray mutation would corrupt every list, for every
+    /// user, for the rest of the process.
+    /// </summary>
+    public sealed class AncestorValues
+    {
+        /// <summary>
+        /// Shared, process-lifetime "nothing inherited" instance. The three members are empty
+        /// but NEVER null: AnyRegexMatch's empty-list branch tests the pattern against
+        /// string.Empty, whereas a null list returns false, so null and empty are observably
+        /// different for MatchRegex.
+        /// </summary>
+        public static readonly AncestorValues Empty = new([], [], []);
+
+        public IReadOnlyList<string> Tags { get; }
+        public IReadOnlyList<string> Studios { get; }
+        public IReadOnlyList<string> Genres { get; }
+
+        private AncestorValues(IReadOnlyList<string> tags, IReadOnlyList<string> studios, IReadOnlyList<string> genres)
+        {
+            Tags = tags;
+            Studios = studios;
+            Genres = genres;
+        }
+
+        /// <summary>
+        /// Returns a NEW instance holding this instance's values plus the node's own
+        /// Tags/Studios/Genres. Returns <c>this</c> unchanged when the node contributes
+        /// nothing, so a chain of value-less folders allocates nothing.
+        /// </summary>
+        /// <param name="node">The ancestor node whose own values are folded in.</param>
+        /// <returns>The combined values.</returns>
+        public AncestorValues Union(BaseItem node)
+        {
+            if (node is null)
+            {
+                return this;
+            }
+
+            // BaseItem is nullable-OBLIVIOUS in both ABIs (no NullableContextAttribute), so these
+            // three are declared string[] yet can be null at runtime and nothing warns under
+            // Nullable=enable. Guard each one individually.
+            var nodeTags = node.Tags;
+            var nodeStudios = node.Studios;
+            var nodeGenres = node.Genres;
+
+            var hasTags = nodeTags is { Length: > 0 };
+            var hasStudios = nodeStudios is { Length: > 0 };
+            var hasGenres = nodeGenres is { Length: > 0 };
+
+            if (!hasTags && !hasStudios && !hasGenres)
+            {
+                return this;
+            }
+
+            return new AncestorValues(
+                hasTags ? Combine(Tags, nodeTags) : Tags,
+                hasStudios ? Combine(Studios, nodeStudios) : Studios,
+                hasGenres ? Combine(Genres, nodeGenres) : Genres);
+        }
+
+        private static IReadOnlyList<string> Combine(IReadOnlyList<string> existing, string[] additions)
+        {
+            var combined = new List<string>(existing.Count + additions.Length);
+
+            // Ordinal, deliberately NOT OrdinalIgnoreCase (which is what core's GetInheritedTags uses).
+            // Six of the seven operators are OrdinalIgnoreCase so dedup strength is invisible to them,
+            // but MatchRegex is case-SENSITIVE (GetOrCreateRegex passes RegexOptions.None) — case-insensitive
+            // dedup could discard the only casing a pattern would have matched.
+            var seen = new HashSet<string>(existing.Count + additions.Length, StringComparer.Ordinal);
+
+            foreach (var value in existing)
+            {
+                if (value is not null && seen.Add(value))
+                {
+                    combined.Add(value);
+                }
+            }
+
+            foreach (var value in additions)
+            {
+                if (value is not null && seen.Add(value))
+                {
+                    combined.Add(value);
+                }
+            }
+
+            return combined;
+        }
+    }
+
+    internal static class AncestorValueResolver
+    {
+        // Runaway/cycle insurance ONLY; it must never bind. Measured real depth in the dev
+        // library is 4 (episode->season->series->folder), 2 (movie), 3 (audio);
+        // /music/Artist/Album/Disc/track reaches 5 and deep genre trees maybe 7.
+        // Do NOT "tighten" this to 10 — a binding cap produces truncated results.
+        private const int MaxAncestorDepth = 20;
+
+        /// <summary>
+        /// Ancestor-inherited values for <paramref name="item"/>, EXCLUDING the item's own
+        /// values (Engine unions the item's own field separately).
+        ///
+        /// The walk is: parent chain (stopping BEFORE AggregateFolder/UserRootFolder/UserView)
+        /// UNION libraryManager.GetCollectionFolders(chainTop). The second half is NOT optional:
+        /// a CollectionFolder (a Jellyfin library) is never in the ParentId chain — it hangs off
+        /// the UserRootFolder as a sibling structure — so a parents-only walk finds season tags
+        /// but never library tags. Core's BaseItem.GetInheritedTags()/GetAncestorIds() have the
+        /// same two-part shape.
+        ///
+        /// COST: the memo is keyed on the IMMEDIATE PARENT id and is consulted BEFORE any parent
+        /// is materialized, so a hit costs one dictionary lookup and ZERO ILibraryManager calls —
+        /// parity with the code this replaces. A miss costs O(distinct containers) GetItemById
+        /// plus one GetCollectionFolders path-scan per top physical folder.
+        /// NOTE: when a list's ONLY rule is parent-aware, SmartList takes the expensive-only path
+        /// (SmartList.cs:3026) and this runs once per CANDIDATE item, not per Phase-2 survivor.
+        /// </summary>
+        /// <param name="item">The item whose ancestors are walked.</param>
+        /// <param name="libraryManager">Library manager used for the library (CollectionFolder) union.</param>
+        /// <param name="memo">Per-refresh memo keyed by ANCESTOR NODE id.</param>
+        /// <param name="logger">Optional logger.</param>
+        /// <returns>The inherited values; never null.</returns>
+        internal static AncestorValues Resolve(
+            BaseItem item,
+            ILibraryManager libraryManager,
+            ConcurrentDictionary<Guid, AncestorValues> memo,
+            ILogger? logger)
+        {
+            // MEMO-FIRST on the raw ParentId Guid — do NOT call GetParent() before this line.
+            // GetParent() is `ParentId.IsEmpty() ? null : LibraryManager.GetItemById(ParentId)`,
+            // so materializing the parent first would cost a library round-trip per ITEM.
+            var parentId = item.ParentId;
+            if (!parentId.IsEmpty() && memo.TryGetValue(parentId, out var cached))
+            {
+                return cached;
+            }
+
+            var node = item.GetParent() ?? item.GetOwner();   // GetOwner() covers extras (empty ParentId, set OwnerId)
+            if (node is null || IsWalkBoundary(node))
+            {
+                return AncestorValues.Empty;
+            }
+
+            var chain = new List<BaseItem>();
+            var visited = new HashSet<Guid>();
+            AncestorValues? seed = null;
+            var truncated = false;
+
+            while (node is not null && !IsWalkBoundary(node))
+            {
+                if (memo.TryGetValue(node.Id, out var hit)) { seed = hit; break; }
+                if (!visited.Add(node.Id) || chain.Count >= MaxAncestorDepth)
+                {
+                    logger?.LogWarning(
+                        "SmartLists ancestor walk stopped early at '{Name}' ({Id}) - cycle or depth cap",
+                        node.Name, node.Id);
+                    truncated = true;
+                    break;
+                }
+                chain.Add(node);
+                node = node.GetParent() ?? node.GetOwner();
+            }
+
+            if (seed is null)
+            {
+                // Library values are resolved from the deepest node reached. GetCollectionFolders
+                // walks independently of our chain, so it is valid (and required) even when the
+                // chain was truncated — dropping it on truncation would silently reproduce #495.
+                seed = GetLibraryValues(chain[^1], libraryManager, logger);
+            }
+
+            var acc = seed;
+            for (var i = chain.Count - 1; i >= 0; i--)
+            {
+                acc = acc.Union(chain[i]);
+
+                // NEVER memoize a truncated (partial) result. A truncated walk is missing the TOP
+                // of the chain, so caching it would make later walks return a value that depends on
+                // WHICH ITEM WARMED THE CACHE FIRST (an episode 4 levels down vs a series 1 level down).
+                if (!truncated) { memo[chain[i].Id] = acc; }
+            }
+
+            return acc;
+        }
+
+        private static bool IsWalkBoundary(BaseItem node)
+            => node is AggregateFolder || node is UserRootFolder || node is UserView;
+
+        private static AncestorValues GetLibraryValues(BaseItem anchor, ILibraryManager libraryManager, ILogger? logger)
+        {
+            try
+            {
+                var acc = AncestorValues.Empty;
+                foreach (var folder in libraryManager.GetCollectionFolders(anchor)) { acc = acc.Union(folder); }
+                return acc;
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex, "SmartLists failed to resolve library values for '{Name}'", anchor.Name);
+                return AncestorValues.Empty;
+            }
+        }
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/AncestorValueResolver.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/AncestorValueResolver.cs
@@ -152,7 +152,12 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             var node = item.GetParent() ?? item.GetOwner();   // GetOwner() covers extras (empty ParentId, set OwnerId)
             if (node is null || IsWalkBoundary(node))
             {
-                return AncestorValues.Empty;
+                // No walkable ancestors — either the parent could not be resolved at all, or the
+                // item sits directly under the AggregateFolder/UserRootFolder boundary. The library
+                // still counts in both cases: GetCollectionFolders resolves independently of the
+                // parent chain, so returning Empty here would drop library values for these items
+                // exactly the way the old one-level extractors dropped season values in #495.
+                return GetLibraryValues(item, libraryManager, logger);
             }
 
             var chain = new List<BaseItem>();

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
@@ -226,33 +226,27 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             {
                 return BuildParentAwareFieldExpression(r, param, logger,
                     baseField: "Tags",
-                    parentSeriesField: "ParentSeriesTags",
-                    parentAlbumField: "ParentAlbumTags",
+                    parentField: "ParentTags",
                     onlyParent: r.OnlyParentTags == true,
-                    includeParentSeries: r.IncludeParentSeriesTags == true,
-                    includeParentAlbum: r.IncludeParentAlbumTags == true);
+                    includeParent: r.IncludeParentTagsEffective);
             }
 
             if (r.MemberName == "Studios")
             {
                 return BuildParentAwareFieldExpression(r, param, logger,
                     baseField: "Studios",
-                    parentSeriesField: "ParentSeriesStudios",
-                    parentAlbumField: "ParentAlbumStudios",
+                    parentField: "ParentStudios",
                     onlyParent: r.OnlyParentStudios == true,
-                    includeParentSeries: r.IncludeParentSeriesStudios == true,
-                    includeParentAlbum: r.IncludeParentAlbumStudios == true);
+                    includeParent: r.IncludeParentStudiosEffective);
             }
 
             if (r.MemberName == "Genres")
             {
                 return BuildParentAwareFieldExpression(r, param, logger,
                     baseField: "Genres",
-                    parentSeriesField: "ParentSeriesGenres",
-                    parentAlbumField: "ParentAlbumGenres",
+                    parentField: "ParentGenres",
                     onlyParent: r.OnlyParentGenres == true,
-                    includeParentSeries: r.IncludeParentSeriesGenres == true,
-                    includeParentAlbum: r.IncludeParentAlbumGenres == true);
+                    includeParent: r.IncludeParentGenresEffective);
             }
 
             return null;
@@ -268,22 +262,16 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             ParameterExpression param,
             ILogger? logger,
             string baseField,
-            string parentSeriesField,
-            string parentAlbumField,
+            string parentField,
             bool onlyParent,
-            bool includeParentSeries,
-            bool includeParentAlbum)
+            bool includeParent)
         {
             if (onlyParent)
             {
-                var fields = new List<string>();
-                if (includeParentSeries) fields.Add(parentSeriesField);
-                if (includeParentAlbum) fields.Add(parentAlbumField);
-
-                if (fields.Count > 0)
+                if (includeParent)
                 {
-                    logger?.LogDebug("SmartLists building {Field} expression with ONLY parent fields: {Fields}", baseField, string.Join(", ", fields));
-                    return BuildCombinedStringEnumerableExpression(r, param, logger, [.. fields]);
+                    logger?.LogDebug("SmartLists building {Field} expression with ONLY parent fields: {Fields}", baseField, parentField);
+                    return BuildCombinedStringEnumerableExpression(r, param, logger, parentField);
                 }
 
                 // OnlyParent is true but no parent source flags are set — return always-false
@@ -292,13 +280,10 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                 return System.Linq.Expressions.Expression.Constant(false);
             }
 
-            if (includeParentSeries || includeParentAlbum)
+            if (includeParent)
             {
-                var fields = new List<string> { baseField };
-                if (includeParentSeries) fields.Add(parentSeriesField);
-                if (includeParentAlbum) fields.Add(parentAlbumField);
-                logger?.LogDebug("SmartLists building {Field} expression with parent inclusion: {Fields}", baseField, string.Join(", ", fields));
-                return BuildCombinedStringEnumerableExpression(r, param, logger, [.. fields]);
+                logger?.LogDebug("SmartLists building {Field} expression with parent inclusion: {Fields}", baseField, string.Join(", ", baseField, parentField));
+                return BuildCombinedStringEnumerableExpression(r, param, logger, baseField, parentField);
             }
 
             return null;
@@ -312,7 +297,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         /// <param name="r">The expression rule</param>
         /// <param name="param">The parameter expression</param>
         /// <param name="logger">Logger instance</param>
-        /// <param name="fieldNames">The fields to evaluate together (e.g., "Genres", "ParentSeriesGenres", "ParentAlbumGenres")</param>
+        /// <param name="fieldNames">The fields to evaluate together (e.g., "Genres", "ParentGenres")</param>
         private static System.Linq.Expressions.Expression BuildCombinedStringEnumerableExpression(Expression r, ParameterExpression param, ILogger? logger, params string[] fieldNames)
         {
             if (fieldNames.Length == 0)
@@ -1633,35 +1618,6 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             }
 
             return false;
-        }
-
-        /// <summary>
-        /// Checks if the combined (deduplicated) entries from both lists contain exactly one
-        /// distinct value and that value equals the target. Used for Equal/NotEqual on
-        /// Tags/Studios/Genres when "Include parent series" is enabled.
-        /// </summary>
-        private static bool OnlyCombinedItemEquals(IEnumerable<string> list, IEnumerable<string> parentList, string value)
-        {
-            var items = (list ?? Enumerable.Empty<string>())
-                .Concat(parentList ?? Enumerable.Empty<string>())
-                .Where(s => !string.IsNullOrEmpty(s))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .Take(2)
-                .ToList();
-
-            return items.Count == 1 && items[0].Equals(value, StringComparison.OrdinalIgnoreCase);
-        }
-
-        /// <summary>
-        /// Checks if any item in the combined (deduplicated) list from both sources
-        /// exactly equals the target value. Used for Equal/NotEqual on Tags/Studios/Genres
-        /// when "Include parent series" is enabled.
-        /// </summary>
-        private static bool AnyCombinedItemEquals(IEnumerable<string> list, IEnumerable<string> parentList, string value)
-        {
-            return (list ?? Enumerable.Empty<string>())
-                .Concat(parentList ?? Enumerable.Empty<string>())
-                .Any(s => s != null && s.Equals(value, StringComparison.OrdinalIgnoreCase));
         }
 
         internal static bool AnyRegexMatch(IEnumerable<string> list, string pattern)

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Expression.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Expression.cs
@@ -28,11 +28,13 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? IncludePlaylistOnly { get; set; } = null;
 
-        // Tags-specific option - only serialize when meaningful
+        // Legacy - read via IncludeParent*Effective, no longer written by the UI.
+        // Do NOT remove: this is an on-disk JSON key older saved lists still carry.
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? IncludeParentSeriesTags { get; set; } = null;
 
-        // Tags-specific option for audio tracks - only serialize when meaningful
+        // Legacy - read via IncludeParent*Effective, no longer written by the UI.
+        // Do NOT remove: this is an on-disk JSON key older saved lists still carry.
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? IncludeParentAlbumTags { get; set; } = null;
 
@@ -40,11 +42,13 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? OnlyParentTags { get; set; } = null;
 
-        // Studios-specific option - only serialize when meaningful
+        // Legacy - read via IncludeParent*Effective, no longer written by the UI.
+        // Do NOT remove: this is an on-disk JSON key older saved lists still carry.
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? IncludeParentSeriesStudios { get; set; } = null;
 
-        // Studios-specific option for audio tracks - only serialize when meaningful
+        // Legacy - read via IncludeParent*Effective, no longer written by the UI.
+        // Do NOT remove: this is an on-disk JSON key older saved lists still carry.
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? IncludeParentAlbumStudios { get; set; } = null;
 
@@ -52,17 +56,43 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? OnlyParentStudios { get; set; } = null;
 
-        // Genres-specific option - only serialize when meaningful
+        // Legacy - read via IncludeParent*Effective, no longer written by the UI.
+        // Do NOT remove: this is an on-disk JSON key older saved lists still carry.
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? IncludeParentSeriesGenres { get; set; } = null;
 
-        // Genres-specific option for audio tracks - only serialize when meaningful
+        // Legacy - read via IncludeParent*Effective, no longer written by the UI.
+        // Do NOT remove: this is an on-disk JSON key older saved lists still carry.
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? IncludeParentAlbumGenres { get; set; } = null;
 
         // Genres-specific option to only check parent genres (skip item's own genres) - only serialize when meaningful
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? OnlyParentGenres { get; set; } = null;
+
+        // Tags-specific option: also match values inherited from ancestors (season, series, album, folder, library) - only serialize when meaningful
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? IncludeParentTags { get; set; } = null;
+
+        // Studios-specific option: also match values inherited from ancestors - only serialize when meaningful
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? IncludeParentStudios { get; set; } = null;
+
+        // Genres-specific option: also match values inherited from ancestors - only serialize when meaningful
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? IncludeParentGenres { get; set; } = null;
+
+        // Legacy parent flags fold into these. This is the ONLY place new + legacy are combined —
+        // Engine, IsParentAwareListExpression, GenerateRuleSetHash and FieldRequirements.Analyze
+        // all read these, never the raw flags.
+        [JsonIgnore]
+        public bool IncludeParentTagsEffective => IncludeParentTags == true || IncludeParentSeriesTags == true || IncludeParentAlbumTags == true;
+
+        [JsonIgnore]
+        public bool IncludeParentStudiosEffective => IncludeParentStudios == true || IncludeParentSeriesStudios == true || IncludeParentAlbumStudios == true;
+
+        [JsonIgnore]
+        public bool IncludeParentGenresEffective => IncludeParentGenres == true || IncludeParentSeriesGenres == true || IncludeParentAlbumGenres == true;
 
         // AudioLanguages-specific option - only serialize when meaningful
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
@@ -94,40 +94,22 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             set => RequiredGroups = value ? RequiredGroups | ExtractionGroup.SeriesName : RequiredGroups & ~ExtractionGroup.SeriesName;
         }
 
-        public bool ExtractParentSeriesTags
+        public bool ExtractParentTags
         {
-            get => RequiredGroups.HasFlag(ExtractionGroup.ParentSeriesTags);
-            set => RequiredGroups = value ? RequiredGroups | ExtractionGroup.ParentSeriesTags : RequiredGroups & ~ExtractionGroup.ParentSeriesTags;
+            get => RequiredGroups.HasFlag(ExtractionGroup.ParentTags);
+            set => RequiredGroups = value ? RequiredGroups | ExtractionGroup.ParentTags : RequiredGroups & ~ExtractionGroup.ParentTags;
         }
 
-        public bool ExtractParentSeriesStudios
+        public bool ExtractParentStudios
         {
-            get => RequiredGroups.HasFlag(ExtractionGroup.ParentSeriesStudios);
-            set => RequiredGroups = value ? RequiredGroups | ExtractionGroup.ParentSeriesStudios : RequiredGroups & ~ExtractionGroup.ParentSeriesStudios;
+            get => RequiredGroups.HasFlag(ExtractionGroup.ParentStudios);
+            set => RequiredGroups = value ? RequiredGroups | ExtractionGroup.ParentStudios : RequiredGroups & ~ExtractionGroup.ParentStudios;
         }
 
-        public bool ExtractParentSeriesGenres
+        public bool ExtractParentGenres
         {
-            get => RequiredGroups.HasFlag(ExtractionGroup.ParentSeriesGenres);
-            set => RequiredGroups = value ? RequiredGroups | ExtractionGroup.ParentSeriesGenres : RequiredGroups & ~ExtractionGroup.ParentSeriesGenres;
-        }
-
-        public bool ExtractParentAlbumGenres
-        {
-            get => RequiredGroups.HasFlag(ExtractionGroup.ParentAlbumGenres);
-            set => RequiredGroups = value ? RequiredGroups | ExtractionGroup.ParentAlbumGenres : RequiredGroups & ~ExtractionGroup.ParentAlbumGenres;
-        }
-
-        public bool ExtractParentAlbumTags
-        {
-            get => RequiredGroups.HasFlag(ExtractionGroup.ParentAlbumTags);
-            set => RequiredGroups = value ? RequiredGroups | ExtractionGroup.ParentAlbumTags : RequiredGroups & ~ExtractionGroup.ParentAlbumTags;
-        }
-
-        public bool ExtractParentAlbumStudios
-        {
-            get => RequiredGroups.HasFlag(ExtractionGroup.ParentAlbumStudios);
-            set => RequiredGroups = value ? RequiredGroups | ExtractionGroup.ParentAlbumStudios : RequiredGroups & ~ExtractionGroup.ParentAlbumStudios;
+            get => RequiredGroups.HasFlag(ExtractionGroup.ParentGenres);
+            set => RequiredGroups = value ? RequiredGroups | ExtractionGroup.ParentGenres : RequiredGroups & ~ExtractionGroup.ParentGenres;
         }
 
         public bool ExtractLastEpisodeAirDate
@@ -318,8 +300,6 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         private static readonly ConcurrentDictionary<Type, System.Reflection.PropertyInfo?> _parentIndexPropertyCache = new();
         private static readonly ConcurrentDictionary<Type, System.Reflection.PropertyInfo?> _indexPropertyCache = new();
         private static readonly ConcurrentDictionary<Type, System.Reflection.PropertyInfo?> _seriesIdPropertyCache = new();
-        private static readonly ConcurrentDictionary<Type, System.Reflection.PropertyInfo?> _albumIdPropertyCache = new();
-        private static readonly ConcurrentDictionary<Type, System.Reflection.PropertyInfo?> _parentIdPropertyCache = new();
 
 
         /// <summary>
@@ -1935,27 +1915,6 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             return false;
         }
 
-        /// <summary>
-        /// Helper method to safely extract an album ID as Guid from audio items.
-        /// Prefers AlbumId when available and falls back to ParentId.
-        /// </summary>
-        private static bool TryGetAudioAlbumGuid(BaseItem baseItem, out Guid albumGuid)
-        {
-            albumGuid = Guid.Empty;
-            if (baseItem is not Audio) return false;
-
-            var audioType = baseItem.GetType();
-
-            var albumIdProperty = _albumIdPropertyCache.GetOrAdd(audioType, t => t.GetProperty("AlbumId"));
-            if (albumIdProperty != null && TryExtractGuid(albumIdProperty.GetValue(baseItem), out albumGuid))
-            {
-                return true;
-            }
-
-            var parentIdProperty = _parentIdPropertyCache.GetOrAdd(audioType, t => t.GetProperty("ParentId"));
-            return parentIdProperty != null && TryExtractGuid(parentIdProperty.GetValue(baseItem), out albumGuid);
-        }
-
         private static bool TryExtractGuid(object? value, out Guid guid)
         {
             guid = Guid.Empty;
@@ -1982,43 +1941,6 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             }
 
             return false;
-        }
-
-        private delegate bool TryResolveParentKey(BaseItem baseItem, out Guid parentId);
-
-        private static List<string>? GetOrFetchParentValues(
-            BaseItem baseItem,
-            TryResolveParentKey keyResolver,
-            ConcurrentDictionary<Guid, List<string>> cache,
-            Func<Guid, (List<string> Values, string ParentName)> fetcher,
-            Action<Guid, List<string>> logCacheHit,
-            Action<Guid, string, List<string>> logFetched,
-            Action<Exception, Guid> logFailure)
-        {
-            if (!keyResolver(baseItem, out var parentId))
-            {
-                return null;
-            }
-
-            if (cache.TryGetValue(parentId, out var cachedValues))
-            {
-                logCacheHit(parentId, cachedValues);
-                return cachedValues;
-            }
-
-            try
-            {
-                var (values, parentName) = fetcher(parentId);
-                cache[parentId] = values;
-                logFetched(parentId, parentName, values);
-                return values;
-            }
-            catch (Exception ex)
-            {
-                logFailure(ex, parentId);
-                cache[parentId] = [];
-                return [];
-            }
         }
 
         /// <summary>
@@ -2174,353 +2096,30 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         }
 
         /// <summary>
-        /// Extracts the parent series tags for episodes with per-refresh caching.
-        /// This is an expensive operation as it requires a database lookup, so caching is critical for performance.
+        /// Resolves ancestor-inherited Tags/Studios/Genres in ONE walk and assigns only the
+        /// requested lists. Assignment is BY REFERENCE — AncestorValues is immutable and its
+        /// members are IReadOnlyList, so sharing across operands is safe and allocation-free.
         /// </summary>
-        private static void ExtractParentSeriesTags(Operand operand, BaseItem baseItem, ILibraryManager libraryManager, RefreshQueueServiceRefreshCache cache, ILogger? logger)
+        private static void ExtractAncestorValues(
+            Operand operand,
+            BaseItem baseItem,
+            ILibraryManager libraryManager,
+            RefreshQueueServiceRefreshCache cache,
+            ILogger? logger,
+            bool wantTags,
+            bool wantStudios,
+            bool wantGenres)
         {
-            operand.ParentSeriesTags = [];
             try
             {
-                // Only process episodes - other item types don't have parent series
-                if (baseItem is not Episode)
-                {
-                    logger?.LogDebug("Item '{ItemName}' is not an episode, parent series tags remain empty", baseItem.Name);
-                    return;
-                }
-
-                // Use helper to extract SeriesId safely
-                if (TryGetEpisodeSeriesGuid(baseItem, out var seriesGuid))
-                {
-                    // Check cache first to avoid repeated library lookups (expensive!)
-                    if (cache.SeriesTagsById.TryGetValue(seriesGuid, out var cachedTags))
-                    {
-                        operand.ParentSeriesTags = cachedTags;
-                        logger?.LogDebug("Using cached parent series tags for episode '{EpisodeName}' (series ID: {SeriesId}): [{Tags}]",
-                            baseItem.Name, seriesGuid, string.Join(", ", cachedTags));
-                    }
-                    else
-                    {
-                        try
-                        {
-                            // Get the parent series from the library manager (expensive operation!)
-                            var parentSeries = libraryManager.GetItemById(seriesGuid);
-                            var seriesTags = parentSeries?.Tags?.ToList() ?? [];
-
-                            // Cache the result for future episodes from the same series
-                            cache.SeriesTagsById[seriesGuid] = seriesTags;
-                            operand.ParentSeriesTags = seriesTags;
-
-                            logger?.LogDebug("Extracted and cached parent series tags for episode '{EpisodeName}' (series: '{SeriesName}'): [{Tags}]",
-                                baseItem.Name, parentSeries?.Name ?? "Unknown", string.Join(", ", seriesTags));
-                        }
-                        catch (Exception ex)
-                        {
-                            logger?.LogDebug(ex, "Failed to get parent series tags for episode '{EpisodeName}' with SeriesId {SeriesId}",
-                                baseItem.Name, seriesGuid);
-
-                            // Cache empty list to avoid repeated failures
-                            cache.SeriesTagsById[seriesGuid] = [];
-                        }
-                    }
-                }
-                else
-                {
-                    logger?.LogDebug("Could not extract valid SeriesId from episode '{EpisodeName}'", baseItem.Name);
-                }
+                var values = AncestorValueResolver.Resolve(baseItem, libraryManager, cache.AncestorValuesById, logger);
+                if (wantTags) { operand.ParentTags = values.Tags; }
+                if (wantStudios) { operand.ParentStudios = values.Studios; }
+                if (wantGenres) { operand.ParentGenres = values.Genres; }
             }
             catch (Exception ex)
             {
-                logger?.LogWarning(ex, "Failed to extract parent series tags for item '{ItemName}'", baseItem.Name);
-            }
-        }
-
-        /// <summary>
-        /// Extracts the parent series studios for episodes with per-refresh caching.
-        /// This is an expensive operation as it requires a database lookup, so caching is critical for performance.
-        /// </summary>
-        private static void ExtractParentSeriesStudios(Operand operand, BaseItem baseItem, ILibraryManager libraryManager, RefreshQueueServiceRefreshCache cache, ILogger? logger)
-        {
-            operand.ParentSeriesStudios = [];
-            try
-            {
-                // Only process episodes - other item types don't have parent series
-                if (baseItem is not Episode)
-                {
-                    logger?.LogDebug("Item '{ItemName}' is not an episode, parent series studios remain empty", baseItem.Name);
-                    return;
-                }
-
-                // Use helper to extract SeriesId safely
-                if (TryGetEpisodeSeriesGuid(baseItem, out var seriesGuid))
-                {
-                    // Check cache first to avoid repeated library lookups (expensive!)
-                    if (cache.SeriesStudiosById.TryGetValue(seriesGuid, out var cachedStudios))
-                    {
-                        operand.ParentSeriesStudios = cachedStudios;
-                        logger?.LogDebug("Using cached parent series studios for episode '{EpisodeName}' (series ID: {SeriesId}): [{Studios}]",
-                            baseItem.Name, seriesGuid, string.Join(", ", cachedStudios));
-                    }
-                    else
-                    {
-                        try
-                        {
-                            // Get the parent series from the library manager (expensive operation!)
-                            var parentSeries = libraryManager.GetItemById(seriesGuid);
-                            var seriesStudios = parentSeries?.Studios?.ToList() ?? [];
-
-                            // Cache the result for future episodes from the same series
-                            cache.SeriesStudiosById[seriesGuid] = seriesStudios;
-                            operand.ParentSeriesStudios = seriesStudios;
-
-                            logger?.LogDebug("Extracted and cached parent series studios for episode '{EpisodeName}' (series: '{SeriesName}'): [{Studios}]",
-                                baseItem.Name, parentSeries?.Name ?? "Unknown", string.Join(", ", seriesStudios));
-                        }
-                        catch (Exception ex)
-                        {
-                            logger?.LogDebug(ex, "Failed to get parent series studios for episode '{EpisodeName}' with SeriesId {SeriesId}",
-                                baseItem.Name, seriesGuid);
-
-                            // Cache empty list to avoid repeated failures
-                            cache.SeriesStudiosById[seriesGuid] = [];
-                        }
-                    }
-                }
-                else
-                {
-                    logger?.LogDebug("Could not extract valid SeriesId from episode '{EpisodeName}'", baseItem.Name);
-                }
-            }
-            catch (Exception ex)
-            {
-                logger?.LogWarning(ex, "Failed to extract parent series studios for item '{ItemName}'", baseItem.Name);
-            }
-        }
-
-        /// <summary>
-        /// Extracts the parent series genres for episodes with per-refresh caching.
-        /// This is an expensive operation as it requires a database lookup, so caching is critical for performance.
-        /// </summary>
-        private static void ExtractParentSeriesGenres(Operand operand, BaseItem baseItem, ILibraryManager libraryManager, RefreshQueueServiceRefreshCache cache, ILogger? logger)
-        {
-            operand.ParentSeriesGenres = [];
-            try
-            {
-                // Only process episodes - other item types don't have parent series
-                if (baseItem is not Episode)
-                {
-                    logger?.LogDebug("Item '{ItemName}' is not an episode, parent series genres remain empty", baseItem.Name);
-                    return;
-                }
-
-                // Use helper to extract SeriesId safely
-                if (TryGetEpisodeSeriesGuid(baseItem, out var seriesGuid))
-                {
-                    // Check cache first to avoid repeated library lookups (expensive!)
-                    if (cache.SeriesGenresById.TryGetValue(seriesGuid, out var cachedGenres))
-                    {
-                        operand.ParentSeriesGenres = cachedGenres;
-                        logger?.LogDebug("Using cached parent series genres for episode '{EpisodeName}' (series ID: {SeriesId}): [{Genres}]",
-                            baseItem.Name, seriesGuid, string.Join(", ", cachedGenres));
-                    }
-                    else
-                    {
-                        try
-                        {
-                            // Get the parent series from the library manager (expensive operation!)
-                            var parentSeries = libraryManager.GetItemById(seriesGuid);
-                            var seriesGenres = parentSeries?.Genres?.ToList() ?? [];
-
-                            // Cache the result for future episodes from the same series
-                            cache.SeriesGenresById[seriesGuid] = seriesGenres;
-                            operand.ParentSeriesGenres = seriesGenres;
-
-                            logger?.LogDebug("Extracted and cached parent series genres for episode '{EpisodeName}' (series: '{SeriesName}'): [{Genres}]",
-                                baseItem.Name, parentSeries?.Name ?? "Unknown", string.Join(", ", seriesGenres));
-                        }
-                        catch (Exception ex)
-                        {
-                            logger?.LogDebug(ex, "Failed to get parent series genres for episode '{EpisodeName}' with SeriesId {SeriesId}",
-                                baseItem.Name, seriesGuid);
-
-                            // Cache empty list to avoid repeated failures
-                            cache.SeriesGenresById[seriesGuid] = [];
-                        }
-                    }
-                }
-                else
-                {
-                    logger?.LogDebug("Could not extract valid SeriesId from episode '{EpisodeName}'", baseItem.Name);
-                }
-            }
-            catch (Exception ex)
-            {
-                logger?.LogWarning(ex, "Failed to extract parent series genres for item '{ItemName}'", baseItem.Name);
-            }
-        }
-
-        /// <summary>
-        /// Extracts parent album genres for audio tracks with per-refresh caching.
-        /// This is an expensive operation as it requires a database lookup, so caching is critical for performance.
-        /// </summary>
-        private static void ExtractParentAlbumGenres(Operand operand, BaseItem baseItem, ILibraryManager libraryManager, RefreshQueueServiceRefreshCache cache, ILogger? logger)
-        {
-            operand.ParentAlbumGenres = [];
-            try
-            {
-                if (baseItem is not Audio)
-                {
-                    logger?.LogDebug("Item '{ItemName}' is not an audio track, parent album genres remain empty", baseItem.Name);
-                    return;
-                }
-
-                var albumGenres = GetOrFetchParentValues(
-                    baseItem,
-                    TryGetAudioAlbumGuid,
-                    cache.AlbumGenresById,
-                    albumGuid =>
-                    {
-                        var parentAlbum = libraryManager.GetItemById(albumGuid);
-                        return (parentAlbum?.Genres?.ToList() ?? [], parentAlbum?.Name ?? "Unknown");
-                    },
-                    (albumGuid, cachedGenres) =>
-                    {
-                        logger?.LogDebug("Using cached parent album genres for audio track '{TrackName}' (album ID: {AlbumId}): [{Genres}]",
-                            baseItem.Name, albumGuid, string.Join(", ", cachedGenres));
-                    },
-                    (albumGuid, albumName, fetchedGenres) =>
-                    {
-                        logger?.LogDebug("Extracted and cached parent album genres for audio track '{TrackName}' (album: '{AlbumName}'): [{Genres}]",
-                            baseItem.Name, albumName, string.Join(", ", fetchedGenres));
-                    },
-                    (ex, albumGuid) =>
-                    {
-                        logger?.LogDebug(ex, "Failed to get parent album genres for audio track '{TrackName}' with AlbumId {AlbumId}",
-                            baseItem.Name, albumGuid);
-                    });
-
-                if (albumGenres != null)
-                {
-                    operand.ParentAlbumGenres = albumGenres;
-                }
-                else
-                {
-                    logger?.LogDebug("Could not extract valid AlbumId or ParentId from audio track '{TrackName}'", baseItem.Name);
-                }
-            }
-            catch (Exception ex)
-            {
-                logger?.LogWarning(ex, "Failed to extract parent album genres for item '{ItemName}'", baseItem.Name);
-            }
-        }
-
-        /// <summary>
-        /// Extracts parent album tags for audio tracks with per-refresh caching.
-        /// This is an expensive operation as it requires a database lookup, so caching is critical for performance.
-        /// </summary>
-        private static void ExtractParentAlbumTags(Operand operand, BaseItem baseItem, ILibraryManager libraryManager, RefreshQueueServiceRefreshCache cache, ILogger? logger)
-        {
-            operand.ParentAlbumTags = [];
-            try
-            {
-                if (baseItem is not Audio)
-                {
-                    logger?.LogDebug("Item '{ItemName}' is not an audio track, parent album tags remain empty", baseItem.Name);
-                    return;
-                }
-
-                var albumTags = GetOrFetchParentValues(
-                    baseItem,
-                    TryGetAudioAlbumGuid,
-                    cache.AlbumTagsById,
-                    albumGuid =>
-                    {
-                        var parentAlbum = libraryManager.GetItemById(albumGuid);
-                        return (parentAlbum?.Tags?.ToList() ?? [], parentAlbum?.Name ?? "Unknown");
-                    },
-                    (albumGuid, cachedTags) =>
-                    {
-                        logger?.LogDebug("Using cached parent album tags for audio track '{TrackName}' (album ID: {AlbumId}): [{Tags}]",
-                            baseItem.Name, albumGuid, string.Join(", ", cachedTags));
-                    },
-                    (albumGuid, albumName, fetchedTags) =>
-                    {
-                        logger?.LogDebug("Extracted and cached parent album tags for audio track '{TrackName}' (album: '{AlbumName}'): [{Tags}]",
-                            baseItem.Name, albumName, string.Join(", ", fetchedTags));
-                    },
-                    (ex, albumGuid) =>
-                    {
-                        logger?.LogDebug(ex, "Failed to get parent album tags for audio track '{TrackName}' with AlbumId {AlbumId}",
-                            baseItem.Name, albumGuid);
-                    });
-
-                if (albumTags != null)
-                {
-                    operand.ParentAlbumTags = albumTags;
-                }
-                else
-                {
-                    logger?.LogDebug("Could not extract valid AlbumId or ParentId from audio track '{TrackName}'", baseItem.Name);
-                }
-            }
-            catch (Exception ex)
-            {
-                logger?.LogWarning(ex, "Failed to extract parent album tags for item '{ItemName}'", baseItem.Name);
-            }
-        }
-
-        /// <summary>
-        /// Extracts parent album studios for audio tracks with per-refresh caching.
-        /// This is an expensive operation as it requires a database lookup, so caching is critical for performance.
-        /// </summary>
-        private static void ExtractParentAlbumStudios(Operand operand, BaseItem baseItem, ILibraryManager libraryManager, RefreshQueueServiceRefreshCache cache, ILogger? logger)
-        {
-            operand.ParentAlbumStudios = [];
-            try
-            {
-                if (baseItem is not Audio)
-                {
-                    logger?.LogDebug("Item '{ItemName}' is not an audio track, parent album studios remain empty", baseItem.Name);
-                    return;
-                }
-
-                var albumStudios = GetOrFetchParentValues(
-                    baseItem,
-                    TryGetAudioAlbumGuid,
-                    cache.AlbumStudiosById,
-                    albumGuid =>
-                    {
-                        var parentAlbum = libraryManager.GetItemById(albumGuid);
-                        return (parentAlbum?.Studios?.ToList() ?? [], parentAlbum?.Name ?? "Unknown");
-                    },
-                    (albumGuid, cachedStudios) =>
-                    {
-                        logger?.LogDebug("Using cached parent album studios for audio track '{TrackName}' (album ID: {AlbumId}): [{Studios}]",
-                            baseItem.Name, albumGuid, string.Join(", ", cachedStudios));
-                    },
-                    (albumGuid, albumName, fetchedStudios) =>
-                    {
-                        logger?.LogDebug("Extracted and cached parent album studios for audio track '{TrackName}' (album: '{AlbumName}'): [{Studios}]",
-                            baseItem.Name, albumName, string.Join(", ", fetchedStudios));
-                    },
-                    (ex, albumGuid) =>
-                    {
-                        logger?.LogDebug(ex, "Failed to get parent album studios for audio track '{TrackName}' with AlbumId {AlbumId}",
-                            baseItem.Name, albumGuid);
-                    });
-
-                if (albumStudios != null)
-                {
-                    operand.ParentAlbumStudios = albumStudios;
-                }
-                else
-                {
-                    logger?.LogDebug("Could not extract valid AlbumId or ParentId from audio track '{TrackName}'", baseItem.Name);
-                }
-            }
-            catch (Exception ex)
-            {
-                logger?.LogWarning(ex, "Failed to extract parent album studios for item '{ItemName}'", baseItem.Name);
+                logger?.LogWarning(ex, "SmartLists failed to resolve ancestor values for '{Name}'", baseItem.Name);
             }
         }
 
@@ -2874,10 +2473,9 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             var extractPeople = options.ExtractPeople;
             var extractNextUnwatched = options.ExtractNextUnwatched;
             var extractSeriesName = options.ExtractSeriesName;
-            var extractParentSeriesTags = options.ExtractParentSeriesTags;
-            var extractParentSeriesStudios = options.ExtractParentSeriesStudios;
-            var extractParentSeriesGenres = options.ExtractParentSeriesGenres;
-            var extractParentAlbumGenres = options.ExtractParentAlbumGenres;
+            var extractParentTags = options.ExtractParentTags;
+            var extractParentStudios = options.ExtractParentStudios;
+            var extractParentGenres = options.ExtractParentGenres;
             var extractLastEpisodeAirDate = options.ExtractLastEpisodeAirDate;
 
             // Cheap extraction flags (for performance optimization)
@@ -3305,71 +2903,19 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                 logger?.LogDebug("LibraryInfo extraction skipped for item {Name} - not needed by rules", baseItem.Name);
             }
 
-            // Extract parent series tags for episodes - only when needed for performance
-            // This is an expensive operation (database lookup), so we use caching
-            if (extractParentSeriesTags)
+            // Ancestor-inherited Tags/Studios/Genres (season/series/album/artist/folder/library).
+            // Expensive (tree walk + library lookup), so gated on the requirement flags and
+            // memoized per ancestor node. The else-branch reset is load-bearing: Phase 1 builds
+            // its operand with the parent groups masked off, and must never see stale values.
+            if (extractParentTags || extractParentStudios || extractParentGenres)
             {
-                ExtractParentSeriesTags(operand, baseItem, libraryManager, cache, logger);
-            }
-            else
-            {
-                operand.ParentSeriesTags = [];
-            }
-
-            // Extract parent series studios for episodes - only when needed for performance
-            // This is an expensive operation (database lookup), so we use caching
-            if (extractParentSeriesStudios)
-            {
-                ExtractParentSeriesStudios(operand, baseItem, libraryManager, cache, logger);
-            }
-            else
-            {
-                operand.ParentSeriesStudios = [];
+                ExtractAncestorValues(operand, baseItem, libraryManager, cache, logger,
+                    extractParentTags, extractParentStudios, extractParentGenres);
             }
 
-            // Extract parent series genres for episodes - only when needed for performance
-            // This is an expensive operation (database lookup), so we use caching
-            if (extractParentSeriesGenres)
-            {
-                ExtractParentSeriesGenres(operand, baseItem, libraryManager, cache, logger);
-            }
-            else
-            {
-                operand.ParentSeriesGenres = [];
-            }
-
-            // Extract parent album genres for audio tracks - only when needed for performance
-            // This is an expensive operation (database lookup), so we use caching
-            if (extractParentAlbumGenres)
-            {
-                ExtractParentAlbumGenres(operand, baseItem, libraryManager, cache, logger);
-            }
-            else
-            {
-                operand.ParentAlbumGenres = [];
-            }
-
-            // Extract parent album tags for audio tracks - only when needed for performance
-            // This is an expensive operation (database lookup), so we use caching
-            if (options.ExtractParentAlbumTags)
-            {
-                ExtractParentAlbumTags(operand, baseItem, libraryManager, cache, logger);
-            }
-            else
-            {
-                operand.ParentAlbumTags = [];
-            }
-
-            // Extract parent album studios for audio tracks - only when needed for performance
-            // This is an expensive operation (database lookup), so we use caching
-            if (options.ExtractParentAlbumStudios)
-            {
-                ExtractParentAlbumStudios(operand, baseItem, libraryManager, cache, logger);
-            }
-            else
-            {
-                operand.ParentAlbumStudios = [];
-            }
+            if (!extractParentTags) { operand.ParentTags = []; }
+            if (!extractParentStudios) { operand.ParentStudios = []; }
+            if (!extractParentGenres) { operand.ParentGenres = []; }
 
             // AudioMetadata extraction - conditionally extracted for performance optimization
             // Includes Album, Artists, AlbumArtists for music-related items

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/FieldRegistry.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/FieldRegistry.cs
@@ -47,13 +47,10 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
     /// - Playlists: ItemPlaylists, PlaylistMembershipCache
     /// - NextUnwatched: NextUnwatched cache
     /// - SeriesName: SeriesNameById
-        /// - ParentSeriesTags: SeriesTagsById
-        /// - ParentSeriesStudios: SeriesStudiosById
-        /// - ParentSeriesGenres: SeriesGenresById
-        /// - ParentAlbumGenres: AlbumGenresById
-        /// - ParentAlbumTags: AlbumTagsById
-        /// - ParentAlbumStudios: AlbumStudiosById
-        /// - LastEpisodeAirDate: LastEpisodeAirDateById
+    /// - ParentTags: AncestorValuesById
+    /// - ParentStudios: AncestorValuesById
+    /// - ParentGenres: AncestorValuesById
+    /// - LastEpisodeAirDate: LastEpisodeAirDateById
     /// - LibraryInfo: LibraryNameById
     /// </summary>
     [Flags]
@@ -71,15 +68,13 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         Playlists = 1 << 5,           // Fields: Playlists | Cache: ItemPlaylists, PlaylistMembershipCache
         NextUnwatched = 1 << 6,       // Fields: NextUnwatched | Cache: NextUnwatched
         SeriesName = 1 << 7,          // Fields: SeriesName | Cache: SeriesNameById
-        ParentSeriesTags = 1 << 8,    // Fields: Tags (with IncludeParentSeriesTags) | Cache: SeriesTagsById
-        ParentSeriesStudios = 1 << 9, // Fields: Studios (with IncludeParentSeriesStudios) | Cache: SeriesStudiosById
-        ParentSeriesGenres = 1 << 10, // Fields: Genres (with IncludeParentSeriesGenres) | Cache: SeriesGenresById
+        ParentTags = 1 << 8,          // Fields: Tags (with IncludeParentTags) | Cache: AncestorValuesById
+        ParentStudios = 1 << 9,       // Fields: Studios (with IncludeParentStudios) | Cache: AncestorValuesById
+        ParentGenres = 1 << 10,       // Fields: Genres (with IncludeParentGenres) | Cache: AncestorValuesById
         SimilarTo = 1 << 11,          // Fields: SimilarTo | Special handling in Engine
         LastEpisodeAirDate = 1 << 12, // Fields: LastEpisodeAirDate | Cache: LastEpisodeAirDateById
         ExternalLists = 1 << 20,      // Fields: ExternalList | Cache: ExternalListData, ItemExternalLists
-        ParentAlbumGenres = 1 << 21,  // Fields: Genres (with IncludeParentAlbumGenres) | Cache: AlbumGenresById
-        ParentAlbumTags = 1 << 22,    // Fields: Tags (with IncludeParentAlbumTags) | Cache: AlbumTagsById
-        ParentAlbumStudios = 1 << 23, // Fields: Studios (with IncludeParentAlbumStudios) | Cache: AlbumStudiosById
+                                      // (1 << 21 .. 1 << 23 free)
 
         // Cheap extraction groups (conditional but fast - don't trigger two-phase filtering)
         // Defined in FieldRegistry.CheapExtractionGroups

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Operand.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Operand.cs
@@ -25,12 +25,14 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         public double DateModified { get; set; } = 0;
         public double ReleaseDate { get; set; } = 0;
         public List<string> Tags { get; set; } = [];
-        public List<string> ParentSeriesTags { get; set; } = [];
-        public List<string> ParentAlbumTags { get; set; } = [];
-        public List<string> ParentSeriesStudios { get; set; } = [];
-        public List<string> ParentAlbumStudios { get; set; } = [];
-        public List<string> ParentSeriesGenres { get; set; } = [];
-        public List<string> ParentAlbumGenres { get; set; } = [];
+        // Ancestor-inherited values (season/series/album/artist/folder/library), resolved by
+        // AncestorValueResolver. IReadOnlyList so the shared AncestorValues.Empty singleton cannot
+        // be mutated through an operand; the "= []" initializers are load-bearing, because
+        // AnyRegexMatch treats an empty list (pattern tested against string.Empty) differently
+        // from a null one.
+        public IReadOnlyList<string> ParentTags { get; set; } = [];
+        public IReadOnlyList<string> ParentStudios { get; set; } = [];
+        public IReadOnlyList<string> ParentGenres { get; set; } = [];
         public double RuntimeMinutes { get; set; } = 0;
         public string OfficialRating { get; set; } = string.Empty;
         public List<string> AudioLanguages { get; set; } = [];

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -65,9 +65,9 @@ namespace Jellyfin.Plugin.SmartLists.Core
 
         private static bool IsParentAwareListExpression(Expression expr)
         {
-            return (expr.MemberName == "Tags" && (expr.IncludeParentSeriesTags == true || expr.IncludeParentAlbumTags == true || expr.OnlyParentTags == true)) ||
-                   (expr.MemberName == "Studios" && (expr.IncludeParentSeriesStudios == true || expr.IncludeParentAlbumStudios == true || expr.OnlyParentStudios == true)) ||
-                   (expr.MemberName == "Genres" && (expr.IncludeParentSeriesGenres == true || expr.IncludeParentAlbumGenres == true || expr.OnlyParentGenres == true));
+            return (expr.MemberName == "Tags" && (expr.IncludeParentTagsEffective || expr.OnlyParentTags == true)) ||
+                   (expr.MemberName == "Studios" && (expr.IncludeParentStudiosEffective || expr.OnlyParentStudios == true)) ||
+                   (expr.MemberName == "Genres" && (expr.IncludeParentGenresEffective || expr.OnlyParentGenres == true));
         }
 
         public SmartList(SmartPlaylistDto dto)
@@ -474,21 +474,15 @@ namespace Jellyfin.Plugin.SmartLists.Core
                         hashBuilder.Append(':');
                         hashBuilder.Append(expr.UserId ?? "");
                         hashBuilder.Append(':');
-                        hashBuilder.Append(expr.IncludeParentSeriesTags?.ToString() ?? "null");
-                        hashBuilder.Append(':');
-                        hashBuilder.Append(expr.IncludeParentAlbumTags?.ToString() ?? "null");
+                        hashBuilder.Append(expr.IncludeParentTagsEffective);
                         hashBuilder.Append(':');
                         hashBuilder.Append(expr.OnlyParentTags?.ToString() ?? "null");
                         hashBuilder.Append(':');
-                        hashBuilder.Append(expr.IncludeParentSeriesStudios?.ToString() ?? "null");
-                        hashBuilder.Append(':');
-                        hashBuilder.Append(expr.IncludeParentAlbumStudios?.ToString() ?? "null");
+                        hashBuilder.Append(expr.IncludeParentStudiosEffective);
                         hashBuilder.Append(':');
                         hashBuilder.Append(expr.OnlyParentStudios?.ToString() ?? "null");
                         hashBuilder.Append(':');
-                        hashBuilder.Append(expr.IncludeParentSeriesGenres?.ToString() ?? "null");
-                        hashBuilder.Append(':');
-                        hashBuilder.Append(expr.IncludeParentAlbumGenres?.ToString() ?? "null");
+                        hashBuilder.Append(expr.IncludeParentGenresEffective);
                         hashBuilder.Append(':');
                         hashBuilder.Append(expr.OnlyParentGenres?.ToString() ?? "null");
                         hashBuilder.Append(':');
@@ -3693,12 +3687,9 @@ namespace Jellyfin.Plugin.SmartLists.Core
         public bool NeedsPlaylists => RequiredGroups.HasFlag(ExtractionGroup.Playlists);
         public bool NeedsNextUnwatched => RequiredGroups.HasFlag(ExtractionGroup.NextUnwatched);
         public bool NeedsSeriesName => RequiredGroups.HasFlag(ExtractionGroup.SeriesName);
-        public bool NeedsParentSeriesTags => RequiredGroups.HasFlag(ExtractionGroup.ParentSeriesTags);
-        public bool NeedsParentAlbumTags => RequiredGroups.HasFlag(ExtractionGroup.ParentAlbumTags);
-        public bool NeedsParentSeriesStudios => RequiredGroups.HasFlag(ExtractionGroup.ParentSeriesStudios);
-        public bool NeedsParentAlbumStudios => RequiredGroups.HasFlag(ExtractionGroup.ParentAlbumStudios);
-        public bool NeedsParentSeriesGenres => RequiredGroups.HasFlag(ExtractionGroup.ParentSeriesGenres);
-        public bool NeedsParentAlbumGenres => RequiredGroups.HasFlag(ExtractionGroup.ParentAlbumGenres);
+        public bool NeedsParentTags => RequiredGroups.HasFlag(ExtractionGroup.ParentTags);
+        public bool NeedsParentStudios => RequiredGroups.HasFlag(ExtractionGroup.ParentStudios);
+        public bool NeedsParentGenres => RequiredGroups.HasFlag(ExtractionGroup.ParentGenres);
         public bool NeedsSimilarTo => RequiredGroups.HasFlag(ExtractionGroup.SimilarTo);
         public bool NeedsLastEpisodeAirDate => RequiredGroups.HasFlag(ExtractionGroup.LastEpisodeAirDate);
         public bool NeedsExternalLists => RequiredGroups.HasFlag(ExtractionGroup.ExternalLists);
@@ -3758,15 +3749,13 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 var group = FieldRegistry.GetExtractionGroup(expr.MemberName);
                 requirements.RequiredGroups |= group;
 
-                // Handle special cases for parent series/album fields (conditional on expression flags).
-                // Only add each parent group when its corresponding IncludeParent* flag is explicitly true.
-                // OnlyParent* alone does NOT trigger extraction of both groups — use IncludeParent* to decide which.
-                AddParentGroupIfIncluded(requirements, expr.MemberName, "Tags",    expr.IncludeParentSeriesTags,    ExtractionGroup.ParentSeriesTags);
-                AddParentGroupIfIncluded(requirements, expr.MemberName, "Tags",    expr.IncludeParentAlbumTags,     ExtractionGroup.ParentAlbumTags);
-                AddParentGroupIfIncluded(requirements, expr.MemberName, "Studios", expr.IncludeParentSeriesStudios, ExtractionGroup.ParentSeriesStudios);
-                AddParentGroupIfIncluded(requirements, expr.MemberName, "Studios", expr.IncludeParentAlbumStudios,  ExtractionGroup.ParentAlbumStudios);
-                AddParentGroupIfIncluded(requirements, expr.MemberName, "Genres",  expr.IncludeParentSeriesGenres,  ExtractionGroup.ParentSeriesGenres);
-                AddParentGroupIfIncluded(requirements, expr.MemberName, "Genres",  expr.IncludeParentAlbumGenres,   ExtractionGroup.ParentAlbumGenres);
+                // Handle special cases for ancestor-inherited fields (conditional on expression flags).
+                // Only add each parent group when the folded IncludeParent*Effective flag is true.
+                // OnlyParent* alone does NOT trigger extraction: with no source it compiles to
+                // constant-false (Engine), so requesting the walk would be wasted work.
+                AddParentGroupIfIncluded(requirements, expr.MemberName, "Tags",    expr.IncludeParentTagsEffective,    ExtractionGroup.ParentTags);
+                AddParentGroupIfIncluded(requirements, expr.MemberName, "Studios", expr.IncludeParentStudiosEffective, ExtractionGroup.ParentStudios);
+                AddParentGroupIfIncluded(requirements, expr.MemberName, "Genres",  expr.IncludeParentGenresEffective,  ExtractionGroup.ParentGenres);
 
                 // Collect SimilarTo expressions for reference item lookup
                 if (expr.MemberName == "SimilarTo")

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.SmartLists.Core.Enums;
 using Jellyfin.Plugin.SmartLists.Core.Models;
+using Jellyfin.Plugin.SmartLists.Core.QueryEngine;
 using Jellyfin.Plugin.SmartLists.Services.Collections;
 using Jellyfin.Plugin.SmartLists.Services.ExternalList;
 using Jellyfin.Plugin.SmartLists.Services.Playlists;
@@ -294,6 +295,17 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                 }
                 _logger.LogError(ex, "Error processing {OperationType} operation for list {ListId} ({ListName})",
                     item.OperationType, item.ListId, item.ListName);
+            }
+            finally
+            {
+                // Bound ancestor-memo staleness to a single list refresh. RefreshCache itself is
+                // per-user and survives until the whole queue drains, but each AncestorValuesById
+                // entry embeds every value above it, so a season/library retag would otherwise
+                // stay invisible across an entire batch. Rebuilding costs one walk per container.
+                foreach (var cache in _refreshCaches.Values)
+                {
+                    cache.AncestorValuesById.Clear();
+                }
             }
         }
 
@@ -735,12 +747,18 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
             public ConcurrentDictionary<Guid, HashSet<Guid>> PlaylistMembershipCache { get; } = new();
             public ConcurrentDictionary<Guid, string> SeriesNameById { get; } = new();
             public ConcurrentDictionary<Guid, string> SeriesSortNameById { get; } = new();
-            public ConcurrentDictionary<Guid, List<string>> SeriesTagsById { get; } = new();
-            public ConcurrentDictionary<Guid, List<string>> SeriesStudiosById { get; } = new();
-            public ConcurrentDictionary<Guid, List<string>> SeriesGenresById { get; } = new();
-            public ConcurrentDictionary<Guid, List<string>> AlbumGenresById { get; } = new();
-            public ConcurrentDictionary<Guid, List<string>> AlbumTagsById { get; } = new();
-            public ConcurrentDictionary<Guid, List<string>> AlbumStudiosById { get; } = new();
+
+            /// <summary>
+            /// Ancestor-inherited Tags/Studios/Genres, keyed by the ANCESTOR NODE id (season id,
+            /// album id, folder id) — never the item id — so every episode of a season is a single
+            /// lookup and the walk itself runs once per container. Each entry is the COMPLETE union
+            /// for that node and everything above it INCLUDING the library CollectionFolder, so a
+            /// memo hit needs no further work. Cleared per queue item (see ProcessQueueItemAsync)
+            /// rather than per queue drain: entries embed everything above them, so a stale entry
+            /// after a retag would otherwise affect a whole subtree until the queue emptied.
+            /// </summary>
+            public ConcurrentDictionary<Guid, AncestorValues> AncestorValuesById { get; } = new();
+
             public ConcurrentDictionary<Guid, CategorizedPeople> ItemPeople { get; } = new();
             
             // User-specific data cache - keyed by (ItemId, UserId) to support playlist user + additional users in rules

--- a/docs/content/examples/advanced-examples.md
+++ b/docs/content/examples/advanced-examples.md
@@ -28,13 +28,13 @@ Here are some more complex playlist and collection examples:
 - Catches brand-new episodes even when they're downloaded before the release date metadata is published; once metadata arrives, the rule re-evaluates normally on the next refresh
 
 ## Kids' Shows Progress
-- **Next Unwatched** = True AND **Tags** contain "Kids" (with parent series tags enabled)
+- **Next Unwatched** = True AND **Tags** contain "Kids" (with parent tags enabled, so a tag on the season or series applies to its episodes)
 
 ## Foreign Language Practice
 - **Audio Languages** match `(?i)(ger|fra|spa)` AND **Playback Status** = Unplayed
 
 ## Tagged Series Marathon
-- **Tags** is in "Drama;Thriller" (with parent series tags enabled) AND **Runtime** < 50 minutes
+- **Tags** is in "Drama;Thriller" (with parent tags enabled, so a tag on the season or series applies to its episodes) AND **Runtime** < 50 minutes
 
 ## High-Quality FLAC Music
 - **Audio Codec** = "FLAC" AND **Audio Bit Depth** >= 24 AND **Audio Sample Rate** >= 96000

--- a/docs/content/examples/common-use-cases.md
+++ b/docs/content/examples/common-use-cases.md
@@ -65,7 +65,7 @@ Here are some popular playlist and collection types you can create:
 - **Important**: The smart collection will never include itself, and only playlists you own or that are public are accessible
 
 ### Unplayed Sitcom Episodes
-- **Tags** contains "Sitcom" (with parent series tags enabled) AND **Playback Status** = Unplayed
+- **Tags** contains "Sitcom" (with parent tags enabled, so a tag on the season or series applies to its episodes) AND **Playback Status** = Unplayed
 
 ### Currently Airing Series Collection
 - **Media Types**: Series
@@ -328,6 +328,13 @@ Collections are great for organizing related content that you want to browse tog
 - **Library Name** not equals "Kids Movies"
 - **Genre** contains "Animation"
 - Creates a playlist of animated content, but excludes anything from your "Kids Movies" library
+
+### Everything from a Tagged Library
+- **Tags** contains "kids-safe" with **Yes - Also check parent tags** enabled
+- **Media Type**: Movie
+- Tag the library itself and every movie inside it matches - no need to tag the movies one by one
+- Works the same way for a tag on a plain folder inside the library, or on a season or series for episodes
+- See [Parent metadata options](../user-guide/fields-and-operators.md#parent-metadata-options) for the full list of what counts as a parent
 
 ## Operator Examples
 

--- a/docs/content/user-guide/fields-and-operators.md
+++ b/docs/content/user-guide/fields-and-operators.md
@@ -188,23 +188,46 @@ Filter by cast and crew members. Select "People" in the field dropdown, then cho
 
 | Field | JSON name | Description |
 |-------|-----------|-------------|
-| **Genres** | `Genres` | Content genres |
-| **Studios** | `Studios` | Production studios |
-| **Tags** | `Tags` | Custom tags assigned to media items |
+| **Genres** | `Genres` | Content genres. [See parent metadata options below.](#parent-metadata-options) |
+| **Studios** | `Studios` | Production studios. [See parent metadata options below.](#parent-metadata-options) |
+| **Tags** | `Tags` | Custom tags assigned to media items. [See parent metadata options below.](#parent-metadata-options) |
 | **Album** | `Album` | Album name (music) |
 | **Artists** | `Artists` | Track-level artists (music) |
 | **Album Artists** | `AlbumArtists` | Album-level primary artists (music) |
 | **External List** | `ExternalList` | Match items from an external list (MDBList, IMDb, Letterboxd, Trakt, TMDB, ListenBrainz, Scrob). [See details below.](#external-list) |
 
-**Parent metadata options** for Tags, Studios, and Genres (shown when Episode or Audio media type is selected):
+#### Parent metadata options {#parent-metadata-options}
+
+**Tags**, **Studios**, and **Genres** can also match values inherited from the item's parents. The option is available for **every media type**.
 
 Each of these fields has three options:
 
 - **No - Only check item [tags/studios/genres]** (default) - Only checks the item's own metadata.
-- **Yes - Also check [tags/studios/genres] from parent series/album** - Matches if either the item or its parent series/album has the specified value. Useful when parent-level metadata is more complete.
-- **Yes - Only check [tags/studios/genres] from parent series/album** - Skips the item's own metadata entirely and only checks the parent series/album. Useful when you want to filter purely by series/album-level metadata.
+- **Yes - Also check parent [tags/studios/genres] (season, series, album, folder, library)** - Matches if the item **or** any of its parents has the value. Useful when the metadata lives higher up than the item itself.
+- **Yes - Only check parent [tags/studios/genres] (season, series, album, folder, library)** - Skips the item's own metadata entirely and checks only its parents.
 
-The label and option text adapts based on the selected media type (e.g., "parent series" for episodes, "parent album" for audio tracks).
+**What counts as a parent?** Everything above the item, all the way up to and including the Jellyfin library it lives in:
+
+| Item | What is checked |
+|-------|-----------|
+| **Episode** | Season → series → the folders they sit in → library |
+| **Season** | Series → the folders it sits in → library |
+| **Track** | Album → artist folder → the folders they sit in → library |
+| **Movie, series, album, video, photo, book** | The folders it sits in → library |
+| **Extras** (trailers, behind the scenes, ...) | The movie or series they belong to → everything above that |
+
+So a tag set on a single **season** now applies to that season's episodes, and a tag set on the **library itself** applies to everything inside it.
+
+!!! note "Collections and playlists are not parents"
+    Being a member of a Jellyfin **collection** or **playlist** does not count — those are links, not folders, so their tags, studios, and genres never flow down to the items inside them. Use the [Collection Name](#collection-name) or [Playlist Name](#playlist-name) fields to filter on membership instead.
+
+!!! warning "Positive operators match more items, negative operators match fewer"
+    Enabling the option adds the parents' values to what gets checked, which pulls the two families of operators in opposite directions:
+
+    - **equals**, **contains**, **is in**, **matches regex** match **more** items - the item matches if it *or any parent* matches.
+    - **not equals**, **not contains**, **is not in** match **fewer** items - *every* checked source has to not match, so a value sitting on a season, folder, or library is now enough to exclude the item.
+
+    Lists that already had the option enabled before the plugin gained the full parent walk will therefore change contents on their first refresh - music lists most of all, since they now also see values from the artist folder and the library, not just the album.
 
 #### Collection Name
 

--- a/docs/superpowers/plans/2026-08-14-generic-parent-tag-walk.md
+++ b/docs/superpowers/plans/2026-08-14-generic-parent-tag-walk.md
@@ -1254,7 +1254,32 @@ Expected during a full refresh: **no** `NotSupportedException`, **no** `Argument
 | | line 37 | same |
 | `docs/content/examples/common-use-cases.md` | line 68 | same |
 | | new section | One Movies-library-tag example (the capability gain) |
-| Release notes (tag message body) | — | Existing lists change contents on first refresh: positive operators gain items, **negative operators lose items**; audio lists with the album option now also see artist-folder and library values |
+| Release notes (tag message body) | — | Existing lists change contents on first refresh: positive operators gain items, **negative operators lose items**; audio lists with the album option now also see artist-folder and library values. **Draft text parked below — carry it into the `/release` tag message.** |
+
+### Drafted release-note text (for the `/release` tag message body)
+
+Parked here so it survives to tag time. The docs version in `fields-and-operators.md` is deliberately
+abbreviated; this is the only place the audio-specific shrinkage is spelled out for users.
+
+> **Parent tags, studios, and genres now walk the whole ancestor chain**
+>
+> The "also check parent" option on **Tags**, **Studios**, and **Genres** used to stop at the parent
+> series (episodes) or the parent album (audio). It now walks every ancestor up to and including the
+> Jellyfin library: season → series → the folders they sit in → library for episodes, album → artist
+> folder → the folders they sit in → library for tracks, and the folders → library for everything
+> else. The option is also no longer limited to episodes and audio — it is available for every media
+> type, so a tag on a movie library or on a plain folder now applies to everything inside it.
+>
+> **Existing lists that already had the option enabled will change contents on their first refresh.**
+> Positive operators (equals, contains, is in, matches regex) match **more** items, because the item
+> matches if it *or any ancestor* matches. Negative operators (not equals, not contains, is not in)
+> match **fewer** items, because every checked source has to not match — a value sitting on a season,
+> a folder, or the library is now enough to exclude the item. Music lists move the most: a
+> not-contains or not-equals rule with the album option enabled now also sees values from the artist
+> folder and the library, not just the album, so those playlists can visibly shrink.
+>
+> Collection and playlist membership still does not count — those are links, not folders, so their
+> tags, studios, and genres never flow down to the items inside them.
 
 Not touched, deliberately: `docs/content/user-guide/advanced-configuration.md` (parent flags were never documented for file editors — see Open Question 2) and `docs/content/development/integration-api.md` (see Open Question 2).
 

--- a/docs/superpowers/plans/2026-08-14-generic-parent-tag-walk.md
+++ b/docs/superpowers/plans/2026-08-14-generic-parent-tag-walk.md
@@ -1,0 +1,1275 @@
+# Generic Ancestor Walk for Tags / Studios / Genres (issue #495) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A tag applied to a **season**, a **physical folder**, or a **library** must match the items beneath it when "Include parent tags" is enabled — not just a tag on the Series (episodes) or the Album (audio tracks). Same for Studios and Genres. The option becomes valid for **all** media types.
+
+**Architecture:** Replace the six one-level extractors (`ExtractParentSeries{Tags,Studios,Genres}` + `ExtractParentAlbum{Tags,Studios,Genres}`, ~350 lines) with **one memoized ancestor walk** in a new file, `Core/QueryEngine/AncestorValueResolver.cs`, that collects Tags + Studios + Genres in a single pass. Runtime plumbing collapses (Operand 6 lists → 3, ExtractionGroup 6 bits → 3, RefreshCache 6 dicts → 1, Engine loses 2 parameters and 2 dead helpers, frontend loses ~135 lines of media-type label swapping). **Nothing is renamed or removed on disk** — `Expression` gains 3 flags plus 3 computed folds; the 9 existing flags stay untouched, so there is no migration, no shim, no deprecation window.
+
+**Tech Stack:** C# (.NET 9/10 multi-target, Jellyfin plugin), xUnit test project (net10.0 only), vanilla JS (Jellyfin admin UI conventions), mkdocs.
+
+---
+
+## Amendments (decided after the plan was drafted — these OVERRIDE the body)
+
+### Amendment 1 — No dual-write. The `10.11` stable line is retired.
+
+Repo owner, 2026-08-14: *"I won't release any more stable to the 10.11 branch, only 12 from now on."*
+
+Every instruction in this plan to **dual-write** the legacy flags is **cancelled**. It existed solely so a list edited on a `12.x` build survived a rollback to a `10.11.X.0` stable release; that rollback is now impossible.
+
+| | Decision |
+|---|---|
+| **Write** legacy `IncludeParentSeries*` / `IncludeParentAlbum*` keys on save | **NO.** New saves emit `IncludeParentTags` / `OnlyParentTags` (+ Studios/Genres) only. |
+| **Read** legacy keys | **YES, permanently.** Lists saved by older builds still carry them. C# folds via `IncludeParent*Effective`; JS edit-mode repopulation must still recognise them. |
+| Legacy flag declarations on `Expression` | **Kept**, unchanged, read-only. |
+
+Affected: **Major 5** (withdrawn), the "Written by" column of the mapping table (read `JS dual-write (one release)` as **"not written"**), **Task 10 Steps 3-4**, **Task 12** grep gate, **Task 13 Step E**, **Open Question 1** (closed).
+
+Task 12's gate becomes: legacy identifiers must still appear in JS on the **read/repopulate** path, and must **not** appear on the **write/serialize** path.
+
+### Amendment 2 — Remaining open questions, resolved
+
+| # | Question | Decision |
+|---|---|---|
+| 2 | Document `IncludeParentTags` / `OnlyParentTags` as public API? | **No.** Keep internal — the parent flags have never been documented and documenting makes them a supported contract. YAGNI. |
+| 3 | Fold in the symlinked-library `GetCollectionFolders` gap (~20 lines)? | **No — follow-up issue.** Pre-existing and already documented (`LibraryManagerHelper.cs:98-101`); not introduced here. Out of scope. |
+| 4 | Gate audio to stop at the album for one release? | **No.** Ship the generic walk as-is. Gating audio is a speculative special-case that contradicts the whole point. **Must appear in release notes** — `NotContains`/`NotEqual` audio rules will visibly shrink. |
+| 5 | Confirm depth cap of 20 | **Keep 20.** Measured real depth is 4-5. |
+
+---
+
+## Problem Statement
+
+GitHub issue **#495**: a user tagged a **season** with `seasontag02` and their **"Series" library** with a library-level tag. Their episodes did not match a `Tags` rule even with "Include parent series tags" enabled.
+
+**Confirmed root cause:** `Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs:2180-2236` (`ExtractParentSeriesTags`) resolves the episode's `SeriesId` via reflection (`TryGetEpisodeSeriesGuid`, Factory.cs:1923-1936), calls `libraryManager.GetItemById(seriesGuid)` (Factory.cs:2207) and reads **only that Series' `Tags`**. The Season sitting between episode and series is never touched, and nothing above the Series is either. The same shape is repeated in five siblings:
+
+| Extractor | Location | Reads exactly one level |
+|---|---|---|
+| `ExtractParentSeriesTags` | Factory.cs:2180-2236 | Series `.Tags` |
+| `ExtractParentSeriesStudios` | Factory.cs:2242-2298 | Series `.Studios` |
+| `ExtractParentSeriesGenres` | Factory.cs:2304-2360 | Series `.Genres` |
+| `ExtractParentAlbumGenres` | Factory.cs:2366-2415 | MusicAlbum `.Genres` |
+| `ExtractParentAlbumTags` | Factory.cs:2421-2470 | MusicAlbum `.Tags` |
+| `ExtractParentAlbumStudios` | Factory.cs:2476-2525 | MusicAlbum `.Studios` |
+
+All six also hard-return for anything that is not an `Episode` (Factory.cs:2186) or not `Audio` (Factory.cs:2371), which is why the option is offered only when Episode or Audio is a selected media type.
+
+---
+
+## Load-Bearing Facts (verified against the codebase and the live dev DB)
+
+1. **A `GetParent()` walk NEVER reaches the library.** Measured by recursive `ParentId` CTE on `dev/jellyfin-data/config/data/jellyfin.db`:
+   - Episode `Moss and the German` `8F4F4464` → Season `3C34646F` → Series `CACA970C` → Folder `7CA8CCF8` (`shows`) → AggregateFolder `F27CAA37` (`root`) → null
+   - Movie `3619F76A` → Folder `5B0D238E` (`movies`) → AggregateFolder `root`
+   - Audio `04FAD2F9` → MusicAlbum `B5E5B661` → Folder `20A90C40` (`music`) → AggregateFolder `root`
+
+   The tagged library `CollectionFolder BC3A7D1D` (`Serier`) has `ParentId = E9D5075A` (the **UserRootFolder**) — it is a sibling structure, never an ancestor. **The brief's "stop at the CollectionFolder inclusive" is unimplementable as written and would ship a half-fix** (season tag starts matching, library tag still never does).
+   The walk must therefore be: **parent chain (stopping before AggregateFolder / UserRootFolder / UserView) UNION `libraryManager.GetCollectionFolders(chainTop)`** — structurally identical to what `BaseItem.GetInheritedTags()` and `GetAncestorIds()` do in core.
+
+2. **Library tags are real and live on the CollectionFolder `BaseItem`.** `SELECT Id,Name,Type,Tags FROM BaseItems WHERE Tags<>''` returns `BC3A7D1D | Serier | ...CollectionFolder | seriestag01`, and `GET /Items?ids=BC3A7D1D&fields=Tags` returns `Tags: ['seriestag01']`. Tags are **not** in `LibraryOptions`.
+
+3. **`BaseItem.TopParentId` does not exist.** It is a DB column and an `InternalItemsQuery` filter only. `GetTopParent()` returns the *physical* top folder, never the library.
+
+4. **`SeasonId` / `SeriesId` drift from the real tree.** Episode `8F4F4464` has `ParentId=3C34646F` but `SeasonId=98C6594D`. Use `ParentId`/`GetParent()` exclusively; never `DisplayParentId` (`Episode.DisplayParentId => SeasonId`).
+
+5. **`Audio` has no `AlbumId` property** in either ABI (only `MusicAlbum AlbumEntity => FindParent<MusicAlbum>()`), so `TryGetAudioAlbumGuid`'s reflected `"AlbumId"` lookup always returns null and the `ParentId` fallback is what has always run. The walk visits the same node for audio — no regression there.
+
+6. **Tags/Studios/Genres are registered as CHEAP** (`FieldRegistry.cs:281-283`, `ExtractionGroup.ItemLists`, inside `CheapExtractionGroups`). `FieldRegistry.IsExpensiveField("Tags")` is **false**. The **only** thing promoting a parent-aware rule to the expensive tier is the hardcoded flag-name match in `SmartList.cs:66-71` (`IsParentAwareListExpression`). Miss it and the rule is evaluated in Phase 1 against an operand whose parent list `Factory` reset to `[]`, matching nothing, with **no exception and no log**.
+
+7. **`Expression` property names ARE the on-disk JSON schema.** `SmartListFileSystem.cs:75-79` `SharedJsonOptions` sets no `UnmappedMemberHandling` (STJ default `Skip` → unknown keys silently discarded) and no `PropertyNameCaseInsensitive` (reads are case-sensitive). Every refresh re-serializes the whole DTO (`PlaylistStore.SaveAsync:124`, `CollectionStore.SaveAsync:104`, driven by `RefreshQueueService.cs:523/601`), so a removed property is **erased from disk**, not merely ignored.
+
+8. **Extras have no parent.** Row `E173B706` (`Gag reel season 1`, `Video`, `ExtraType=0`) has an empty `ParentId` and `OwnerId` pointing at the `Modern Family` Series. Core's own `GetCollectionFolders` falls back to `GetOwner()`; so must the walk.
+
+9. **The test stub throws on everything but `GetItemById`.** `Jellyfin.Plugin.SmartLists.Tests/Support/TestItems.cs:30-49`. A probe confirmed `GetInheritedTags()` and `GetAncestorIds()` both throw `NotSupportedException` there today. Existing fixtures never set `ParentId` and never register containers, so a naive walk test would pass vacuously.
+
+---
+
+## Adversarial Review Resolutions
+
+Every blocker and major from the review is folded into the tasks below. Cross-reference:
+
+### Blocker 1 — `CS0053` inconsistent accessibility
+`RefreshQueueService` is `public class` (RefreshQueueService.cs:54) and `RefreshCache` is `public sealed class` (RefreshQueueService.cs:723), so a **public** property may not expose an **internal** type. Verified failure: `RefreshQueueService.cs(744,107): error CS0053`.
+**Resolution:** `AncestorValues` is declared **`public sealed class`**; only `AncestorValueResolver` stays `internal static`. Verified to build clean (0 errors / 0 warnings) on both net9.0 and net10.0. → **Task 1, Task 2**.
+
+### Blocker 2 — The grep gate contradicts the mandatory back-compat rule
+"grep `IncludeParentSeries|IncludeParentAlbum` over the whole plugin must return hits ONLY in Expression.cs" would force deletion of the legacy reads in `config-rules.js:3202/3214/3226` and `config-lists.js:1658-1686`, which are exactly the back-compat hinge.
+**Resolution:** the gate is restated as **two** greps — a negative one restricted to `--include='*.cs'`, and a **positive** one asserting the JS legacy reads still exist. → **Task 12, Step 1**.
+
+### Blocker 3 — "one cache hit per episode" is false as originally designed
+`var node = item.GetParent() ?? item.GetOwner();` executing **before** the memo lookup costs a full `ILibraryManager.GetItemById` round-trip per item. Today's code costs **zero** library calls on a memo hit (`TryGetEpisodeSeriesGuid` reads a property, and `Factory.cs:2196` consults the memo first). Measured: 10k episodes / 500 seasons goes from 50 `GetItemById` to ~10,550.
+**Resolution:** the memo is keyed on `item.ParentId` — a plain `Guid` field needing no resolution — and consulted **before** any parent is materialized. Restores exact parity with today's memo-first pattern. → **Task 1, `Resolve` body**.
+
+### Major 4 — `GenerateRuleSetHash` was left unspecified
+There was no "dedicated cache-key section". Forgetting a flag here produces a stale-compiled-rule bug that only reproduces without a Jellyfin restart (`_ruleCache` is process-static, `SmartList.cs:50`, bounded at 1000 entries).
+**Resolution:** the exact six replacement appends are spelled out verbatim. → **Task 8, Step 2**.
+
+### Major 5 — Downgrade / cross-release-line reads — **WITHDRAWN, see Amendment 1**
+The review assumed the two concurrent release lines in CLAUDE.md ("Release Lines") and proposed dual-writing the legacy flags so a list edited on a `12.x` build survived a rollback to the `10.11.X.0` stable line.
+**Resolution: no dual-write.** Superseded by **Amendment 1** — the `10.11` stable line is retired, so the rollback this defended against cannot occur. Reading legacy flags stays mandatory; only the *writing* of legacy keys is dropped.
+
+### Major 6 — Negative operators SHRINK, they do not grow
+`Engine.cs:332-338`: `NotEqual|NotContains|IsNotIn` fold with `AndAlso`, so a larger ancestor value set can only **remove** items. Live DB: MusicArtist 50 rows / 42 with Genres, MusicAlbum 14 / 9 — an existing `Genres NotEqual X (include parent album)` audio rule changes results for most of that library.
+**Resolution:** stated explicitly in docs **and** release notes, plus two dedicated e2e scenarios (G and H) that capture the item set **before** deploying and diff after. → **Task 11**, **Task 13 scenarios G/H**.
+
+### Major 7 — Mutable static singleton reachable from every Operand
+`AncestorValues.Empty` holding mutable `List<string>` assigned by reference into `Operand`'s public settable `List<string>` properties means a single stray mutation corrupts every item in every list for the remaining **process** lifetime.
+**Resolution:** `AncestorValues` members are typed **`IReadOnlyList<string>`** (mutation is a compile error) and `Operand`'s three parent properties become `IReadOnlyList<string>` too, so assignment stays zero-copy. Every Engine consumer (`AnyItemEquals`, `AnyItemContains`, `AnyItemIsInList`, `AnyRegexMatch` — Engine.cs:1534/1554/1667/1729) takes `IEnumerable<string>`, so no call site changes. → **Task 1, Task 5**.
+
+### Major 8 — "only runs on Phase-2 survivors" is false for the #495 shape
+When the ONLY rule is a parent-aware Tags rule, `hasNonExpensiveRules` is false and `SmartList.cs:3026` takes the expensive-only branch, extracting full operands for **every** candidate item. A rule set with zero cheap rules also sets `hasExpensiveOnlyRuleSets = true` (SmartList.cs:3193-3195), promoting every item into `phase1Survivors` (SmartList.cs:3214-3217).
+**Resolution:** the real bound is stated in the code comment and here — **worst case is one walk attempt per candidate item, not per Phase-2 survivor**. Combined with the Blocker 3 fix that is one dictionary lookup per item plus one walk per distinct container. Task 13 adds the single-rule-over-a-full-library scenario and records refresh wall-clock. → **Task 1 comment, Task 13 scenario I**.
+
+### Major 9 — No invalidation; staleness blast radius grows
+`_refreshCaches` is keyed **per user** (RefreshQueueService.cs:78, :636) and cleared only when the whole queue drains (:200-203) or on Dispose (:715). Each `AncestorValuesById` entry embeds the union of everything above it, so retagging one library invalidates ~550 descendant entries, versus today where retagging a Series invalidated exactly one and retagging a Season invalidated nothing.
+**Resolution:** `AncestorValuesById` is cleared **per queue item** in a new `finally` block on `ProcessQueueItemAsync` (RefreshQueueService.cs:224-298, which currently has no `finally`). It is cheap to rebuild (one walk per distinct container) and this bounds staleness to a single list refresh. → **Task 2, Step 2**.
+
+### Minor A — Truncated walk silently loses the library contribution
+The original `seed = truncated || chain.Count == 0 ? Empty : GetLibraryValues(...)` short-circuits away the library values on the depth-cap path — the exact failure #495 is about.
+**Resolution:** on truncation, **still** resolve library values from the deepest node reached (`GetCollectionFolders` walks independently of the chain and is unaffected by the cap). Keep the no-memo-write guard. The dead `chain.Count == 0` arm is dropped. → **Task 1**.
+
+### Minor B — Cold-miss cost is 10x, not parity
+Scenario A goes from 50 `RetrieveItem` calls (one per series) to ~550 (500 seasons + 50 series + folders). Jellyfin's LRU is `Environment.ProcessorCount * 100` (200 on a 2-core NAS), below the 500 distinct seasons, and the candidate query sets no `OrderBy` (`PlaylistService.cs:1271-1279`) so touch order is not guaranteed contiguous.
+**Resolution:** documented honestly as `O(distinct containers)` DB reads + `O(items)` dictionary lookups. Task 13 compares refresh wall-clock against a **pre-change baseline** rather than assuming parity.
+
+---
+
+## Global Constraints
+
+- Build treats all warnings as errors (`AnalysisMode=Recommended`); CA1822 (make static) and CA1305 (locale) **will** fail the build.
+- Per-task verification: `cd dev && ./build-local.sh` (net10.0) plus `dotnet test`. Task 12 additionally verifies `JELLYFIN_ABI=10.11.0 ./build-local.sh` (net9.0).
+- Frontend: **no ES6 template literals** (`grep -c '\`' config-rules.js` must stay `0`), string concatenation only, no arrow functions in these files. `is="emby-select"` is the existing and correct pattern (the `is=` ban is specific to `emby-input`).
+- **No HTML changes.** `config.html` and `user-playlists.html` contain zero matches for `parent`/`tags-options`/`studios-options`/`genres-options` — all markup is generated at runtime by `config-rules.js`. No new JS files → no `.csproj` `EmbeddedResource` and no `Plugin.cs` `GetPages()` registration.
+- Line numbers were captured on `main` at `80d68a1`. Treat them as anchors: locate the quoted code, don't trust raw numbers blindly. **Never** read `.claude/worktrees/**` (stale duplicates) or `docs/site/**` (generated).
+- Work on branch `fix/495-ancestor-value-walk`. Commit after each task; commit messages end with:
+
+```text
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01S9FFji6MP136o3bq298BWJ
+```
+
+---
+
+## Back-Compat: exact old-flag → new-flag mapping
+
+**Strategy: additive on disk, fold on read, dual-write from the UI for one release.** No migration, no deserialize-only shim, no restore-path hook, no deprecation window. `SmartListDto.MigrateLegacyFields` (SmartListDto.cs:157-180) and `StorageMigrationHostedService` are **not** touched.
+
+### Persisted flags (all nine keep their exact names and behaviour)
+
+| On-disk JSON key | Status after change | Read by | Written by |
+|---|---|---|---|
+| `IncludeParentSeriesTags` | **kept**, legacy | `IncludeParentTagsEffective` fold | JS dual-write (one release) |
+| `IncludeParentAlbumTags` | **kept**, legacy | `IncludeParentTagsEffective` fold | JS dual-write (one release) |
+| `IncludeParentTags` | **new** | `IncludeParentTagsEffective` fold | JS |
+| `OnlyParentTags` | **unchanged** | read directly, `== true` | JS |
+| `IncludeParentSeriesStudios` | **kept**, legacy | `IncludeParentStudiosEffective` fold | JS dual-write (one release) |
+| `IncludeParentAlbumStudios` | **kept**, legacy | `IncludeParentStudiosEffective` fold | JS dual-write (one release) |
+| `IncludeParentStudios` | **new** | `IncludeParentStudiosEffective` fold | JS |
+| `OnlyParentStudios` | **unchanged** | read directly, `== true` | JS |
+| `IncludeParentSeriesGenres` | **kept**, legacy | `IncludeParentGenresEffective` fold | JS dual-write (one release) |
+| `IncludeParentAlbumGenres` | **kept**, legacy | `IncludeParentGenresEffective` fold | JS dual-write (one release) |
+| `IncludeParentGenres` | **new** | `IncludeParentGenresEffective` fold | JS |
+| `OnlyParentGenres` | **unchanged** | read directly, `== true` | JS |
+
+### C# read-side fold (the ONE place new + legacy combine)
+
+```
+IncludeParentTags == true    OR IncludeParentSeriesTags == true    OR IncludeParentAlbumTags == true    -> IncludeParentTagsEffective
+IncludeParentStudios == true OR IncludeParentSeriesStudios == true OR IncludeParentAlbumStudios == true -> IncludeParentStudiosEffective
+IncludeParentGenres == true  OR IncludeParentSeriesGenres == true  OR IncludeParentAlbumGenres == true  -> IncludeParentGenresEffective
+```
+
+There are exactly **four** consumers, and all four read the fold, never the raw flags:
+
+1. `Engine.BuildParentAwareListExpression` (Engine.cs:225/236/247)
+2. `SmartList.IsParentAwareListExpression` (SmartList.cs:66-71)
+3. `SmartList.GenerateRuleSetHash` (SmartList.cs:477-493)
+4. `SmartList.FieldRequirements.Analyze` (SmartList.cs:3764-3769)
+
+### Runtime-only renames (never serialized, safe to change)
+
+| Old | New |
+|---|---|
+| `Operand.ParentSeriesTags` + `Operand.ParentAlbumTags` | `Operand.ParentTags` |
+| `Operand.ParentSeriesStudios` + `Operand.ParentAlbumStudios` | `Operand.ParentStudios` |
+| `Operand.ParentSeriesGenres` + `Operand.ParentAlbumGenres` | `Operand.ParentGenres` |
+| `ExtractionGroup.ParentSeriesTags` (1<<8) + `ParentAlbumTags` (1<<22) | `ExtractionGroup.ParentTags` (1<<8) |
+| `ExtractionGroup.ParentSeriesStudios` (1<<9) + `ParentAlbumStudios` (1<<23) | `ExtractionGroup.ParentStudios` (1<<9) |
+| `ExtractionGroup.ParentSeriesGenres` (1<<10) + `ParentAlbumGenres` (1<<21) | `ExtractionGroup.ParentGenres` (1<<10) |
+| `RefreshCache.{Series,Album}{Tags,Studios,Genres}ById` (6 dicts) | `RefreshCache.AncestorValuesById` (1 dict) |
+
+### Semantics explicitly preserved
+
+- `OnlyParentX = true` **with** a source → ancestors only. Unchanged.
+- `OnlyParentX = true` **without** any source → still compiles to `Expression.Constant(false)` (Engine.cs:289-292). Both UI writers now always emit the Include flag alongside `OnlyParent`, so the state is unreachable from the UI; the branch survives as a safety net for hand-edited JSON and API consumers. `EngineOperatorTests.cs:947-954` survives with only a property rename.
+- The six non-regex operators are provably identical across the 2-lists → 1-list collapse: `AnyItemEquals`/`AnyItemContains`/`AnyItemIsInList` are `list.Any(pred)` with null/empty → false, so `P(A) OR P(B) == P(A ∪ B)` and by De Morgan `¬P(A) AND ¬P(B) == ¬P(A ∪ B)`. **Keeping `BuildCombinedStringEnumerableExpression` (Engine.cs:316-346) completely unchanged is what guarantees this.**
+
+### Two intended behaviour changes (release notes, not just docs)
+
+1. Existing episode/audio lists with the option enabled **change contents on first refresh**. Positive operators (`Equal`, `Contains`, `IsIn`, `MatchRegex`) **gain** items (Season, physical-folder, library, and for audio MusicArtist-folder values now count). Negative operators (`NotEqual`, `NotContains`, `IsNotIn`) **lose** items, because they AND-fold. Also, a saved `IncludeParentSeriesTags` on an Audio-only list yields `[]` today and starts matching after the change.
+2. `MatchRegex` is the one operator whose result can change on the *fold* itself. `AnyRegexMatch` (Engine.cs:1685-1692) is not a pure existential — for an **empty** list it tests the pattern against `string.Empty`. Today an episode rule OR-folds three terms and the permanently-empty `ParentAlbumTags` term makes any pattern matching `""` (`^$`, `.*`, negative lookaheads) match everything. Two terms shrink that surface: `Tags MatchRegex ^$ (include parent)` now matches only when both the item's own and its ancestors' tags are empty.
+
+---
+
+## File Structure
+
+```
+Jellyfin.Plugin.SmartLists/
+├── Core/QueryEngine/
+│   ├── AncestorValueResolver.cs      NEW  (AncestorValues + AncestorValueResolver)
+│   ├── Expression.cs                 +3 flags, +3 folds, comment-only edits on 6 legacy
+│   ├── Operand.cs                    6 lists -> 3, typed IReadOnlyList<string>
+│   ├── Engine.cs                     builders lose 2 params; 2 dead helpers deleted
+│   ├── Factory.cs                    6 extractors + 2 helpers + 2 caches deleted; 1 added
+│   └── FieldRegistry.cs              6 bits -> 3, doc header collapsed
+├── Core/SmartList.cs                 4 consumption sites repointed
+├── Services/Shared/RefreshQueueService.cs   6 dicts -> 1; per-queue-item clear
+└── Configuration/
+    ├── config-rules.js               markup strings, updaters gutted, serialize, deserialize
+    ├── config-lists.js               rule summary suffixes
+    └── config-init.js                stale comment only
+
+Jellyfin.Plugin.SmartLists.Tests/
+├── Support/TestItems.cs              stub gains GetCollectionFolders; chained builders
+├── Core/QueryEngine/EngineOperatorTests.cs   5 tests renamed to new members
+└── Core/QueryEngine/AncestorWalkTests.cs     NEW
+```
+
+---
+
+## Task 1: New file — `AncestorValues` + `AncestorValueResolver`
+
+**Files:**
+- Create: `Jellyfin.Plugin.SmartLists/Core/QueryEngine/AncestorValueResolver.cs`
+
+**Interfaces:**
+- Consumes: `MediaBrowser.Controller.Entities.BaseItem`, `MediaBrowser.Controller.Library.ILibraryManager`, `Microsoft.Extensions.Logging.ILogger`.
+- Produces: `public sealed class AncestorValues` (Task 2 exposes it on a public property; Task 4 assigns it to `Operand`) and `internal static class AncestorValueResolver` with the single entry point `Resolve`.
+
+- [ ] **Step 1: Write `AncestorValues`**
+
+```csharp
+/// <summary>
+/// Ancestor-inherited Tags/Studios/Genres for one node of the item tree.
+/// IMMUTABLE: instances are shared across operands via the per-refresh memo and are
+/// assigned to Operand properties BY REFERENCE. Members are IReadOnlyList so that
+/// mutation is a compile error rather than a comment-enforced convention — Empty is a
+/// process-lifetime singleton and a stray mutation would corrupt every list, for every
+/// user, for the rest of the process.
+/// </summary>
+public sealed class AncestorValues
+{
+    public static readonly AncestorValues Empty = new([], [], []);
+
+    public IReadOnlyList<string> Tags { get; }
+    public IReadOnlyList<string> Studios { get; }
+    public IReadOnlyList<string> Genres { get; }
+
+    private AncestorValues(IReadOnlyList<string> tags, IReadOnlyList<string> studios, IReadOnlyList<string> genres)
+    {
+        Tags = tags;
+        Studios = studios;
+        Genres = genres;
+    }
+
+    /// <summary>
+    /// Returns a NEW instance holding this instance's values plus the node's own
+    /// Tags/Studios/Genres. Returns <c>this</c> unchanged when the node contributes
+    /// nothing, so a chain of value-less folders allocates nothing.
+    /// </summary>
+    public AncestorValues Union(BaseItem node) { /* see step 2 */ }
+}
+```
+
+Requirements for the public `Empty` singleton: `IReadOnlyList<string> x = []` target-types to an empty collection — that is a non-null empty list, which matters because `AnyRegexMatch`'s empty-list branch runs for empty but **not** for null.
+
+- [ ] **Step 2: Write `Union`**
+
+`BaseItem` is nullable-**oblivious** in both ABIs (no `NullableContextAttribute`), so `node.Tags` is declared `string[]` yet can be null and **nothing warns** under `Nullable=enable` + `TreatWarningsAsErrors`. Null-guard each of the three arrays individually.
+
+De-duplicate with **`StringComparer.Ordinal`**, not `OrdinalIgnoreCase`. Put this comment on the line:
+
+```csharp
+// Ordinal, deliberately NOT OrdinalIgnoreCase (which is what core's GetInheritedTags uses).
+// Six of the seven operators are OrdinalIgnoreCase so dedup strength is invisible to them,
+// but MatchRegex is case-SENSITIVE (GetOrCreateRegex passes RegexOptions.None) — case-insensitive
+// dedup could discard the only casing a pattern would have matched.
+```
+
+Return `this` when all three of the node's arrays are null/empty.
+
+- [ ] **Step 3: Write `AncestorValueResolver`**
+
+```csharp
+internal static class AncestorValueResolver
+{
+    // Runaway/cycle insurance ONLY; it must never bind. Measured real depth in the dev
+    // library is 4 (episode->season->series->folder), 2 (movie), 3 (audio);
+    // /music/Artist/Album/Disc/track reaches 5 and deep genre trees maybe 7.
+    // Do NOT "tighten" this to 10 — a binding cap produces truncated results.
+    private const int MaxAncestorDepth = 20;
+
+    /// <summary>
+    /// Ancestor-inherited values for <paramref name="item"/>, EXCLUDING the item's own
+    /// values (Engine unions the item's own field separately).
+    ///
+    /// The walk is: parent chain (stopping BEFORE AggregateFolder/UserRootFolder/UserView)
+    /// UNION libraryManager.GetCollectionFolders(chainTop). The second half is NOT optional:
+    /// a CollectionFolder (a Jellyfin library) is never in the ParentId chain — it hangs off
+    /// the UserRootFolder as a sibling structure — so a parents-only walk finds season tags
+    /// but never library tags. Core's BaseItem.GetInheritedTags()/GetAncestorIds() have the
+    /// same two-part shape.
+    ///
+    /// COST: the memo is keyed on the IMMEDIATE PARENT id and is consulted BEFORE any parent
+    /// is materialized, so a hit costs one dictionary lookup and ZERO ILibraryManager calls —
+    /// parity with the code this replaces. A miss costs O(distinct containers) GetItemById
+    /// plus one GetCollectionFolders path-scan per top physical folder.
+    /// NOTE: when a list's ONLY rule is parent-aware, SmartList takes the expensive-only path
+    /// (SmartList.cs:3026) and this runs once per CANDIDATE item, not per Phase-2 survivor.
+    /// </summary>
+    internal static AncestorValues Resolve(
+        BaseItem item,
+        ILibraryManager libraryManager,
+        ConcurrentDictionary<Guid, AncestorValues> memo,
+        ILogger? logger)
+    {
+        // MEMO-FIRST on the raw ParentId Guid — do NOT call GetParent() before this line.
+        // GetParent() is `ParentId.IsEmpty() ? null : LibraryManager.GetItemById(ParentId)`,
+        // so materializing the parent first would cost a library round-trip per ITEM.
+        var parentId = item.ParentId;
+        if (!parentId.IsEmpty() && memo.TryGetValue(parentId, out var cached))
+        {
+            return cached;
+        }
+
+        var node = item.GetParent() ?? item.GetOwner();   // GetOwner() covers extras (empty ParentId, set OwnerId)
+        if (node is null || IsWalkBoundary(node))
+        {
+            return AncestorValues.Empty;
+        }
+
+        var chain = new List<BaseItem>();
+        var visited = new HashSet<Guid>();
+        AncestorValues? seed = null;
+        var truncated = false;
+
+        while (node is not null && !IsWalkBoundary(node))
+        {
+            if (memo.TryGetValue(node.Id, out var hit)) { seed = hit; break; }
+            if (!visited.Add(node.Id) || chain.Count >= MaxAncestorDepth)
+            {
+                logger?.LogWarning(
+                    "SmartLists ancestor walk stopped early at '{Name}' ({Id}) - cycle or depth cap",
+                    node.Name, node.Id);
+                truncated = true;
+                break;
+            }
+            chain.Add(node);
+            node = node.GetParent() ?? node.GetOwner();
+        }
+
+        if (seed is null)
+        {
+            // Library values are resolved from the deepest node reached. GetCollectionFolders
+            // walks independently of our chain, so it is valid (and required) even when the
+            // chain was truncated — dropping it on truncation would silently reproduce #495.
+            seed = GetLibraryValues(chain[^1], libraryManager, logger);
+        }
+
+        var acc = seed;
+        for (var i = chain.Count - 1; i >= 0; i--)
+        {
+            acc = acc.Union(chain[i]);
+
+            // NEVER memoize a truncated (partial) result. A truncated walk is missing the TOP
+            // of the chain, so caching it would make later walks return a value that depends on
+            // WHICH ITEM WARMED THE CACHE FIRST (an episode 4 levels down vs a series 1 level down).
+            if (!truncated) { memo[chain[i].Id] = acc; }
+        }
+
+        return acc;
+    }
+
+    private static bool IsWalkBoundary(BaseItem node)
+        => node is AggregateFolder || node is UserRootFolder || node is UserView;
+
+    private static AncestorValues GetLibraryValues(BaseItem anchor, ILibraryManager libraryManager, ILogger? logger)
+    {
+        try
+        {
+            var acc = AncestorValues.Empty;
+            foreach (var folder in libraryManager.GetCollectionFolders(anchor)) { acc = acc.Union(folder); }
+            return acc;
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex, "SmartLists failed to resolve library values for '{Name}'", anchor.Name);
+            return AncestorValues.Empty;
+        }
+    }
+}
+```
+
+Hard constraints for the implementer:
+- `AncestorValues` **must** be `public sealed class` (Task 2 exposes it on a public property — `internal` produces `CS0053`).
+- Use the **1-arg** `GetCollectionFolders(BaseItem)` overload. It is already used at `Factory.cs:3925`, so it is proven to compile on both ABIs.
+- Never call `BaseItem.GetAncestorIds()` or `GetInheritedTags()` — both reach `GetCollectionFolders` in a way the test stub throws on, `GetInheritedTags` has no Studios/Genres counterpart, and it unions the item's own tags in.
+- Never reuse `Factory._knownUnsupportedTypes` (Factory.cs:219-222) as the boundary test — it is a log-noise filter used at exactly one site (:3504), it omits `UserView` and `PlaylistsFolder`, and it includes plain `Folder`, which the walk **must** traverse.
+- **No negative caching.** A `GetItemById` miss simply makes `GetParent()` return null, ending the chain, which still yields the library values via the seed. Do not write `Empty` into the memo on failure (the six extractors did that at Factory.cs:2223/2285/2347 and 2019; with recursive memoization that would poison a whole subtree).
+
+- [ ] **Step 4: Build**
+
+Run: `cd dev && ./build-local.sh`
+Expected: succeeds with the file compiling standalone (nothing references it yet). Watch CA1822 and CA1305 on the new logging calls.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Jellyfin.Plugin.SmartLists/Core/QueryEngine/AncestorValueResolver.cs
+git commit -m "Add memoized ancestor value walk (parents + library folders)"
+```
+
+---
+
+## Task 2: RefreshCache — one memo, cleared per queue item
+
+**Files:**
+- Modify: `Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs` (~lines 738-743, and `ProcessQueueItemAsync` at ~224-298)
+
+**Interfaces:**
+- Consumes: `AncestorValues` (Task 1).
+- Produces: `RefreshCache.AncestorValuesById`. Task 4 writes and reads it.
+
+- [ ] **Step 1: Swap the six dicts for one**
+
+Delete these six lines (RefreshQueueService.cs:738-743):
+
+```csharp
+            public ConcurrentDictionary<Guid, List<string>> SeriesTagsById { get; } = new();
+            public ConcurrentDictionary<Guid, List<string>> SeriesStudiosById { get; } = new();
+            public ConcurrentDictionary<Guid, List<string>> SeriesGenresById { get; } = new();
+            public ConcurrentDictionary<Guid, List<string>> AlbumGenresById { get; } = new();
+            public ConcurrentDictionary<Guid, List<string>> AlbumTagsById { get; } = new();
+            public ConcurrentDictionary<Guid, List<string>> AlbumStudiosById { get; } = new();
+```
+
+Replace with:
+
+```csharp
+            /// <summary>
+            /// Ancestor-inherited Tags/Studios/Genres, keyed by the ANCESTOR NODE id (season id,
+            /// album id, folder id) — never the item id — so every episode of a season is a single
+            /// lookup and the walk itself runs once per container. Each entry is the COMPLETE union
+            /// for that node and everything above it INCLUDING the library CollectionFolder, so a
+            /// memo hit needs no further work. Cleared per queue item (see ProcessQueueItemAsync)
+            /// rather than per queue drain: entries embed everything above them, so a stale entry
+            /// after a retag would otherwise affect a whole subtree until the queue emptied.
+            /// </summary>
+            public ConcurrentDictionary<Guid, AncestorValues> AncestorValuesById { get; } = new();
+```
+
+Leave `SeriesNameById` (:736) and `SeriesSortNameById` (:737) **untouched** — they belong to `ExtractSeriesName` and to sorting. Add `using Jellyfin.Plugin.SmartLists.Core.QueryEngine;` if absent (verified: no name collision).
+
+- [ ] **Step 2: Clear the memo per queue item**
+
+`ProcessQueueItemAsync` (~line 224) currently has `try` / `catch(OperationCanceledException)` / `catch(Exception)` and **no** `finally`. Add one after the last catch block (~line 297):
+
+```csharp
+            finally
+            {
+                // Bound ancestor-memo staleness to a single list refresh. RefreshCache itself is
+                // per-user and survives until the whole queue drains, but each AncestorValuesById
+                // entry embeds every value above it, so a season/library retag would otherwise
+                // stay invisible across an entire batch. Rebuilding costs one walk per container.
+                foreach (var cache in _refreshCaches.Values)
+                {
+                    cache.AncestorValuesById.Clear();
+                }
+            }
+```
+
+- [ ] **Step 3: Build and commit**
+
+```bash
+cd dev && ./build-local.sh
+git add Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
+git commit -m "Replace six parent-value caches with one ancestor memo, cleared per queue item"
+```
+
+(The build will fail until Task 4 removes the extractors that reference the deleted dicts. If executing tasks in isolation, run `dotnet build` and accept only errors naming `SeriesTagsById`/`AlbumTagsById`/etc. in `Factory.cs`; verify no other file references them: `grep -rn 'SeriesTagsById\|SeriesStudiosById\|SeriesGenresById\|AlbumTagsById\|AlbumStudiosById\|AlbumGenresById' --include='*.cs' .` should hit only `Factory.cs`.)
+
+---
+
+## Task 3: FieldRegistry — six extraction bits become three
+
+**Files:**
+- Modify: `Jellyfin.Plugin.SmartLists/Core/QueryEngine/FieldRegistry.cs` (~lines 50-55, 74-82)
+
+**Interfaces:**
+- Produces: `ExtractionGroup.ParentTags`, `ParentStudios`, `ParentGenres`. Tasks 4 and 8 consume them.
+
+- [ ] **Step 1: Collapse the enum members**
+
+Delete lines 74-76 (`ParentSeriesTags = 1 << 8`, `ParentSeriesStudios = 1 << 9`, `ParentSeriesGenres = 1 << 10`) and lines 80-82 (`ParentAlbumGenres = 1 << 21`, `ParentAlbumTags = 1 << 22`, `ParentAlbumStudios = 1 << 23`). At the `1 << 8` position, **inside the expensive block** (above the `// Cheap extraction groups` comment at line 84), insert:
+
+```csharp
+        ParentTags = 1 << 8,          // Fields: Tags (with IncludeParentTags) | Cache: AncestorValuesById
+        ParentStudios = 1 << 9,       // Fields: Studios (with IncludeParentStudios) | Cache: AncestorValuesById
+        ParentGenres = 1 << 10,       // Fields: Genres (with IncludeParentGenres) | Cache: AncestorValuesById
+```
+
+Add `// (1 << 21 .. 1 << 23 free)` next to `ExternalLists = 1 << 20`. Renumbering is safe: `ExtractionGroup` is never serialized (only `RandomGroupSelectionDto` maps a string to a group).
+
+- [ ] **Step 2: Collapse the doc header**
+
+Replace the six `CACHING REQUIREMENTS BY GROUP` lines at 50-55 with three naming `AncestorValuesById`, and fix their stray 8-space indentation to the 4-space of their neighbours.
+
+- [ ] **Step 3: Do NOT touch two things**
+
+- Do **not** add the new bits to `CheapExtractionGroups` (:168-171). If they leak in, `phase1Groups` (SmartList.cs:3174) stops deferring and the walk runs for every candidate item unconditionally.
+- Do **not** touch the `Genres` / `Studios` / `Tags` field registrations at :281-283 — they stay `ExtractionGroup.ItemLists` (cheap), which is what keeps `FieldRegistryInvariantTests.cs:468-469` green with no edits.
+
+- [ ] **Step 4: Verify and commit**
+
+```bash
+dotnet test --filter FullyQualifiedName~FieldRegistryInvariantTests
+```
+Expected: `IsExpensiveField_PinsTheKnownTierOfEachExtractionGroup` and `ExtractionGroupMembership_MatchesEachFieldsDeclaredFlags` pass with **zero** edits to that test file. If either needed editing, the tier boundary was moved by mistake.
+
+```bash
+git add Jellyfin.Plugin.SmartLists/Core/QueryEngine/FieldRegistry.cs
+git commit -m "Collapse six parent extraction groups into ParentTags/ParentStudios/ParentGenres"
+```
+
+---
+
+## Task 4: Factory — delete six extractors, add one
+
+**Files:**
+- Modify: `Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs`
+
+**Interfaces:**
+- Consumes: `AncestorValueResolver.Resolve` (Task 1), `RefreshCache.AncestorValuesById` (Task 2), `ExtractionGroup.Parent*` (Task 3).
+- Produces: `MediaTypeExtractionOptions.ExtractParentTags/ExtractParentStudios/ExtractParentGenres`; writes `Operand.ParentTags/ParentStudios/ParentGenres` (Task 5).
+
+- [ ] **Step 1: Delete**
+
+| What | Location |
+|---|---|
+| `ExtractParentSeriesTags` | 2180-2236 |
+| `ExtractParentSeriesStudios` | 2242-2298 |
+| `ExtractParentSeriesGenres` | 2304-2360 |
+| `ExtractParentAlbumGenres` | 2366-2415 |
+| `ExtractParentAlbumTags` | 2421-2470 |
+| `ExtractParentAlbumStudios` | 2476-2525 |
+| `TryGetAudioAlbumGuid` | 1942-1957 (no other caller) |
+| `GetOrFetchParentValues` + `TryResolveParentKey` delegate | 1987-2022 (the album trio was its only user) |
+| `_albumIdPropertyCache`, `_parentIdPropertyCache` | 321-322 (orphaned by the above) |
+
+**Do NOT delete** `TryGetEpisodeSeriesGuid` (1923-1936), `TryExtractGuid` (1959-1985) or `_seriesIdPropertyCache` (320) — `ExtractSeriesName` (2035) and the NextUnwatched path (3412) still use them, and reusing `SeriesId` in the walk would re-introduce the exact Season-skip that **is** bug #495. Leave `ExtractSeriesName`/`ResolveAndCacheSeriesName`/`ExtractSeriesNameFromExtra` (2029-2107) and `ExtractLibraryNames` (3909-3957) entirely untouched.
+
+- [ ] **Step 2: Collapse the options bools** (Factory.cs:97-131)
+
+Replace the six get/set-over-a-bit properties with three:
+
+```csharp
+        public bool ExtractParentTags
+        {
+            get => RequiredGroups.HasFlag(ExtractionGroup.ParentTags);
+            set => RequiredGroups = value ? RequiredGroups | ExtractionGroup.ParentTags : RequiredGroups & ~ExtractionGroup.ParentTags;
+        }
+```
+
+…and the `ParentStudios` / `ParentGenres` equivalents.
+
+- [ ] **Step 3: Add the single extractor**
+
+```csharp
+        /// <summary>
+        /// Resolves ancestor-inherited Tags/Studios/Genres in ONE walk and assigns only the
+        /// requested lists. Assignment is BY REFERENCE — AncestorValues is immutable and its
+        /// members are IReadOnlyList, so sharing across operands is safe and allocation-free.
+        /// </summary>
+        private static void ExtractAncestorValues(
+            Operand operand,
+            BaseItem baseItem,
+            ILibraryManager libraryManager,
+            RefreshQueueService.RefreshCache cache,
+            ILogger? logger,
+            bool wantTags,
+            bool wantStudios,
+            bool wantGenres)
+        {
+            try
+            {
+                var values = AncestorValueResolver.Resolve(baseItem, libraryManager, cache.AncestorValuesById, logger);
+                if (wantTags) { operand.ParentTags = values.Tags; }
+                if (wantStudios) { operand.ParentStudios = values.Studios; }
+                if (wantGenres) { operand.ParentGenres = values.Genres; }
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex, "SmartLists failed to resolve ancestor values for '{Name}'", baseItem.Name);
+            }
+        }
+```
+
+- [ ] **Step 4: Replace the four hoisted locals** (Factory.cs:2877-2880)
+
+Replace `extractParentSeriesTags` / `extractParentSeriesStudios` / `extractParentSeriesGenres` / `extractParentAlbumGenres` with three: `extractParentTags`, `extractParentStudios`, `extractParentGenres`. Do **not** reproduce the existing asymmetry where `ParentAlbumTags`/`ParentAlbumStudios` were read as `options.*` directly at 3354/3365.
+
+- [ ] **Step 5: Replace the six dispatch blocks with one** (Factory.cs:3308-3372)
+
+```csharp
+            // Ancestor-inherited Tags/Studios/Genres (season/series/album/artist/folder/library).
+            // Expensive (tree walk + library lookup), so gated on the requirement flags and
+            // memoized per ancestor node. The else-branch reset is load-bearing: Phase 1 builds
+            // its operand with the parent groups masked off, and must never see stale values.
+            if (extractParentTags || extractParentStudios || extractParentGenres)
+            {
+                ExtractAncestorValues(operand, baseItem, libraryManager, cache, logger,
+                    extractParentTags, extractParentStudios, extractParentGenres);
+            }
+
+            if (!extractParentTags) { operand.ParentTags = []; }
+            if (!extractParentStudios) { operand.ParentStudios = []; }
+            if (!extractParentGenres) { operand.ParentGenres = []; }
+```
+
+There are **no** `is not Episode` / `is not Audio` guards — dropping them **is** the all-media-types broadening.
+
+- [ ] **Step 6: Verify and commit**
+
+```bash
+cd dev && ./build-local.sh
+grep -n 'ParentSeriesTags\|ParentAlbumTags\|ParentSeriesStudios\|ParentAlbumStudios\|ParentSeriesGenres\|ParentAlbumGenres\|GetOrFetchParentValues\|TryGetAudioAlbumGuid\|_albumIdPropertyCache\|_parentIdPropertyCache' Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
+grep -n 'TryGetEpisodeSeriesGuid' Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
+```
+Expected: the first grep returns **nothing**; the second still returns its definition plus the `ExtractSeriesName` and NextUnwatched call sites.
+
+```bash
+git add Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
+git commit -m "Replace six one-level parent extractors with one ancestor walk"
+```
+
+---
+
+## Task 5: Operand — six parent lists become three
+
+**Files:**
+- Modify: `Jellyfin.Plugin.SmartLists/Core/QueryEngine/Operand.cs` (lines 28-33)
+
+- [ ] **Step 1: Replace**
+
+```csharp
+        public IReadOnlyList<string> ParentTags { get; set; } = [];
+        public IReadOnlyList<string> ParentStudios { get; set; } = [];
+        public IReadOnlyList<string> ParentGenres { get; set; } = [];
+```
+
+Notes:
+- `IReadOnlyList<string>` (not `List<string>`) so the shared, process-lifetime `AncestorValues.Empty` singleton cannot be mutated through an operand. Every Engine consumer takes `IEnumerable<string>` (`AnyItemEquals`/`AnyItemContains`/`AnyItemIsInList`/`AnyRegexMatch`, Engine.cs:1534/1554/1667/1729), and `IReadOnlyList<string>` is reference-assignable to `IEnumerable<string>`, so `Expression.Call` argument validation succeeds unchanged.
+- The `= []` initializers are **load-bearing**, not cosmetic: `AnyRegexMatch`'s empty-list branch tests the pattern against `string.Empty`, whereas a null list returns false — null and empty are observably different for `MatchRegex`.
+- Engine reaches these **only** via `Expression.PropertyOrField(param, "<literal>")`, so a spelling mismatch with Engine's string literals compiles clean and throws `ArgumentException` at rule-compile time (per refresh), never at build time. Task 9 adds the test that catches it.
+
+- [ ] **Step 2: Build**
+
+The build now fails **only** in `EngineOperatorTests` object initializers. That compile failure is the intended guard rail; Task 9 fixes it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Jellyfin.Plugin.SmartLists/Core/QueryEngine/Operand.cs
+git commit -m "Collapse six Operand parent lists into ParentTags/ParentStudios/ParentGenres"
+```
+
+---
+
+## Task 6: Expression — three new flags plus three folds (purely additive)
+
+**Files:**
+- Modify: `Jellyfin.Plugin.SmartLists/Core/QueryEngine/Expression.cs`
+
+**Interfaces:**
+- Produces: `IncludeParentTags`/`IncludeParentStudios`/`IncludeParentGenres` (persisted) and `IncludeParentTagsEffective`/`IncludeParentStudiosEffective`/`IncludeParentGenresEffective` (computed). Tasks 7 and 8 read only the `*Effective` folds.
+
+- [ ] **Step 1: Insert the three new flags**
+
+Immediately after `OnlyParentGenres` (~line 65), matching the surrounding style exactly:
+
+```csharp
+        // Tags-specific option: also match values inherited from ancestors (season, series, album, folder, library) - only serialize when meaningful
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? IncludeParentTags { get; set; } = null;
+
+        // Studios-specific option: also match values inherited from ancestors - only serialize when meaningful
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? IncludeParentStudios { get; set; } = null;
+
+        // Genres-specific option: also match values inherited from ancestors - only serialize when meaningful
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? IncludeParentGenres { get; set; } = null;
+```
+
+- [ ] **Step 2: Insert the three folds directly after them**
+
+```csharp
+        // Legacy parent flags fold into these. This is the ONLY place new + legacy are combined —
+        // Engine, IsParentAwareListExpression, GenerateRuleSetHash and FieldRequirements.Analyze
+        // all read these, never the raw flags.
+        [JsonIgnore]
+        public bool IncludeParentTagsEffective => IncludeParentTags == true || IncludeParentSeriesTags == true || IncludeParentAlbumTags == true;
+
+        [JsonIgnore]
+        public bool IncludeParentStudiosEffective => IncludeParentStudios == true || IncludeParentSeriesStudios == true || IncludeParentAlbumStudios == true;
+
+        [JsonIgnore]
+        public bool IncludeParentGenresEffective => IncludeParentGenres == true || IncludeParentSeriesGenres == true || IncludeParentAlbumGenres == true;
+```
+
+Use plain `[JsonIgnore]`, **not** `WhenWritingDefault` — these are get-only so STJ never binds them, and they must never be written.
+
+- [ ] **Step 3: Comment-only edits on the six legacy flags**
+
+Change **only** the `//` comments above `IncludeParentSeriesTags` (33), `IncludeParentAlbumTags` (37), `IncludeParentSeriesStudios` (45), `IncludeParentAlbumStudios` (49), `IncludeParentSeriesGenres` (57), `IncludeParentAlbumGenres` (61) to:
+
+```csharp
+        // Legacy - read via IncludeParent*Effective, still written by the UI for downgrade
+        // compatibility. Do NOT remove: this is an on-disk JSON key.
+```
+
+Touch **nothing** about `OnlyParentTags` (41), `OnlyParentStudios` (53), `OnlyParentGenres` (65).
+
+- [ ] **Step 4: Build and commit**
+
+```bash
+cd dev && ./build-local.sh
+git add Jellyfin.Plugin.SmartLists/Core/QueryEngine/Expression.cs
+git commit -m "Add IncludeParent{Tags,Studios,Genres} plus legacy-folding Effective properties"
+```
+
+---
+
+## Task 7: Engine — repoint the builders, delete two dead helpers
+
+**Files:**
+- Modify: `Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs`
+
+- [ ] **Step 1: `BuildParentAwareListExpression`** (223-259)
+
+Keep the three `if` blocks and the `ModelExpression r` parameter name. Each now passes a single parent field and a single include flag:
+
+```csharp
+            if (r.MemberName == "Tags")
+            {
+                return BuildParentAwareFieldExpression(r, param, logger,
+                    baseField: "Tags",
+                    parentField: "ParentTags",
+                    onlyParent: r.OnlyParentTags == true,
+                    includeParent: r.IncludeParentTagsEffective);
+            }
+```
+
+…and the `Studios` → `"ParentStudios"` / `r.OnlyParentStudios` / `r.IncludeParentStudiosEffective` and `Genres` → `"ParentGenres"` / `r.OnlyParentGenres` / `r.IncludeParentGenresEffective` equivalents. Keep the `== true` coercion on `OnlyParentX` so null and false stay identical.
+
+- [ ] **Step 2: `BuildParentAwareFieldExpression`** (266-305)
+
+Drop the `parentSeriesField`/`parentAlbumField` pair for a single `parentField`, and drop `includeParentAlbum`. The field list becomes `[parentField]` for only-parent and `[baseField, parentField]` for include.
+
+**KEEP verbatim**: the `System.Linq.Expressions.Expression.Constant(false)` branch at 289-292 and its XML doc at 262-265. `OnlyParentX = true` with no source still matches nothing.
+
+- [ ] **Step 3: Leave three things COMPLETELY unchanged**
+
+- `BuildCombinedStringEnumerableExpression` (316-346). Its per-field OR/AND fold with `isNegativeOperator = NotEqual|NotContains|IsNotIn` is precisely what makes the collapse provably safe for the six non-regex operators. `Aggregate` over a one-element list returns that element, so the only-parent case needs nothing special.
+- `BuildStringEnumerableExpression` (1272-1360), including its `MemberExpression` parameter type — folding two terms needs no widening.
+- The `BuildExpr` hook at line 144.
+
+- [ ] **Step 4: Delete two dead helpers**
+
+`OnlyCombinedItemEquals` (1643-1653) and `AnyCombinedItemEquals` (1660-1665). Zero callers, not resolved by any `GetMethod` string — **and their XML docs falsely claim to implement this exact parent path**, so leaving them will mislead the next reader into thinking the old two-list design is still live. Say that in the commit message.
+
+Do **not** touch `OnlyItemEquals`/`OnlyCollectionEquals`/`OnlyPlaylistEquals` (1595/1603/1611) — production-unreferenced but exercised by `EngineInternalsTests`, pre-existing and unrelated.
+
+- [ ] **Step 5: Build and commit**
+
+```bash
+cd dev && ./build-local.sh
+git add Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
+git commit -m "Point parent-aware builders at the single ancestor field; drop two dead combined helpers whose docs misdescribed this path"
+```
+
+---
+
+## Task 8: SmartList — the four consumption sites
+
+**Files:**
+- Modify: `Jellyfin.Plugin.SmartLists/Core/SmartList.cs`
+
+> This task carries the highest silent-breakage risk in the change. All four edits are compile-clean if wrong; only the tests in Task 9 catch them.
+
+- [ ] **Step 1: `IsParentAwareListExpression`** (66-71) — THE critical edit
+
+```csharp
+        private static bool IsParentAwareListExpression(Expression expr)
+        {
+            return (expr.MemberName == "Tags" && (expr.IncludeParentTagsEffective || expr.OnlyParentTags == true)) ||
+                   (expr.MemberName == "Studios" && (expr.IncludeParentStudiosEffective || expr.OnlyParentStudios == true)) ||
+                   (expr.MemberName == "Genres" && (expr.IncludeParentGenresEffective || expr.OnlyParentGenres == true));
+        }
+```
+
+Why this matters: Tags/Studios/Genres are registered `ItemLists` (cheap), so `FieldRegistry.IsExpensiveField("Tags")` is **false**, and this hardcoded predicate is the **only** thing promoting a parent-aware rule to the expensive tier. Miss it and the rule lands in `cheapCompiledRules` (:3003), is evaluated in Phase 1 against an operand whose `ParentTags` Factory reset to `[]` (phase1Groups masking at :3174), and matches **nothing** — no exception, no log, a fresh instance of #495.
+
+- [ ] **Step 2: `GenerateRuleSetHash`** (477-493) — exact replacement
+
+Delete the nine `Append` pairs and replace with **exactly** these six, keeping the surrounding `hashBuilder.Append(':');` separators and the position between `UserId` (:475) and `IncludeCollectionOnly` (:495):
+
+```csharp
+                        hashBuilder.Append(':');
+                        hashBuilder.Append(expr.IncludeParentTagsEffective);
+                        hashBuilder.Append(':');
+                        hashBuilder.Append(expr.OnlyParentTags?.ToString() ?? "null");
+                        hashBuilder.Append(':');
+                        hashBuilder.Append(expr.IncludeParentStudiosEffective);
+                        hashBuilder.Append(':');
+                        hashBuilder.Append(expr.OnlyParentStudios?.ToString() ?? "null");
+                        hashBuilder.Append(':');
+                        hashBuilder.Append(expr.IncludeParentGenresEffective);
+                        hashBuilder.Append(':');
+                        hashBuilder.Append(expr.OnlyParentGenres?.ToString() ?? "null");
+```
+
+Notes:
+- Folding to a non-nullable `bool` is safe here **because the fold is a total function of behaviour**: two expressions that fold identically compile identically, so they may share a cache entry.
+- Keep the surviving `OnlyParentX` in their existing `?.ToString() ?? "null"` form.
+- `Id` is already in the key (SmartList.cs:423), so there is no cross-list collision.
+- Forgetting any of these produces a stale-compiled-rule bug that only reproduces **without** a Jellyfin restart: `_ruleCache` (SmartList.cs:50) is process-static, holds up to 1000 entries and cleans up no more often than every 5 minutes, so it will not self-heal.
+
+- [ ] **Step 3: `FieldRequirements` accessors** (3696-3701)
+
+Six become three:
+
+```csharp
+            public bool NeedsParentTags => RequiredGroups.HasFlag(ExtractionGroup.ParentTags);
+            public bool NeedsParentStudios => RequiredGroups.HasFlag(ExtractionGroup.ParentStudios);
+            public bool NeedsParentGenres => RequiredGroups.HasFlag(ExtractionGroup.ParentGenres);
+```
+
+(Nothing reads any of the six today; they are kept only because every other group in that block follows this convention.)
+
+- [ ] **Step 4: `FieldRequirements.Analyze`** (3764-3769)
+
+Six `AddParentGroupIfIncluded` calls become three:
+
+```csharp
+                    AddParentGroupIfIncluded(requirements, expr.MemberName, "Tags", expr.IncludeParentTagsEffective, ExtractionGroup.ParentTags);
+                    AddParentGroupIfIncluded(requirements, expr.MemberName, "Studios", expr.IncludeParentStudiosEffective, ExtractionGroup.ParentStudios);
+                    AddParentGroupIfIncluded(requirements, expr.MemberName, "Genres", expr.IncludeParentGenresEffective, ExtractionGroup.ParentGenres);
+```
+
+The helper at 3721-3730 takes `bool? includeFlag`, so the plain `bool` converts implicitly — **no signature change**. Reword the comment at 3761-3763 (`"OnlyParent* alone does NOT trigger extraction of both groups — use IncludeParent* to decide which"`) since there is no longer a "which"; the behaviour is unchanged and deliberate — `OnlyParent`-with-no-source compiles to constant-false and correctly requests no extraction.
+
+- [ ] **Step 5: Leave these untouched (verify only)**
+
+Two-phase entry decision (2929-2935), Phase-1 masking (3172-3181), per-rule split (2985-3006), `hasNonExpensiveRules` (1005-1019), and all four `FromRequirements` call sites (2533/3047/3258/3424) — all bit-count-agnostic. Confirm the two hand-built options objects (`DoesSeriesMatchCollectionsRules` 2330-2342, MaxPlayTime fallback 2874-2885) still leave the new flags off.
+
+- [ ] **Step 6: Build and commit**
+
+```bash
+cd dev && ./build-local.sh
+git add Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+git commit -m "Point expensiveness gate, rule-cache hash and requirement analysis at the folded parent flags"
+```
+
+---
+
+## Task 9: Tests
+
+**Files:**
+- Modify: `Jellyfin.Plugin.SmartLists.Tests/Support/TestItems.cs`
+- Modify: `Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/EngineOperatorTests.cs`
+- Create: `Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/AncestorWalkTests.cs`
+
+**Interfaces:**
+- Consumes everything from Tasks 1-8. `AncestorValueResolver` is `internal` and `InternalsVisibleTo` is already wired (`Jellyfin.Plugin.SmartLists.csproj:25`), so `Resolve` is directly reachable without stubbing `IUserManager`/`IUserDataManager`.
+
+- [ ] **Step 1: Extend `TestLibraryManager`** (TestItems.cs:30-49)
+
+The stub implements only `GetItemById` and throws `NotSupportedException` on everything else — a probe confirmed `GetInheritedTags()` and `GetAncestorIds()` both throw there today. Add **one** deliberate arm:
+
+```csharp
+        // Registered by CHAIN-TOP folder id — that is the anchor the resolver passes to
+        // GetCollectionFolders, and it is deliberately not the item id.
+        internal static readonly ConcurrentDictionary<Guid, List<Folder>> CollectionFolders = new();
+```
+
+…returning `CollectionFolders.TryGetValue(id, out var f) ? f : new List<Folder>()` for `GetCollectionFolders(BaseItem)`. Keep throw-by-default for everything else; that guard is deliberate ("if production code under test ever starts depending on more of the library manager, these tests must fail loudly").
+
+- [ ] **Step 2: Add chained fixture builders** (TestItems.cs, near 106-167)
+
+Nothing in `TestItems` currently produces an item whose `GetParent()` returns non-null — `Ep` (119-147) sets `SeriesId` but never `ParentId`, and `SeasonOf`/`Album` (151-165) are never registered in `TestLibraryManager.Items`. Add:
+
+```csharp
+        public static T Under<T>(T child, BaseItem parent) where T : BaseItem   // sets child.ParentId, registers BOTH in Items
+        public static Folder PhysicalFolder(string name, params string[] tags)
+```
+
+Constraints: use fresh `Guid.NewGuid()` (Items is process-wide and never cleared), set `Name` **before** `SortName` (reading an unset `SortName` throws NRE), terminate chains with a null parent rather than constructing an `AggregateFolder`, and return plain `Folder` instances with `Tags` from the `CollectionFolders` stub rather than a real `CollectionFolder`.
+
+- [ ] **Step 3: Rewrite the five existing tests** (EngineOperatorTests.cs:893-966)
+
+Rename members only; **assertions stay verbatim**.
+
+| Test | Change |
+|---|---|
+| `CompileRule_TagsIncludingParentSeries_OrsItemAndParentForPositiveOperators` | `IncludeParentSeriesTags` → `IncludeParentTags`; `Operand.ParentSeriesTags` → `ParentTags`. Rename to `..._TagsIncludingParent_...` |
+| `CompileRule_TagsIncludingParentSeries_AndsItemAndParentForNegativeOperators` | same rename. **Assertions must not change** — the positive-OR / negative-AND asymmetry is the one non-obvious semantic and must survive |
+| `CompileRule_TagsOnlyParentSeries_IgnoresTheItemsOwnTags` | `IncludeParentSeriesTags` + `OnlyParentTags` → `IncludeParentTags` + `OnlyParentTags` |
+| `CompileRule_TagsOnlyParentWithNoParentSource_MatchesNothing` | **KEPT AS-IS** apart from the member rename — that semantic is deliberately preserved |
+| `CompileRule_GenresIncludingParentAlbum_OrsItemAndParent` | `IncludeParentAlbumGenres` → `IncludeParentGenres`; `ParentAlbumGenres` → `ParentGenres` |
+
+- [ ] **Step 4: Add `AncestorWalkTests`** — named cases
+
+| # | Test name | What it proves |
+|---|---|---|
+| 1 | `Resolve_FindsTagSetOnTheSeason_TheLevelTheOldCodeSkipped` | episode → season → series → folder; the **season's** tag is returned. This is #495 proper. **Must FAIL if the walk is reverted to `SeriesId`.** |
+| 2 | `Resolve_UnionsLibraryFolderValues_NotReachableViaParentChain` | same chain, a tag registered on the stubbed `GetCollectionFolders(chainTop)` is returned. **Must FAIL if `GetCollectionFolders` is dropped from the resolver** — this is the half a parents-only walk would miss. |
+| 3 | `Resolve_CollectsTagsStudiosAndGenresInOneWalk` | all three kinds come back from a single call |
+| 4 | `Resolve_MemoHitCostsNoLibraryCalls` | second episode of the same season resolves from the memo; assert the stub's `GetItemById` call counter did not increase (proves the **`ParentId` memo-first** fix from Blocker 3) |
+| 5 | `Resolve_MemoizesOneEntryPerAncestorNode` | two episodes of one season → exactly one memo entry per ancestor, not per item |
+| 6 | `Resolve_CycleTerminatesAndWritesNoMemoEntries` | `A.ParentId=B`, `B.ParentId=A` → returns without hanging and `memo.Count == 0` |
+| 7 | `Resolve_TruncatedWalkStillReturnsLibraryValues` | depth-cap path still unions `GetCollectionFolders` (Minor A) |
+| 8 | `Resolve_ExtraWithNoParentResolvesViaOwner` | empty `ParentId`, set `OwnerId` → the owner's chain is walked |
+| 9 | `Resolve_StopsAtWalkBoundary_DoesNotClimbIntoAggregateFolder` | boundary type test |
+| 10 | `Resolve_DedupesOrdinallyAcrossLevels` | `Series01` on the library and `series01` on the season both survive (Ordinal, not OrdinalIgnoreCase) |
+| 11 | `CompileRule_TagsNotEqual_AcrossTwoLevelWalk_ExcludesWhenAnyAncestorMatches` | negated operator across a 2-level walk |
+| 12 | `CompileRule_TagsMatchRegexEmptyPattern_WithAndWithoutAncestorValues` | locks the `^$` empty-list semantics both ways |
+| 13 | `IsNonExpensiveExpression_ClassifiesParentAwareTagsRuleAsExpensive` | **new coverage for the #1 silent-failure mode** — nothing exercises `IsParentAwareListExpression` today |
+| 14 | `GenerateRuleSetHash_DiffersWhenIncludeParentTagsToggles` | **new coverage** — nothing exercises the rule-cache key today |
+| 15 | `Expression_LegacyAlbumFlagFoldsIntoIncludeParentTagsEffective` | round-trip a rule carrying only `"IncludeParentAlbumTags": true` and assert the fold is true and no `*Effective` property is serialized |
+| 16 | `CompileRule_UsingNewParentFields_DoesNotThrowArgumentException` | catches an Engine-literal ↔ Operand-property spelling mismatch, which otherwise only fails at refresh time |
+
+- [ ] **Step 5: Verify and commit**
+
+```bash
+dotnet test
+```
+Expected: all green. Note the test project is net10.0-only by design; the walk uses no 12-only API (`GetParent`/`GetOwner`/`GetCollectionFolders` are byte-identical in both ABIs).
+
+```bash
+git add Jellyfin.Plugin.SmartLists.Tests/
+git commit -m "Test ancestor walk, library union, memoization, expensiveness gate and rule-cache key"
+```
+
+---
+
+## Task 10: Frontend
+
+**Files:**
+- Modify: `Jellyfin.Plugin.SmartLists/Configuration/config-rules.js`
+- Modify: `Jellyfin.Plugin.SmartLists/Configuration/config-lists.js`
+- Modify: `Jellyfin.Plugin.SmartLists/Configuration/config-init.js`
+
+**Non-goals:** no HTML changes, no `config-core.js` changes (`shouldShowField` at config-rules.js:2226-2266 already offers Tags/Studios/Genres for every media type), no `config-templates.js` changes, no `syncAdvancedSection` changes (the dropdowns live in the rule row, not in `#advanced-options-body`).
+
+**Keep every function name.** `updateTagsOptionsVisibility` / `updateStudiosOptionsVisibility` / `updateGenresOptionsVisibility` and the three `updateAll*OptionsVisibility` wrappers keep their exact names and the exact `(ruleRow, fieldValue, page)` signature — `page` becomes unused but **must** stay, because `updateAllRules` (2778-2790) hard-codes `updateFunction(ruleRow, fieldSelect.value, page)`. Do **not** merge the three into one: that would force edits at six external call sites, two of which sit behind `if (SmartLists.updateAllXxx)` existence guards that fail **silently** on a rename (the divs would simply never appear, with no console error). Keeping the names means zero edits at those six sites and zero edits at the seven internal call sites (1312-1319, 1352-1354, 1944-1946, 1975-1977, 2171-2173, 2188-2190, 3111-3113).
+
+- [ ] **Step 1: Rewrite the twelve dropdown strings** (config-rules.js:1204-1233)
+
+Keep container divs, inline styles, class names and `is="emby-select" class="emby-select ..."` byte-identical. Keep option **values** `'false'` / `'true'` / `'only'` — they are the wire contract shared by `extractRuleConfig`, `collectRulesFromForm` and `populateRuleRow`. Since the runtime label-swapping is deleted, this static text becomes the final user-visible text.
+
+| Block | Label | value="false" | value="true" | value="only" |
+|---|---|---|---|---|
+| Tags | `Include parent tags:` | `No - Only check item tags` | `Yes - Also check parent tags (season, series, album, folder, library)` | `Yes - Only check parent tags (season, series, album, folder, library)` |
+| Studios | `Include parent studios:` | `No - Only check item studios` | `Yes - Also check parent studios (season, series, album, folder, library)` | `Yes - Only check parent studios (season, series, album, folder, library)` |
+| Genres | `Include parent genres:` | `No - Only check item genres` | `Yes - Also check parent genres (season, series, album, folder, library)` | `Yes - Only check parent genres (season, series, album, folder, library)` |
+
+- [ ] **Step 2: Gut the three visibility updaters** (2451-2491, 2498-2543, 2545-2590)
+
+Delete the entire three-way label/option-text swap block **including** its `select.options.length >= 3` guard (a dangling guard would silently skip a future block), and delete the `getRowScope`/`getSelectedMediaTypes`/`hasEpisode`/`hasAudio` lookups. Each function becomes:
+
+```js
+    SmartLists.updateTagsOptionsVisibility = function (ruleRow, fieldValue, page) {
+        const tagsOptionsDiv = ruleRow.querySelector('.rule-tags-options');
+        if (tagsOptionsDiv) {
+            tagsOptionsDiv.style.display = fieldValue === 'Tags' ? 'block' : 'none';
+        }
+    };
+```
+
+Identical surgery for `.rule-studios-options` / `'Studios'` and `.rule-genres-options` / `'Genres'`. ~135 lines become ~18.
+
+- [ ] **Step 3: Serialize — `collectRulesFromForm`** (2929-2942, 2944-2957, 2959-2972)
+
+Drop `&& (hasEpisode || hasAudio)` from all three guards. **Dual-write** the legacy flags (Major 5) so an older plugin build on the other release line still honours the setting:
+
+```js
+                    const tagsSelect = rule.querySelector('.rule-tags-select');
+                    if (tagsSelect && memberName === 'Tags') {
+                        const tagsSelectValue = tagsSelect.value;
+                        if (tagsSelectValue === 'only') {
+                            expression.OnlyParentTags = true;
+                            expression.IncludeParentTags = true;
+                            // Downgrade compatibility: the 10.11 stable line still reads only these.
+                            // Remove once that line is retired (see plan Open Question 1).
+                            expression.IncludeParentSeriesTags = true;
+                            expression.IncludeParentAlbumTags = true;
+                        } else if (tagsSelectValue === 'true') {
+                            expression.IncludeParentTags = true;
+                            expression.IncludeParentSeriesTags = true;
+                            expression.IncludeParentAlbumTags = true;
+                        }
+                        // If 'false' (default), don't include the parameter to save space
+                    }
+```
+
+Same shape for Studios (`OnlyParentStudios`/`IncludeParentStudios`/`IncludeParentSeriesStudios`/`IncludeParentAlbumStudios`) and Genres. Emitting the Include flag alongside `'only'` is what keeps the incoherent `OnlyParent`-with-no-source state unreachable from the UI.
+
+**Keep** `hasEpisode`/`hasAudio` computed at 2796-2805 — NextUnwatched (2859) and IncludeEpisodesWithinSeries (2891) still use them.
+
+- [ ] **Step 4: Serialize — `extractRuleConfig`** (1625-1645, the clone path)
+
+Give it the **byte-identical** emission shape, keyed off `fieldValue`/`tagsValue`. Today these two writers disagree (`extractRuleConfig` emits `OnlyParentTags` alone and never the Album flags) and round-trip only by accident. After this step, cloning a rule and saving a rule must produce identical JSON.
+
+- [ ] **Step 5: Deserialize — `populateRuleRow`** (3196-3231)
+
+**EXTEND the OR-chain, never replace it.** This is the single highest-risk line in the frontend change: if it reads only the new flag, every pre-upgrade rule repopulates as `'No'`, the user hits Save, and `collectRulesFromForm` emits nothing — the setting is destroyed with no warning.
+
+```js
+        if (expression.MemberName === 'Tags') {
+            const tagsSelect = ruleRow.querySelector('.rule-tags-select');
+            if (tagsSelect) {
+                let includeValue = 'false';
+                if (expression.OnlyParentTags === true) {
+                    includeValue = 'only';
+                } else if (expression.IncludeParentTags === true || expression.IncludeParentSeriesTags === true || expression.IncludeParentAlbumTags === true) {
+                    includeValue = 'true';
+                }
+                tagsSelect.value = includeValue;
+            }
+        }
+```
+
+Same for Studios (3208-3219, add `IncludeParentStudios` to the OR) and Genres (3220-3231, add `IncludeParentGenres`). **Preserve** the ordering contract documented at 3149-3150: visibility updaters run first, select values are restored after.
+
+- [ ] **Step 6: Rule summary suffixes** (config-lists.js:1653-1695)
+
+Collapse each field's 4-way branch to 2 cases that **still read the legacy flags**, or pre-existing lists lose their suffix on the cards and look broken:
+
+```js
+            if (rule.OnlyParentTags === true) {
+                tagsInfo = ' (only parent tags)';
+            } else if (rule.IncludeParentTags === true || rule.IncludeParentSeriesTags === true || rule.IncludeParentAlbumTags === true) {
+                tagsInfo = ' (including parent tags)';
+            }
+```
+
+Same for `studiosInfo` and `genresInfo`. Delete the two hoisted locals `includesParentSeriesGenres`/`includesParentAlbumGenres` at 1682-1683. The locals `tagsInfo`/`studiosInfo`/`genresInfo` **must** keep their names and default to `''` — line 1714 concatenates them unconditionally.
+
+- [ ] **Step 7: One comment in config-init.js** (2942)
+
+`// Update visibility of parent series options based on media types` → `// Update visibility of parent metadata options`. No other config-init.js change.
+
+- [ ] **Step 8: Verify and commit**
+
+```bash
+grep -c '`' Jellyfin.Plugin.SmartLists/Configuration/config-rules.js       # must be 0
+grep -c '=>' Jellyfin.Plugin.SmartLists/Configuration/config-rules.js      # must not increase
+grep -c 'IncludeParentSeriesTags' Jellyfin.Plugin.SmartLists/Configuration/config-rules.js   # >= 1 (legacy read + dual write)
+grep -c 'IncludeParentSeriesTags' Jellyfin.Plugin.SmartLists/Configuration/config-lists.js   # >= 1 (legacy read)
+cd dev && ./build-local.sh
+```
+
+```bash
+git add Jellyfin.Plugin.SmartLists/Configuration/
+git commit -m "Offer parent metadata options for all media types; dual-write legacy flags"
+```
+
+---
+
+## Task 11: Docs
+
+**Files:**
+- Modify: `docs/content/user-guide/fields-and-operators.md`
+- Modify: `docs/content/examples/common-use-cases.md`
+- Modify: `docs/content/examples/advanced-examples.md`
+
+Only `docs/content/**` is source — never edit `docs/site/**`.
+
+- [ ] **Step 1: Rewrite `fields-and-operators.md:199-207`**
+
+- Drop the `(shown when Episode or Audio media type is selected)` gate at line 199 — the option now applies to **all** media types.
+- Replace `parent series/album` with the real chains: `episode → season → series → folder → library`; `track → album → artist folder → library`; `movie → folder → library`.
+- **Delete line 207 entirely** (`The label and option text adapts based on the selected media type…`) — there is no more media-type-dependent label swapping.
+- Add an explicit sentence that **season-level and library-level** tags now count — that is what #495 readers will search for.
+- Add a note that **BoxSet/collection and playlist membership do NOT contribute**, because membership is `LinkedChildren` rather than `ParentId`. Now that the option is offered for movies, users will otherwise expect collection tags to flow.
+- Add the operator-direction warning: positive operators (`Equal`, `Contains`, `IsIn`, `MatchRegex`) **match more** items than before; negative operators (`NotEqual`, `NotContains`, `IsNotIn`) **match fewer**, because they require *every* checked source to not match.
+
+- [ ] **Step 2: Pointer on the Membership table** (187-197)
+
+Add a short `see Parent metadata options below` note on the Genres / Studios / Tags rows, since readers of the table for Movies will no longer skip the section.
+
+- [ ] **Step 3: Reword the three examples**
+
+- `advanced-examples.md:31` and `:37`: `(with parent series tags enabled)` → `(with parent tags enabled, so a tag on the season or series applies to its episodes)`.
+- `common-use-cases.md:68`: same rewording.
+- Add **one new example** exercising the capability gain — a Movies list matching a tag applied to the whole library.
+
+- [ ] **Step 4: Verify and commit**
+
+```bash
+grep -rn 'parent series/album\|Episode or Audio media type' docs/content/    # must return nothing
+```
+Build mkdocs to confirm it renders.
+
+```bash
+git add docs/content/
+git commit -m "Document the ancestor walk, all-media-type support and the negative-operator direction"
+```
+
+---
+
+## Task 12: Both-ABI build + review gate
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: The two-part grep gate**
+
+```bash
+# NEGATIVE: C# must read only the folded flags. Restricted to *.cs on purpose —
+# the JS legacy reads are MANDATORY back-compat and must not be swept up.
+grep -rn 'IncludeParentSeries\|IncludeParentAlbum' --include='*.cs' Jellyfin.Plugin.SmartLists/
+#   -> expected: ONLY Expression.cs (six legacy declarations + three folds)
+
+# POSITIVE: the back-compat hinge must still exist in JS.
+grep -c 'IncludeParentSeriesTags' Jellyfin.Plugin.SmartLists/Configuration/config-rules.js   # >= 1
+grep -c 'IncludeParentSeriesTags' Jellyfin.Plugin.SmartLists/Configuration/config-lists.js   # >= 1
+```
+
+- [ ] **Step 2: Build both ABIs**
+
+```bash
+cd dev && ./build-local.sh                        # net10.0 / Jellyfin 12
+cd dev && JELLYFIN_ABI=10.11.0 ./build-local.sh   # net9.0 / Jellyfin 10.11
+cd dev && ./build-local.sh                        # leave the 12.x build deployed for Task 13
+dotnet test
+```
+
+- [ ] **Step 3: Verify the deployed DLL**
+
+The dev container is shared and parallel sessions clobber each other's deployed plugin. Confirm the running build is yours by searching the deployed DLL for the UTF-16 string `IncludeParentTags` before trusting any e2e result.
+
+---
+
+## Task 13: End-to-end verification against the local dev Jellyfin
+
+**Files:** none (verification only). Target: <http://localhost:8096>.
+
+> **FIXTURE HAZARD — read this first.** All three children of the tagged season `3C34646F` (`Moss and the German` `8F4F4464`, `The Work Outing` `AAF2D212`, `Return of the Golden Child` `F07FCC7F`) **already carry `seasontag02` on themselves**. A `Tags contains seasontag02` rule matches them with the walk completely broken. Do **not** use them to prove anything.
+
+- [ ] **Step 0: Confirm the fixture values**
+
+```bash
+sqlite3 dev/jellyfin-data/config/data/jellyfin.db \
+  "SELECT Id, Name, Type, Tags FROM BaseItems WHERE Tags <> '';"
+```
+Expect a `CollectionFolder` row for the Series library carrying the library tag and the `Season` row `3C34646F` carrying `seasontag02`.
+
+`<LIBTAG>` is **`seriestag01`** — confirmed directly against the live DB (`BC3A7D1D | Serier | CollectionFolder | seriestag01`). The issue text's `series01` is the reporter's paraphrase, not the stored value.
+
+> Copy `jellyfin.db-wal` alongside `jellyfin.db` before querying a snapshot — Jellyfin runs in WAL mode and recent tag edits are invisible in the `.db` file alone.
+
+- [ ] **Step A — Season tag (the #495 headline)**
+
+Tag the clean season `814B5C54` (`Season 1`, path `/shows/The IT Crowd (2006)/Season 1`) with `seasontag99`; its children `1359EDA6`, `145405B5`, `4FB59619` all have **empty** own `Tags`.
+Rule: media type `Episode`, `Tags` **contains** `seasontag99`, parent option = **`Yes - Also check parent tags`**.
+Expected: exactly those three episodes. **Before the fix this returns zero.**
+
+- [ ] **Step B — Library tag (the half a parents-only walk would miss)**
+
+`<LIBTAG>` is carried **only** by the `Serier` CollectionFolder `BC3A7D1D` and by no item at all.
+Rule: media type `Episode`, `Tags` **contains** `<LIBTAG>`, parent option = **`Yes - Also check parent tags`**.
+Expected: **every** episode in that library. This is the clean proof the `GetCollectionFolders` union works.
+
+- [ ] **Step C — All-media-type broadening**
+
+Tag the `Filmer` CollectionFolder. Rule: media type `Movie`, `Tags` contains that tag, parent option = `Yes`.
+Expected: all movies in that library. **Today the dropdown is not even shown for Movies** — confirm the div actually appears (the `config-init.js` existence guards fail silently, so "no console error" is not evidence).
+
+- [ ] **Step D — Only parent tags**
+
+Same rule as Step A but parent option = **`Yes - Only check parent tags`**.
+Expected: the same three episodes. Then add `seasontag99` to **one episode's own** tags and re-refresh: the result must be **unchanged** (the item's own tags are ignored).
+
+- [ ] **Step E — Legacy flag back-compat**
+
+Grep confirms **zero** of the 20 saved lists under `dev/jellyfin-data/config/data/smartlists/` currently exercise any parent flag, so nothing existing covers this path. **Before deploying**, hand-write into one list's `config.json` a rule carrying only:
+
+```json
+{ "MemberName": "Tags", "Operator": "Contains", "TargetValue": "seasontag99", "IncludeParentAlbumTags": true }
+```
+
+After upgrade: (1) the rule must still match via the fold, and (2) opening the list in the edit form must show the dropdown reading **`Yes`**, not `No`. Save it and confirm the saved JSON now carries `IncludeParentTags` **and** the two legacy keys (dual-write).
+
+- [ ] **Step F — Negative case (must NOT match)**
+
+Rule: media type `Episode`, `Tags` **NotEqual** `seasontag99`, parent option = `Yes - Also check parent tags`.
+Expected: the three Season 1 episodes are **excluded**; every other episode in the library is present. This is the AND-fold direction.
+
+- [ ] **Step G — Existing audio list shrinks (Major 6, regression watch)**
+
+**Capture first, deploy second.** On the pre-change build, create/refresh an Audio list with `Genres NotContains <a genre that exists on a MusicArtist folder but not on the album>` plus the album parent option enabled, and record the exact item set. After deploying, refresh and diff. Expected: the item set **shrinks** (artist-folder and library genres now count). Confirm the shrink is explainable, not arbitrary.
+
+- [ ] **Step H — Existing episode list shrinks**
+
+Same capture-then-diff for an Episode list with `Tags NotContains <LIBTAG>` and the parent option enabled. Expected: goes from "everything" to "nothing in that library", because the library tag now counts.
+
+- [ ] **Step I — Cost profile on the #495 shape**
+
+Create a list whose **only** rule is `Tags contains <LIBTAG> (include parent)` over the full Series library — this takes the expensive-only path (SmartList.cs:3026), so the walk runs on every candidate item. Record refresh wall-clock and compare against a pre-change baseline for the same-sized list. Expect roughly parity per item (memo hits are dictionary lookups) with a modest one-off cost for the containers.
+
+- [ ] **Step J — Log check**
+
+```bash
+docker logs jellyfin 2>&1 | grep -i "Smart"
+```
+Expected during a full refresh: **no** `NotSupportedException`, **no** `ArgumentException` (that would mean an Engine-literal ↔ Operand-property mismatch), and **no** `ancestor walk stopped early` warning.
+
+- [ ] **Step K: Update `primer.md`** (session-continuity file at repo root; rewrite per its existing structure) and report results.
+
+---
+
+## Docs Update Checklist
+
+| File | Passage | Change |
+|---|---|---|
+| `docs/content/user-guide/fields-and-operators.md` | line 199 | Delete `(shown when Episode or Audio media type is selected)` |
+| | lines 201-205 | Replace `parent series/album` with the real ancestor chains; state that season-level and library-level values count |
+| | line 207 | **Delete** (`The label and option text adapts based on the selected media type…`) |
+| | new paragraph after 205 | Positive operators match more, negative operators match fewer; BoxSet/playlist membership does not contribute |
+| | lines 187-197 (Membership table) | Add `see Parent metadata options below` on the Genres / Studios / Tags rows |
+| `docs/content/examples/advanced-examples.md` | line 31 | `(with parent series tags enabled)` → new wording |
+| | line 37 | same |
+| `docs/content/examples/common-use-cases.md` | line 68 | same |
+| | new section | One Movies-library-tag example (the capability gain) |
+| Release notes (tag message body) | — | Existing lists change contents on first refresh: positive operators gain items, **negative operators lose items**; audio lists with the album option now also see artist-folder and library values |
+
+Not touched, deliberately: `docs/content/user-guide/advanced-configuration.md` (parent flags were never documented for file editors — see Open Question 2) and `docs/content/development/integration-api.md` (see Open Question 2).
+
+---
+
+## Open Questions for the repo owner
+
+> **ALL CLOSED — see [Amendments](#amendments-decided-after-the-plan-was-drafted--these-override-the-body) at the top.** Retained below for the reasoning that produced each decision.
+
+1. ~~**When does the dual-write stop?**~~ **CLOSED — there is no dual-write.** The `10.11` stable line is retired (Amendment 1), so the rollback scenario cannot occur. New saves write only the new keys; legacy keys stay readable forever.
+
+2. **Should the new flag be documented as public API?** `docs/content/user-guide/advanced-configuration.md:105-112` documents `MemberName`/`Operator`/`TargetValue` for hand-editors, and `docs/content/development/integration-api.md:275-290` documents the `ExpressionSets` wire shape. Neither has ever mentioned the parent flags. Documenting `IncludeParentTags`/`OnlyParentTags` makes them a supported contract; leaving them undocumented keeps them internal. Which?
+
+3. **Symlinked / plugin-created virtual libraries are knowingly not covered.** `LibraryManagerHelper.cs:98-101` already documents that `GetCollectionFolders` is unreliable for them and works around it for library *names* via `GetVirtualFolders` path matching (`VirtualFolderInfo.ItemId` is the CollectionFolder id); the dev DB contains one under `/config/plugins/LocalRecs/virtual-libraries/`. Library **tags** will therefore be inconsistent with the existing `LibraryName` field on exactly those libraries. ~20 lines would close it. File as a follow-up issue, or fold into this change?
+
+4. **Is the audio behaviour change acceptable as-is?** Walking past the MusicAlbum picks up MusicArtist-folder and library values that music lists have never seen. For positive operators that is a gain; for `NotContains`/`NotEqual` it will visibly shrink existing playlists (Step G). Ship as-is with release notes, or gate audio to stop at the album for one release?
+
+5. **Depth cap of 20** is set so it never binds (measured real depth 4-5; deep artist/genre trees maybe 7). Confirm 20 is acceptable, or name a different number — but note that a *binding* cap produces truncated results, and truncated walks deliberately skip memo writes to avoid order-dependent caching.

--- a/docs/superpowers/plans/2026-08-14-generic-parent-tag-walk.md
+++ b/docs/superpowers/plans/2026-08-14-generic-parent-tag-walk.md
@@ -24,7 +24,7 @@ Every instruction in this plan to **dual-write** the legacy flags is **cancelled
 | **Read** legacy keys | **YES, permanently.** Lists saved by older builds still carry them. C# folds via `IncludeParent*Effective`; JS edit-mode repopulation must still recognise them. |
 | Legacy flag declarations on `Expression` | **Kept**, unchanged, read-only. |
 
-Affected: **Major 5** (withdrawn), the "Written by" column of the mapping table (read `JS dual-write (one release)` as **"not written"**), **Task 10 Steps 3-4**, **Task 12** grep gate, **Task 13 Step E**, **Open Question 1** (closed).
+Affected: **Major 5** (withdrawn), the "Written by" column of the mapping table, **Task 10 Steps 3-4**, **Task 12** grep gate, **Task 13 Step E**, **Open Question 1** (closed). Those sections have been corrected in place; any residual `dual-write` phrasing below is superseded by this amendment.
 
 Task 12's gate becomes: legacy identifiers must still appear in JS on the **read/repopulate** path, and must **not** appear on the **write/serialize** path.
 
@@ -154,22 +154,22 @@ Claude-Session: https://claude.ai/code/session_01S9FFji6MP136o3bq298BWJ
 
 ## Back-Compat: exact old-flag → new-flag mapping
 
-**Strategy: additive on disk, fold on read, dual-write from the UI for one release.** No migration, no deserialize-only shim, no restore-path hook, no deprecation window. `SmartListDto.MigrateLegacyFields` (SmartListDto.cs:157-180) and `StorageMigrationHostedService` are **not** touched.
+**Strategy: additive on disk, fold on read.** (The plan originally added "dual-write from the UI for one release"; **cancelled by Amendment 1** — new saves write only the new keys.) No migration, no deserialize-only shim, no restore-path hook, no deprecation window. `SmartListDto.MigrateLegacyFields` (SmartListDto.cs:157-180) and `StorageMigrationHostedService` are **not** touched.
 
 ### Persisted flags (all nine keep their exact names and behaviour)
 
 | On-disk JSON key | Status after change | Read by | Written by |
 |---|---|---|---|
-| `IncludeParentSeriesTags` | **kept**, legacy | `IncludeParentTagsEffective` fold | JS dual-write (one release) |
-| `IncludeParentAlbumTags` | **kept**, legacy | `IncludeParentTagsEffective` fold | JS dual-write (one release) |
+| `IncludeParentSeriesTags` | **kept**, legacy | `IncludeParentTagsEffective` fold | **not written** (Amendment 1) |
+| `IncludeParentAlbumTags` | **kept**, legacy | `IncludeParentTagsEffective` fold | **not written** (Amendment 1) |
 | `IncludeParentTags` | **new** | `IncludeParentTagsEffective` fold | JS |
 | `OnlyParentTags` | **unchanged** | read directly, `== true` | JS |
-| `IncludeParentSeriesStudios` | **kept**, legacy | `IncludeParentStudiosEffective` fold | JS dual-write (one release) |
-| `IncludeParentAlbumStudios` | **kept**, legacy | `IncludeParentStudiosEffective` fold | JS dual-write (one release) |
+| `IncludeParentSeriesStudios` | **kept**, legacy | `IncludeParentStudiosEffective` fold | **not written** (Amendment 1) |
+| `IncludeParentAlbumStudios` | **kept**, legacy | `IncludeParentStudiosEffective` fold | **not written** (Amendment 1) |
 | `IncludeParentStudios` | **new** | `IncludeParentStudiosEffective` fold | JS |
 | `OnlyParentStudios` | **unchanged** | read directly, `== true` | JS |
-| `IncludeParentSeriesGenres` | **kept**, legacy | `IncludeParentGenresEffective` fold | JS dual-write (one release) |
-| `IncludeParentAlbumGenres` | **kept**, legacy | `IncludeParentGenresEffective` fold | JS dual-write (one release) |
+| `IncludeParentSeriesGenres` | **kept**, legacy | `IncludeParentGenresEffective` fold | **not written** (Amendment 1) |
+| `IncludeParentAlbumGenres` | **kept**, legacy | `IncludeParentGenresEffective` fold | **not written** (Amendment 1) |
 | `IncludeParentGenres` | **new** | `IncludeParentGenresEffective` fold | JS |
 | `OnlyParentGenres` | **unchanged** | read directly, `== true` | JS |
 
@@ -1003,7 +1003,7 @@ Identical surgery for `.rule-studios-options` / `'Studios'` and `.rule-genres-op
 
 - [ ] **Step 3: Serialize — `collectRulesFromForm`** (2929-2942, 2944-2957, 2959-2972)
 
-Drop `&& (hasEpisode || hasAudio)` from all three guards. **Dual-write** the legacy flags (Major 5) so an older plugin build on the other release line still honours the setting:
+Drop `&& (hasEpisode || hasAudio)` from all three guards. Write **only the new keys** — the dual-write this step originally specified is cancelled by Amendment 1:
 
 ```js
                     const tagsSelect = rule.querySelector('.rule-tags-select');
@@ -1012,20 +1012,14 @@ Drop `&& (hasEpisode || hasAudio)` from all three guards. **Dual-write** the leg
                         if (tagsSelectValue === 'only') {
                             expression.OnlyParentTags = true;
                             expression.IncludeParentTags = true;
-                            // Downgrade compatibility: the 10.11 stable line still reads only these.
-                            // Remove once that line is retired (see plan Open Question 1).
-                            expression.IncludeParentSeriesTags = true;
-                            expression.IncludeParentAlbumTags = true;
                         } else if (tagsSelectValue === 'true') {
                             expression.IncludeParentTags = true;
-                            expression.IncludeParentSeriesTags = true;
-                            expression.IncludeParentAlbumTags = true;
                         }
                         // If 'false' (default), don't include the parameter to save space
                     }
 ```
 
-Same shape for Studios (`OnlyParentStudios`/`IncludeParentStudios`/`IncludeParentSeriesStudios`/`IncludeParentAlbumStudios`) and Genres. Emitting the Include flag alongside `'only'` is what keeps the incoherent `OnlyParent`-with-no-source state unreachable from the UI.
+Same shape for Studios (`OnlyParentStudios`/`IncludeParentStudios`) and Genres. Emitting the Include flag alongside `'only'` is what keeps the incoherent `OnlyParent`-with-no-source state unreachable from the UI.
 
 **Keep** `hasEpisode`/`hasAudio` computed at 2796-2805 — NextUnwatched (2859) and IncludeEpisodesWithinSeries (2891) still use them.
 
@@ -1084,7 +1078,7 @@ cd dev && ./build-local.sh
 
 ```bash
 git add Jellyfin.Plugin.SmartLists/Configuration/
-git commit -m "Offer parent metadata options for all media types; dual-write legacy flags"
+git commit -m "Offer parent metadata options for all media types"
 ```
 
 ---
@@ -1211,7 +1205,7 @@ Grep confirms **zero** of the 20 saved lists under `dev/jellyfin-data/config/dat
 { "MemberName": "Tags", "Operator": "Contains", "TargetValue": "seasontag99", "IncludeParentAlbumTags": true }
 ```
 
-After upgrade: (1) the rule must still match via the fold, and (2) opening the list in the edit form must show the dropdown reading **`Yes`**, not `No`. Save it and confirm the saved JSON now carries `IncludeParentTags` **and** the two legacy keys (dual-write).
+After upgrade: (1) the rule must still match via the fold, and (2) opening the list in the edit form must show the dropdown reading **`Yes`**, not `No`. Save it and confirm the saved JSON now carries `IncludeParentTags` and **no** legacy keys — the legacy keys are read, never written (Amendment 1).
 
 - [ ] **Step F — Negative case (must NOT match)**
 


### PR DESCRIPTION
Fixes #495.

A tag set on a **season** never matched, even with "Include parent series tags" enabled.

`ExtractParentSeriesTags` resolved `episode.SeriesId` and read exactly that one item's values, so the season sitting between the episode and the series was never visited. The same shape was repeated in all six extractors (Tags/Studios/Genres × Series/Album).

## What changed

The six one-level extractors (~350 lines) are replaced by a single memoized ancestor walk in `Core/QueryEngine/AncestorValueResolver.cs`, collecting Tags, Studios and Genres in one pass.

Two facts shaped the design, both verified against a live library:

**A Jellyfin library is never in the `ParentId` chain.** The chain from an episode is `Episode → Season → Series → Folder → AggregateFolder`. A library is a `CollectionFolder` hanging off `UserRootFolder` — a sibling branch. So the walk is:

```
ParentId chain (stopping before AggregateFolder/UserRootFolder/UserView)
  ∪  libraryManager.GetCollectionFolders(...)
```

A parents-only walk would have fixed season tags and left library tags broken. `TopParentId` is no help either — for an episode it is the physical folder, and a `CollectionFolder`'s own `TopParentId` is NULL.

**The memo is keyed on the raw `item.ParentId` Guid and consulted before any `GetParent()` call.** `GetParent()` is `LibraryManager.GetItemById(ParentId)` — a DB hit. Checking the memo first keeps a hit free, matching the cost profile of the code this replaces; a walk then runs once per distinct container.

Because ancestry is now resolved by walking the tree rather than by media type, **the option applies to every media type**, not just episodes and audio.

## Collapse

| | Before | After |
|---|---|---|
| `Operand` parent lists | 6 | 3 |
| `ExtractionGroup` bits | 6 | 3 |
| `RefreshCache` dictionaries | 6 | 1 |
| `Engine` helpers | 2 dead | removed |
| Frontend media-type label swapping | ~135 lines | removed |

## On-disk compatibility

Nothing is renamed or removed. `Expression` keeps all nine legacy flags and gains three `IncludeParent*Effective` folds, so lists saved by older builds keep working with no migration and no shim. The UI no longer *writes* the legacy keys but still *reads* them.

## Behaviour changes

Existing lists with the option enabled change contents on first refresh: positive operators match **more** items, negative operators match **fewer**, because ancestor values now count. Audio is the loudest case — walking past the `MusicAlbum` picks up artist-folder and library values that music lists have never seen. Release-note text is drafted in the plan document.

## Verification

1205 unit tests (+16), 0 warnings on both ABIs (net9.0 / net10.0).

End-to-end against a real Jellyfin instance:

| Case | Result |
|---|---|
| Season tag, no parent option | 0 — reproduces the bug |
| Season tag, include parents / only parents | 3 / 3 |
| Library tag, control / with parents | 0 / 40 |
| Series tag (regression guard) | 6 |
| `NotContains` + parents | 37 of 40 |
| Legacy `IncludeParentSeriesTags` / `IncludeParentAlbumTags` | 3 / 3 |
| Movie + library tag (previously impossible) | 0 / 40 |

The decisive pair is the first two: with the tag existing **only** on the season, the control returns 0 and the fix returns 3.

> Worth knowing for anyone testing this: **Jellyfin propagates a season's tags down onto its episodes on metadata save.** That makes the obvious fixture useless — a `Tags contains <season tag>` rule matches those episodes with parent resolution completely broken. The episode-level copies have to be stripped first, and the no-parent-option control must return 0.

## Also included

A separate commit retires the `10.11-release` stable line in favour of a single `12.x` line, documents the new `12-release` branch, and fixes the release skill's stable version base (it looked for `v10.11.*` tags that no longer exist on this line). Jellyfin 10.11 support is unchanged — both ABIs are still built and published; only the version number 10.11 users see changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9FFji6MP136o3bq298BWJ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Parent Tags, Studios, and Genres can now be matched across media types, including seasons, series, albums, folders, and libraries.
  * Supports inherited metadata from multiple ancestors, with options to include parent values, use only parent values, or combine both.
  * Parent metadata matching now supports broader library and folder scenarios.

* **Bug Fixes**
  * Improved handling of inherited metadata, duplicate values, cycles, and legacy configurations.

* **Documentation**
  * Added examples and guidance for configuring and using parent metadata matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->