### PR TITLE
fix: keep a smart list out of its own Collections/Playlists results (#499)

### DIFF
--- a/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/ListOriginTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/ListOriginTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.SmartLists.Core;
+using Jellyfin.Plugin.SmartLists.Core.Constants;
 using Jellyfin.Plugin.SmartLists.Core.Models;
 using Jellyfin.Plugin.SmartLists.Core.QueryEngine;
 using Jellyfin.Plugin.SmartLists.Services.Shared;
@@ -8,6 +9,7 @@ using Jellyfin.Plugin.SmartLists.Tests.Support;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Playlists;
+using MediaBrowser.Model.Entities;
 
 namespace Jellyfin.Plugin.SmartLists.Tests.Core.QueryEngine;
 
@@ -285,6 +287,32 @@ public class ListOriginTests
         Assert.True(new ListOrigin("col-1", "Movies", BaseItemKind.BoxSet, []).Matches(candidate));
         Assert.False(new ListOrigin("col-1", "Movies", BaseItemKind.BoxSet, [Guid.NewGuid()]).Matches(candidate));
         Assert.True(new ListOrigin("col-1", "Movies", BaseItemKind.BoxSet, [candidate.Id]).Matches(candidate));
+    }
+
+    /// <summary>
+    /// The SmartLists provider-ID tether identifies the list even when the stored Jellyfin id has
+    /// gone stale. This matters because the recovery that repairs a stale id runs AFTER filtering
+    /// (PlaylistService.ProcessPlaylistRefreshAsync filters at ~line 177 and recovers at ~line 263;
+    /// CollectionService filters at ~line 252 and recovers at ~line 341), so on a recovery refresh
+    /// the id set alone points at a container that no longer exists and the real one - still
+    /// tethered - would be left visible to its own rules for that whole refresh.
+    /// </summary>
+    [Fact]
+    public void ListOrigin_MatchesTheTetheredContainerEvenWhenTheStoredIdIsStale()
+    {
+        var tethered = CollectionNamed("Uncollected [Smart]");
+        tethered.SetProviderId(ProviderKeys.SmartLists, "col-1");
+
+        // Stored id is stale (points at a deleted container) and the name fallback is disarmed by
+        // the non-empty id set, so only the tether can identify this.
+        var origin = new ListOrigin("col-1", "Uncollected", BaseItemKind.BoxSet, [Guid.NewGuid()]);
+
+        Assert.True(origin.Matches(tethered));
+
+        // A container tethered to a DIFFERENT smart list is not this list.
+        var other = CollectionNamed("Uncollected [Smart]");
+        other.SetProviderId(ProviderKeys.SmartLists, "col-2");
+        Assert.False(origin.Matches(other));
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/ListOriginTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/ListOriginTests.cs
@@ -1,0 +1,443 @@
+using System.Reflection;
+using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.SmartLists.Core;
+using Jellyfin.Plugin.SmartLists.Core.Models;
+using Jellyfin.Plugin.SmartLists.Core.QueryEngine;
+using Jellyfin.Plugin.SmartLists.Services.Shared;
+using Jellyfin.Plugin.SmartLists.Tests.Support;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Playlists;
+
+namespace Jellyfin.Plugin.SmartLists.Tests.Core.QueryEngine;
+
+/// <summary>
+/// Covers <see cref="ListOrigin"/> - the "which list am I building" identity that keeps a smart
+/// list out of its own Collections/Playlists results - and the two extractors that consume it.
+///
+/// Two defects are pinned here, both reproduced live before the fix:
+///
+/// 1. Issue #499: <c>ExtractCollections</c> was never told which collection was being built, so a
+///    smart collection saw its own name in the Collections field. With the default "[Smart]"
+///    suffix, a rule like <c>Collections NotContains "smart"</c> matches the collection's own name
+///    and the result oscillates 0 -> N -> 0 -> N across refreshes.
+/// 2. The per-item extraction caches were keyed on item id (and depth) only, while the values
+///    stored in them are ALREADY origin-filtered. The cache is per-user and survives until the
+///    whole refresh queue drains, so list B refreshed after list A in one drain inherited A's
+///    exclusions and went blind to playlist/collection A.
+///
+/// The fix also changed WHAT counts as "myself": identity is the Jellyfin item id, with base-name
+/// comparison kept only as a fallback for the very first refresh (before the Jellyfin
+/// playlist/collection exists). Name matching alone wrongly excluded an unrelated, manually
+/// created list that merely shared the name - see
+/// <see cref="ExtractCollections_KeepsAManuallyCreatedCollectionWithTheSameName"/>.
+///
+/// HARNESS NOTE: neither extractor touches <c>ILibraryManager</c> once its caches are seeded -
+/// <c>AllCollections</c> + <c>CollectionDirectChildren</c> for collections (depth membership is
+/// then built entirely off that dictionary), <c>AllPlaylists</c> + <c>PlaylistMembershipCache</c>
+/// for playlists. The library manager passed in is <see cref="TestLibraryManager"/>, which throws
+/// on every unstubbed member, so a regression that starts querying the server fails loudly here.
+///
+/// PRECONDITION: <c>Plugin.Instance</c> is null in a test process, so
+/// <c>NameFormatter.StripPrefixAndSuffix</c> deterministically strips the default "[Smart]"
+/// suffix. The fixtures use that suffix for exactly that reason.
+/// </summary>
+public class ListOriginTests
+{
+    // ---------------------------------------------------------------------------------------
+    // Reaching the private statics (same approach as AncestorWalkTests)
+    // ---------------------------------------------------------------------------------------
+
+    private static readonly MethodInfo ExtractCollectionsMethod =
+        typeof(OperandFactory).GetMethod("ExtractCollections", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    private static readonly MethodInfo ExtractPlaylistsMethod =
+        typeof(OperandFactory).GetMethod("ExtractPlaylists", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    private static List<string> ExtractCollections(
+        BaseItem item,
+        RefreshQueueService.RefreshCache cache,
+        int depth,
+        ListOrigin? origin)
+        => (List<string>)ExtractCollectionsMethod.Invoke(
+            null,
+            [item, TestItems.User, BaseItem.LibraryManager, cache, null, depth, origin])!;
+
+    private static List<string> ExtractPlaylists(
+        BaseItem item,
+        RefreshQueueService.RefreshCache cache,
+        ListOrigin? origin)
+        => (List<string>)ExtractPlaylistsMethod.Invoke(
+            null,
+            [item, TestItems.User, BaseItem.LibraryManager, cache, null, origin])!;
+
+    // ---------------------------------------------------------------------------------------
+    // Fixture builders
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>A BoxSet - what Jellyfin calls a collection. Name before SortName, as ever.</summary>
+    private static BoxSet CollectionNamed(string name)
+    {
+        var boxSet = new BoxSet { Id = Guid.NewGuid(), Name = name };
+        boxSet.SortName = name;
+        return boxSet;
+    }
+
+    private static Playlist PlaylistNamed(string name, Guid? id = null)
+    {
+        var playlist = new Playlist { Id = id ?? Guid.NewGuid(), Name = name };
+        playlist.SortName = name;
+        return playlist;
+    }
+
+    /// <summary>
+    /// Registers a collection and its DIRECT children. Seeding
+    /// <c>CollectionDirectChildren</c> is what keeps <c>ExtractCollections</c> off the library
+    /// manager: the per-depth membership sets are derived from this dictionary alone.
+    /// </summary>
+    private static void SeedCollection(RefreshQueueService.RefreshCache cache, BoxSet boxSet, params BaseItem[] directChildren)
+    {
+        cache.AllCollections = [.. cache.AllCollections ?? [], boxSet];
+        cache.CollectionDirectChildren[boxSet.Id] = directChildren;
+    }
+
+    /// <summary>
+    /// Registers a playlist and its members. Playlists cannot nest, so membership is seeded
+    /// directly rather than derived.
+    /// </summary>
+    private static void SeedPlaylist(RefreshQueueService.RefreshCache cache, Playlist playlist, params BaseItem[] members)
+    {
+        cache.AllPlaylists = [.. cache.AllPlaylists ?? [], playlist];
+        cache.PlaylistMembershipCache[playlist.Id] = [.. members.Select(m => m.Id)];
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Issue #499 - a collection must not see itself
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Issue #499 in one assertion. Before the fix <c>ExtractCollections</c> took no origin at
+    /// all, so the collection being built came straight back in its own Collections field.
+    ///
+    /// The null-origin call first is deliberate: it proves the fixture really does report
+    /// membership, so the empty result below is the guard firing rather than a dead fixture.
+    /// </summary>
+    [Fact]
+    public void ExtractCollections_ExcludesTheCollectionBeingBuilt()
+    {
+        var movie = TestItems.Mov("Blade Runner");
+        var boxSet = CollectionNamed("Movies [Smart]");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedCollection(cache, boxSet, movie);
+
+        Assert.Equal(["Movies [Smart]"], ExtractCollections(movie, cache, depth: 1, origin: null));
+
+        var origin = new ListOrigin("col-1", "Movies", BaseItemKind.BoxSet, [boxSet.Id]);
+
+        Assert.Empty(ExtractCollections(movie, cache, depth: 1, origin));
+    }
+
+    /// <summary>
+    /// The name-collision half of the ID-based design. The origin here is a smart PLAYLIST named
+    /// "Movies" that has already been created in Jellyfin, so it has an id - and that id is not
+    /// the BoxSet's. Under the old base-name comparison (what ExtractPlaylists used to do) the
+    /// BoxSet would be excluded purely because "Movies [Smart]" strips to "Movies", silently
+    /// hiding a collection the user never asked to hide.
+    /// </summary>
+    [Fact]
+    public void ExtractCollections_KeepsAManuallyCreatedCollectionWithTheSameName()
+    {
+        var movie = TestItems.Mov("Blade Runner");
+        var boxSet = CollectionNamed("Movies [Smart]");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedCollection(cache, boxSet, movie);
+
+        // Same base name, different Jellyfin item - a smart playlist, not this collection.
+        var origin = new ListOrigin("pl-1", "Movies", BaseItemKind.Playlist, [Guid.NewGuid()]);
+
+        Assert.Equal(["Movies [Smart]"], ExtractCollections(movie, cache, depth: 1, origin));
+    }
+
+    /// <summary>
+    /// The playlist-side equivalent: building the smart playlist "Movies" must not hide the
+    /// unrelated playlist that happens to be called "Movies [Smart]" as well.
+    /// </summary>
+    [Fact]
+    public void ExtractPlaylists_KeepsAPlaylistThatMerelySharesTheName()
+    {
+        var movie = TestItems.Mov("Blade Runner");
+        var namesake = PlaylistNamed("Movies [Smart]");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedPlaylist(cache, namesake, movie);
+
+        var origin = new ListOrigin("pl-1", "Movies", BaseItemKind.Playlist, [Guid.NewGuid()]);
+
+        Assert.Equal(["Movies [Smart]"], ExtractPlaylists(movie, cache, origin));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Cache poisoning across lists in one queue drain
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The reproduced cross-list leak, on ONE cache - which is what a real refresh queue drain
+    /// gives you, since RefreshCache is per USER and only <c>AncestorValuesById</c> is cleared
+    /// between queue items.
+    ///
+    /// Smart playlist "ZZTest Alpha" refreshes first and correctly records "no playlists" for the
+    /// movie (its own playlist is the only one, and it is excluded). Smart playlist "ZZTest Beta"
+    /// refreshes next in the same drain and asks about the same movie. Before the fix
+    /// <c>ItemPlaylists</c> was keyed on item id alone, so Beta got Alpha's origin-filtered answer
+    /// back and was blind to the playlist it was explicitly filtering on - 65 items became 0.
+    /// </summary>
+    [Fact]
+    public void ExtractPlaylists_DoesNotReuseAnotherListsOriginFilteredResult()
+    {
+        var movie = TestItems.Mov("Blade Runner");
+        var alphaPlaylist = PlaylistNamed("ZZTest Alpha [Smart]");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedPlaylist(cache, alphaPlaylist, movie);
+
+        var alpha = new ListOrigin("alpha", "ZZTest Alpha", BaseItemKind.Playlist, [alphaPlaylist.Id]);
+        var beta = new ListOrigin("beta", "ZZTest Beta", BaseItemKind.Playlist, [Guid.NewGuid()]);
+
+        Assert.Empty(ExtractPlaylists(movie, cache, alpha));
+
+        // Same item, same cache, different list being built.
+        Assert.Equal(["ZZTest Alpha [Smart]"], ExtractPlaylists(movie, cache, beta));
+    }
+
+    /// <summary>
+    /// Same leak on the collections side. This one could not exist before the fix (collections had
+    /// no origin at all), and it is the reason the cache re-key had to ship in the same change:
+    /// the new guard would otherwise have arrived with the defect already known from playlists.
+    /// </summary>
+    [Fact]
+    public void ExtractCollections_DoesNotReuseAnotherListsOriginFilteredResult()
+    {
+        var movie = TestItems.Mov("Blade Runner");
+        var alphaCollection = CollectionNamed("ZZTest Alpha [Smart]");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedCollection(cache, alphaCollection, movie);
+
+        var alpha = new ListOrigin("alpha", "ZZTest Alpha", BaseItemKind.BoxSet, [alphaCollection.Id]);
+        var beta = new ListOrigin("beta", "ZZTest Beta", BaseItemKind.BoxSet, [Guid.NewGuid()]);
+
+        Assert.Empty(ExtractCollections(movie, cache, depth: 1, alpha));
+
+        Assert.Equal(["ZZTest Alpha [Smart]"], ExtractCollections(movie, cache, depth: 1, beta));
+    }
+
+    /// <summary>
+    /// Depth and origin are independent dimensions of the collections cache key. Collapsing the
+    /// tuple back to either one alone breaks a different case, so both halves are asserted here:
+    ///
+    /// - Same origin, two depths: depth 0 sees only the inner BoxSet the movie is directly in;
+    ///   depth 1 also sees the outer BoxSet that contains it. Drop Depth from the key and the
+    ///   second answer is the first one, stale.
+    /// - Same depth, two origins: the exclusion differs per list. Drop OriginKey and this is the
+    ///   cross-list leak above.
+    /// </summary>
+    [Fact]
+    public void ExtractCollections_KeepsDepthAndOriginIndependentInTheCacheKey()
+    {
+        var movie = TestItems.Mov("Blade Runner");
+        var inner = CollectionNamed("Trilogy [Smart]");
+        var outer = CollectionNamed("Franchise [Smart]");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedCollection(cache, inner, movie);
+        SeedCollection(cache, outer, inner);
+
+        var unrelated = new ListOrigin("other-list", "Something Else", BaseItemKind.BoxSet, [Guid.NewGuid()]);
+
+        // Depth is part of the key.
+        Assert.Equal(["Trilogy [Smart]"], ExtractCollections(movie, cache, depth: 0, unrelated));
+        Assert.Equal(["Trilogy [Smart]", "Franchise [Smart]"], ExtractCollections(movie, cache, depth: 1, unrelated));
+
+        // Origin is part of the key, at the same depth.
+        var buildingTrilogy = new ListOrigin("trilogy-list", "Trilogy", BaseItemKind.BoxSet, [inner.Id]);
+
+        Assert.Equal(["Franchise [Smart]"], ExtractCollections(movie, cache, depth: 1, buildingTrilogy));
+        Assert.Equal(["Trilogy [Smart]", "Franchise [Smart]"], ExtractCollections(movie, cache, depth: 1, unrelated));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // ListOrigin itself - id first, base name only as a first-refresh fallback
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The fallback rule, with no Jellyfin plumbing at all. Before the very first refresh the
+    /// playlist/collection does not exist yet, so there is no id to match on and the base name is
+    /// all there is - that behaviour has to survive. The moment ANY id is known, the name stops
+    /// counting, which is what stops unrelated namesakes being excluded.
+    /// </summary>
+    [Fact]
+    public void ListOrigin_FallsBackToBaseNameOnlyWhenNoJellyfinIdIsKnown()
+    {
+        var candidate = CollectionNamed("Movies [Smart]");
+
+        Assert.True(new ListOrigin("col-1", "Movies", BaseItemKind.BoxSet, []).Matches(candidate));
+        Assert.False(new ListOrigin("col-1", "Movies", BaseItemKind.BoxSet, [Guid.NewGuid()]).Matches(candidate));
+        Assert.True(new ListOrigin("col-1", "Movies", BaseItemKind.BoxSet, [candidate.Id]).Matches(candidate));
+    }
+
+    /// <summary>
+    /// An unnamed origin with no ids must match NOTHING rather than everything - an empty base
+    /// name compared with <c>string.Equals</c> would otherwise match any candidate that also
+    /// strips to empty.
+    /// </summary>
+    [Fact]
+    public void ListOrigin_WithNeitherIdNorName_MatchesNothing()
+    {
+        Assert.False(new ListOrigin("col-1", null, BaseItemKind.BoxSet, []).Matches(CollectionNamed("Movies [Smart]")));
+        Assert.False(new ListOrigin("col-1", string.Empty, BaseItemKind.BoxSet, []).Matches(CollectionNamed("[Smart]")));
+    }
+
+    /// <summary>
+    /// The name fallback must never reach across kinds. A smart list that has no Jellyfin id yet is
+    /// still only ever ONE kind of container, so a same-named container of the OTHER kind is a
+    /// different thing entirely - excluding it hides something the user never asked to hide.
+    ///
+    /// This matters most on the collections side, which had no origin filter at all before this
+    /// change: a brand-new smart PLAYLIST "Marvel" would otherwise blank out the hand-made
+    /// collection "Marvel" for every item. It does not heal on the next refresh either - with
+    /// "hide when empty" the empty result deletes the Jellyfin list and clears the stored id
+    /// (PlaylistService/CollectionService), so the fallback stays armed forever.
+    /// </summary>
+    [Fact]
+    public void ListOrigin_NameFallbackIgnoresContainersOfTheOtherKind()
+    {
+        var playlistOrigin = new ListOrigin("pl-1", "Marvel", BaseItemKind.Playlist, []);
+        var collectionOrigin = new ListOrigin("col-1", "Marvel", BaseItemKind.BoxSet, []);
+
+        Assert.False(playlistOrigin.Matches(CollectionNamed("Marvel [Smart]")));
+        Assert.True(playlistOrigin.Matches(PlaylistNamed("Marvel [Smart]")));
+
+        Assert.False(collectionOrigin.Matches(PlaylistNamed("Marvel [Smart]")));
+        Assert.True(collectionOrigin.Matches(CollectionNamed("Marvel [Smart]")));
+    }
+
+    /// <summary>
+    /// The cross-kind case end to end: building the never-yet-created smart playlist "Marvel" must
+    /// leave the hand-made collection "Marvel" visible to its Collections rule.
+    /// </summary>
+    [Fact]
+    public void ExtractCollections_KeepsASameNamedCollectionWhenTheOriginIsAPlaylist()
+    {
+        var movie = TestItems.Mov("Blade Runner");
+        var boxSet = CollectionNamed("Marvel [Smart]");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedCollection(cache, boxSet, movie);
+
+        // No JellyfinPlaylistId: the playlist has never been created, so only the name fallback is left.
+        var list = new SmartList(new SmartPlaylistDto { Id = "pl-1", Name = "Marvel" });
+
+        Assert.Equal(["Marvel [Smart]"], ExtractCollections(movie, cache, depth: 1, list.Origin));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // SmartList carries the Jellyfin ids into the origin
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// An AllUsers playlist is ONE smart list rendered as one Jellyfin playlist PER USER, each
+    /// with its own id in <c>UserPlaylists</c> (plus the legacy top-level id). A single scalar
+    /// origin id would exclude one user's copy and leave every other user's copy visible to the
+    /// list's own Playlists rules, so the origin has to carry the whole set.
+    ///
+    /// Carrying all of them rather than resolving the refreshing user's one is deliberate: the
+    /// copies are indistinguishable to a rule (same name, same contents), so seeing a sibling copy
+    /// is the same self-reference bug wearing a different id.
+    /// </summary>
+    [Fact]
+    public void SmartList_Origin_CoversEveryJellyfinIdOfAnAllUsersPlaylist()
+    {
+        var legacyId = Guid.NewGuid();
+        var firstUserId = Guid.NewGuid();
+        var secondUserId = Guid.NewGuid();
+
+        var list = new SmartList(new SmartPlaylistDto
+        {
+            Id = "pl-1",
+            Name = "Movies",
+            AllUsers = true,
+            JellyfinPlaylistId = legacyId.ToString(),
+            UserPlaylists =
+            [
+                new SmartPlaylistDto.UserPlaylistMapping { UserId = "u1", JellyfinPlaylistId = firstUserId.ToString() },
+                new SmartPlaylistDto.UserPlaylistMapping { UserId = "u2", JellyfinPlaylistId = secondUserId.ToString() },
+            ],
+        });
+
+        Assert.True(list.Origin.Matches(PlaylistNamed("Movies [Smart]", legacyId)));
+        Assert.True(list.Origin.Matches(PlaylistNamed("Movies (tester) [Smart]", firstUserId)));
+        Assert.True(list.Origin.Matches(PlaylistNamed("Movies (other) [Smart]", secondUserId)));
+
+        // A namesake that is not one of this list's playlists stays visible.
+        Assert.False(list.Origin.Matches(PlaylistNamed("Movies [Smart]")));
+    }
+
+    /// <summary>
+    /// End-to-end through the extractor: every per-user copy of an AllUsers playlist drops out at
+    /// once, and an unrelated playlist survives the same pass.
+    /// </summary>
+    [Fact]
+    public void ExtractPlaylists_ExcludesEveryPerUserCopyOfAnAllUsersPlaylist()
+    {
+        var movie = TestItems.Mov("Blade Runner");
+        var firstCopy = PlaylistNamed("Movies (tester) [Smart]");
+        var secondCopy = PlaylistNamed("Movies (other) [Smart]");
+        var unrelated = PlaylistNamed("Favourites");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedPlaylist(cache, firstCopy, movie);
+        SeedPlaylist(cache, secondCopy, movie);
+        SeedPlaylist(cache, unrelated, movie);
+
+        var list = new SmartList(new SmartPlaylistDto
+        {
+            Id = "pl-1",
+            Name = "Movies",
+            AllUsers = true,
+            UserPlaylists =
+            [
+                new SmartPlaylistDto.UserPlaylistMapping { UserId = "u1", JellyfinPlaylistId = firstCopy.Id.ToString() },
+                new SmartPlaylistDto.UserPlaylistMapping { UserId = "u2", JellyfinPlaylistId = secondCopy.Id.ToString() },
+            ],
+        });
+
+        Assert.Equal(["Favourites"], ExtractPlaylists(movie, cache, list.Origin));
+    }
+
+    /// <summary>
+    /// The collection companion: a smart collection's origin carries its BoxSet id, and an
+    /// as-yet-uncreated collection (no id on the DTO) falls back to the base name so the very
+    /// first refresh is still self-reference safe.
+    /// </summary>
+    [Fact]
+    public void SmartList_Origin_UsesTheJellyfinCollectionId()
+    {
+        var boxSet = CollectionNamed("Movies [Smart]");
+
+        var created = new SmartList(new SmartCollectionDto
+        {
+            Id = "col-1",
+            Name = "Movies",
+            JellyfinCollectionId = boxSet.Id.ToString(),
+        });
+
+        Assert.True(created.Origin.Matches(boxSet));
+        Assert.False(created.Origin.Matches(CollectionNamed("Movies [Smart]")));
+
+        var neverRefreshed = new SmartList(new SmartCollectionDto { Id = "col-2", Name = "Movies" });
+
+        Assert.True(neverRefreshed.Origin.Matches(boxSet));
+    }
+}

--- a/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/ListOriginTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/ListOriginTests.cs
@@ -28,10 +28,9 @@ namespace Jellyfin.Plugin.SmartLists.Tests.Core.QueryEngine;
 ///    whole refresh queue drains, so list B refreshed after list A in one drain inherited A's
 ///    exclusions and went blind to playlist/collection A.
 ///
-/// The fix also changed WHAT counts as "myself": identity is the Jellyfin item id, with base-name
-/// comparison kept only as a fallback for the very first refresh (before the Jellyfin
-/// playlist/collection exists). Name matching alone wrongly excluded an unrelated, manually
-/// created list that merely shared the name - see
+/// The fix also changed WHAT counts as "myself": identity only - the SmartLists provider-ID
+/// tether, or a stored Jellyfin item id - never the name. Name matching wrongly excluded an
+/// unrelated, manually created list that merely shared the name - see
 /// <see cref="ExtractCollections_KeepsAManuallyCreatedCollectionWithTheSameName"/>.
 ///
 /// HARNESS NOTE: neither extractor touches <c>ILibraryManager</c> once its caches are seeded -
@@ -135,7 +134,7 @@ public class ListOriginTests
 
         Assert.Equal(["Movies [Smart]"], ExtractCollections(movie, cache, depth: 1, origin: null));
 
-        var origin = new ListOrigin("col-1", "Movies", BaseItemKind.BoxSet, [boxSet.Id]);
+        var origin = new ListOrigin("col-1", [boxSet.Id]);
 
         Assert.Empty(ExtractCollections(movie, cache, depth: 1, origin));
     }
@@ -157,7 +156,7 @@ public class ListOriginTests
         SeedCollection(cache, boxSet, movie);
 
         // Same base name, different Jellyfin item - a smart playlist, not this collection.
-        var origin = new ListOrigin("pl-1", "Movies", BaseItemKind.Playlist, [Guid.NewGuid()]);
+        var origin = new ListOrigin("pl-1", [Guid.NewGuid()]);
 
         Assert.Equal(["Movies [Smart]"], ExtractCollections(movie, cache, depth: 1, origin));
     }
@@ -175,7 +174,7 @@ public class ListOriginTests
         var cache = new RefreshQueueService.RefreshCache();
         SeedPlaylist(cache, namesake, movie);
 
-        var origin = new ListOrigin("pl-1", "Movies", BaseItemKind.Playlist, [Guid.NewGuid()]);
+        var origin = new ListOrigin("pl-1", [Guid.NewGuid()]);
 
         Assert.Equal(["Movies [Smart]"], ExtractPlaylists(movie, cache, origin));
     }
@@ -204,8 +203,8 @@ public class ListOriginTests
         var cache = new RefreshQueueService.RefreshCache();
         SeedPlaylist(cache, alphaPlaylist, movie);
 
-        var alpha = new ListOrigin("alpha", "ZZTest Alpha", BaseItemKind.Playlist, [alphaPlaylist.Id]);
-        var beta = new ListOrigin("beta", "ZZTest Beta", BaseItemKind.Playlist, [Guid.NewGuid()]);
+        var alpha = new ListOrigin("alpha", [alphaPlaylist.Id]);
+        var beta = new ListOrigin("beta", [Guid.NewGuid()]);
 
         Assert.Empty(ExtractPlaylists(movie, cache, alpha));
 
@@ -227,8 +226,8 @@ public class ListOriginTests
         var cache = new RefreshQueueService.RefreshCache();
         SeedCollection(cache, alphaCollection, movie);
 
-        var alpha = new ListOrigin("alpha", "ZZTest Alpha", BaseItemKind.BoxSet, [alphaCollection.Id]);
-        var beta = new ListOrigin("beta", "ZZTest Beta", BaseItemKind.BoxSet, [Guid.NewGuid()]);
+        var alpha = new ListOrigin("alpha", [alphaCollection.Id]);
+        var beta = new ListOrigin("beta", [Guid.NewGuid()]);
 
         Assert.Empty(ExtractCollections(movie, cache, depth: 1, alpha));
 
@@ -256,37 +255,37 @@ public class ListOriginTests
         SeedCollection(cache, inner, movie);
         SeedCollection(cache, outer, inner);
 
-        var unrelated = new ListOrigin("other-list", "Something Else", BaseItemKind.BoxSet, [Guid.NewGuid()]);
+        var unrelated = new ListOrigin("other-list", [Guid.NewGuid()]);
 
         // Depth is part of the key.
         Assert.Equal(["Trilogy [Smart]"], ExtractCollections(movie, cache, depth: 0, unrelated));
         Assert.Equal(["Trilogy [Smart]", "Franchise [Smart]"], ExtractCollections(movie, cache, depth: 1, unrelated));
 
         // Origin is part of the key, at the same depth.
-        var buildingTrilogy = new ListOrigin("trilogy-list", "Trilogy", BaseItemKind.BoxSet, [inner.Id]);
+        var buildingTrilogy = new ListOrigin("trilogy-list", [inner.Id]);
 
         Assert.Equal(["Franchise [Smart]"], ExtractCollections(movie, cache, depth: 1, buildingTrilogy));
         Assert.Equal(["Trilogy [Smart]", "Franchise [Smart]"], ExtractCollections(movie, cache, depth: 1, unrelated));
     }
 
     // ---------------------------------------------------------------------------------------
-    // ListOrigin itself - id first, base name only as a first-refresh fallback
+    // ListOrigin itself - identity only, never name
     // ---------------------------------------------------------------------------------------
 
     /// <summary>
-    /// The fallback rule, with no Jellyfin plumbing at all. Before the very first refresh the
-    /// playlist/collection does not exist yet, so there is no id to match on and the base name is
-    /// all there is - that behaviour has to survive. The moment ANY id is known, the name stops
-    /// counting, which is what stops unrelated namesakes being excluded.
+    /// Identity is the whole rule: the SmartLists provider-ID tether, or a stored Jellyfin item id.
+    /// A name is never consulted, so an identically named container belonging to somebody else is
+    /// always visible - including before this list has been created in Jellyfin, when the id set is
+    /// still empty and there is no container of ours for an item to be a member of anyway.
     /// </summary>
     [Fact]
-    public void ListOrigin_FallsBackToBaseNameOnlyWhenNoJellyfinIdIsKnown()
+    public void ListOrigin_MatchesOnIdentityAndNeverOnName()
     {
         var candidate = CollectionNamed("Movies [Smart]");
 
-        Assert.True(new ListOrigin("col-1", "Movies", BaseItemKind.BoxSet, []).Matches(candidate));
-        Assert.False(new ListOrigin("col-1", "Movies", BaseItemKind.BoxSet, [Guid.NewGuid()]).Matches(candidate));
-        Assert.True(new ListOrigin("col-1", "Movies", BaseItemKind.BoxSet, [candidate.Id]).Matches(candidate));
+        Assert.False(new ListOrigin("col-1", []).Matches(candidate));
+        Assert.False(new ListOrigin("col-1", [Guid.NewGuid()]).Matches(candidate));
+        Assert.True(new ListOrigin("col-1", [candidate.Id]).Matches(candidate));
     }
 
     /// <summary>
@@ -303,9 +302,8 @@ public class ListOriginTests
         var tethered = CollectionNamed("Uncollected [Smart]");
         tethered.SetProviderId(ProviderKeys.SmartLists, "col-1");
 
-        // Stored id is stale (points at a deleted container) and the name fallback is disarmed by
-        // the non-empty id set, so only the tether can identify this.
-        var origin = new ListOrigin("col-1", "Uncollected", BaseItemKind.BoxSet, [Guid.NewGuid()]);
+        // Stored id is stale (points at a deleted container), so only the tether can identify this.
+        var origin = new ListOrigin("col-1", [Guid.NewGuid()]);
 
         Assert.True(origin.Matches(tethered));
 
@@ -316,39 +314,23 @@ public class ListOriginTests
     }
 
     /// <summary>
-    /// An unnamed origin with no ids must match NOTHING rather than everything - an empty base
-    /// name compared with <c>string.Equals</c> would otherwise match any candidate that also
-    /// strips to empty.
+    /// A brand-new smart list - no tether match, no stored id - must match NOTHING, of either kind.
+    /// This is the case a base-name fallback used to cover, and covering it by name was the bug:
+    /// a not-yet-created smart PLAYLIST "Marvel" blanked out the hand-made COLLECTION "Marvel" for
+    /// every item, and with "hide when empty" the id was never stored, so it never healed.
+    /// Nothing is lost by matching nothing here: the list does not exist yet, so no item can be in it.
     /// </summary>
     [Fact]
-    public void ListOrigin_WithNeitherIdNorName_MatchesNothing()
+    public void ListOrigin_WithNoIdentityYet_MatchesNothing()
     {
-        Assert.False(new ListOrigin("col-1", null, BaseItemKind.BoxSet, []).Matches(CollectionNamed("Movies [Smart]")));
-        Assert.False(new ListOrigin("col-1", string.Empty, BaseItemKind.BoxSet, []).Matches(CollectionNamed("[Smart]")));
-    }
+        var brandNewPlaylist = new ListOrigin("pl-1", []);
+        var brandNewCollection = new ListOrigin("col-1", []);
 
-    /// <summary>
-    /// The name fallback must never reach across kinds. A smart list that has no Jellyfin id yet is
-    /// still only ever ONE kind of container, so a same-named container of the OTHER kind is a
-    /// different thing entirely - excluding it hides something the user never asked to hide.
-    ///
-    /// This matters most on the collections side, which had no origin filter at all before this
-    /// change: a brand-new smart PLAYLIST "Marvel" would otherwise blank out the hand-made
-    /// collection "Marvel" for every item. It does not heal on the next refresh either - with
-    /// "hide when empty" the empty result deletes the Jellyfin list and clears the stored id
-    /// (PlaylistService/CollectionService), so the fallback stays armed forever.
-    /// </summary>
-    [Fact]
-    public void ListOrigin_NameFallbackIgnoresContainersOfTheOtherKind()
-    {
-        var playlistOrigin = new ListOrigin("pl-1", "Marvel", BaseItemKind.Playlist, []);
-        var collectionOrigin = new ListOrigin("col-1", "Marvel", BaseItemKind.BoxSet, []);
+        Assert.False(brandNewPlaylist.Matches(CollectionNamed("Marvel [Smart]")));
+        Assert.False(brandNewPlaylist.Matches(PlaylistNamed("Marvel [Smart]")));
 
-        Assert.False(playlistOrigin.Matches(CollectionNamed("Marvel [Smart]")));
-        Assert.True(playlistOrigin.Matches(PlaylistNamed("Marvel [Smart]")));
-
-        Assert.False(collectionOrigin.Matches(PlaylistNamed("Marvel [Smart]")));
-        Assert.True(collectionOrigin.Matches(CollectionNamed("Marvel [Smart]")));
+        Assert.False(brandNewCollection.Matches(CollectionNamed("Marvel [Smart]")));
+        Assert.False(brandNewCollection.Matches(PlaylistNamed("Marvel [Smart]")));
     }
 
     /// <summary>
@@ -364,7 +346,8 @@ public class ListOriginTests
         var cache = new RefreshQueueService.RefreshCache();
         SeedCollection(cache, boxSet, movie);
 
-        // No JellyfinPlaylistId: the playlist has never been created, so only the name fallback is left.
+        // No JellyfinPlaylistId and no tether: the playlist has never been created, so this origin
+        // has no identity at all and must not reach across to the same-named collection.
         var list = new SmartList(new SmartPlaylistDto { Id = "pl-1", Name = "Marvel" });
 
         Assert.Equal(["Marvel [Smart]"], ExtractCollections(movie, cache, depth: 1, list.Origin));
@@ -446,8 +429,9 @@ public class ListOriginTests
 
     /// <summary>
     /// The collection companion: a smart collection's origin carries its BoxSet id, and an
-    /// as-yet-uncreated collection (no id on the DTO) falls back to the base name so the very
-    /// first refresh is still self-reference safe.
+    /// as-yet-uncreated collection (no id on the DTO) matches nothing - it has no container yet, so
+    /// there is nothing of its own for an item to be a member of. The tether covers it from the
+    /// moment the collection is created, including when the stored id later goes stale.
     /// </summary>
     [Fact]
     public void SmartList_Origin_UsesTheJellyfinCollectionId()
@@ -466,6 +450,11 @@ public class ListOriginTests
 
         var neverRefreshed = new SmartList(new SmartCollectionDto { Id = "col-2", Name = "Movies" });
 
-        Assert.True(neverRefreshed.Origin.Matches(boxSet));
+        Assert.False(neverRefreshed.Origin.Matches(boxSet));
+
+        // ...but once its collection exists it is tethered, which identifies it by itself.
+        var tethered = CollectionNamed("Movies [Smart]");
+        tethered.SetProviderId(ProviderKeys.SmartLists, "col-2");
+        Assert.True(neverRefreshed.Origin.Matches(tethered));
     }
 }

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
@@ -170,20 +170,20 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         // Non-flag properties
         public bool IncludeUnwatchedSeries { get; set; } = true;
         public List<string> AdditionalUserIds { get; set; } = [];
-        public string? OriginListName { get; set; } = null; // Name of the playlist/collection being built (to prevent self-reference)
+        public ListOrigin? Origin { get; set; } = null; // The playlist/collection being built (kept out of its own Collections/Playlists results)
         public int CollectionRecursionDepth { get; set; } = 1; // How deep to traverse nested collections (0-10, where 0 = direct members only). Note: Playlists don't support nesting, so no recursion depth for playlists.
 
         /// <summary>
         /// Creates extraction options from FieldRequirements.
         /// </summary>
-        public static MediaTypeExtractionOptions FromRequirements(FieldRequirements requirements, string? originListName = null, int collectionDepth = 1)
+        public static MediaTypeExtractionOptions FromRequirements(FieldRequirements requirements, ListOrigin? origin = null, int collectionDepth = 1)
         {
             return new MediaTypeExtractionOptions
             {
                 RequiredGroups = requirements.RequiredGroups,
                 IncludeUnwatchedSeries = requirements.IncludeUnwatchedSeries,
                 AdditionalUserIds = [.. requirements.AdditionalUserIds], // Defensive copy
-                OriginListName = originListName,
+                Origin = origin,
                 CollectionRecursionDepth = collectionDepth,
             };
         }
@@ -2860,7 +2860,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             // Extract collections - only when needed for performance
             if (options.ExtractCollections)
             {
-                operand.Collections = ExtractCollections(baseItem, user, libraryManager, cache, logger, options.CollectionRecursionDepth);
+                operand.Collections = ExtractCollections(baseItem, user, libraryManager, cache, logger, options.CollectionRecursionDepth, options.Origin);
             }
             else
             {
@@ -2871,7 +2871,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             // Note: Playlists don't support nesting (can't contain other playlists), so no recursion depth needed
             if (options.ExtractPlaylists)
             {
-                operand.Playlists = ExtractPlaylists(baseItem, user, libraryManager, cache, logger, options.OriginListName);
+                operand.Playlists = ExtractPlaylists(baseItem, user, libraryManager, cache, logger, options.Origin);
             }
             else
             {
@@ -3309,24 +3309,21 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         /// <param name="libraryManager">Library manager to query collections</param>
         /// <param name="cache">Per-refresh cache to avoid repeated queries</param>
         /// <param name="logger">Logger for debugging</param>
+        /// <param name="recursionDepth">How deep to traverse nested collections (0 = direct members only)</param>
+        /// <param name="origin">The list being built (kept out of its own results to prevent self-reference)</param>
         /// <returns>List of collection names this item belongs to</returns>
-        private static List<string> ExtractCollections(BaseItem baseItem, User user, ILibraryManager libraryManager, RefreshQueueServiceRefreshCache cache, ILogger? logger, int recursionDepth = 0)
+        private static List<string> ExtractCollections(BaseItem baseItem, User user, ILibraryManager libraryManager, RefreshQueueServiceRefreshCache cache, ILogger? logger, int recursionDepth = 0, ListOrigin? origin = null)
         {
             // Ensure recursion depth is within valid range (0 = no recursion, 1-10 = levels to traverse)
             recursionDepth = Math.Max(0, Math.Min(10, recursionDepth));
 
             // Check if we already have the result cached for this item (with matching depth)
-            // We use a combined key to cache results per depth level
-            var cacheKey = (baseItem.Id, recursionDepth);
+            // We use a combined key to cache results per depth level. The origin is part of the key
+            // because the cached names are already filtered for the list being built.
+            var cacheKey = (baseItem.Id, recursionDepth, origin?.Key ?? string.Empty);
             if (cache.ItemCollectionsWithDepth.TryGetValue(cacheKey, out var cachedCollections))
             {
                 return cachedCollections;
-            }
-
-            // Fallback to legacy cache for depth=1 (backward compatibility)
-            if (recursionDepth == 1 && cache.ItemCollections.TryGetValue(baseItem.Id, out var legacyCachedCollections))
-            {
-                return legacyCachedCollections;
             }
 
             var collections = new List<string>();
@@ -3424,6 +3421,16 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                     if (membershipCacheAtDepth.TryGetValue(collection.Id, out var membershipSet) &&
                         membershipSet.Contains(baseItem.Id))
                     {
+                        // Skip if this collection IS the list being built (prevent self-reference):
+                        // otherwise a rule like Collections NotContains "smart" matches the collection's
+                        // own name and the result oscillates between refreshes.
+                        if (origin?.Matches(collection) == true)
+                        {
+                            logger?.LogDebug("Skipping collection '{CollectionName}' for item '{ItemName}' - it is the list being built (preventing self-reference)",
+                                collection.Name, baseItem.Name);
+                            continue;
+                        }
+
                         collections.Add(collection.Name);
                     }
                 }
@@ -3435,10 +3442,6 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
 
             // Cache the result
             cache.ItemCollectionsWithDepth[cacheKey] = collections;
-            if (recursionDepth == 1)
-            {
-                cache.ItemCollections[baseItem.Id] = collections; // Backward compatibility
-            }
             return collections;
         }
 
@@ -3643,12 +3646,14 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         /// <param name="libraryManager">Library manager to query playlists</param>
         /// <param name="cache">Per-refresh cache to avoid repeated queries</param>
         /// <param name="logger">Logger for debugging</param>
-        /// <param name="originListName">Name of the playlist/collection being built (to prevent self-reference)</param>
+        /// <param name="origin">The list being built (kept out of its own results to prevent self-reference)</param>
         /// <returns>List of playlist names this item belongs to</returns>
-        private static List<string> ExtractPlaylists(BaseItem baseItem, User user, ILibraryManager libraryManager, RefreshQueueServiceRefreshCache cache, ILogger? logger, string? originListName)
+        private static List<string> ExtractPlaylists(BaseItem baseItem, User user, ILibraryManager libraryManager, RefreshQueueServiceRefreshCache cache, ILogger? logger, ListOrigin? origin)
         {
-            // Check if we already have the result cached for this item
-            if (cache.ItemPlaylists.TryGetValue(baseItem.Id, out var cachedPlaylists))
+            // Check if we already have the result cached for this item. The origin is part of the key
+            // because the cached names are already filtered for the list being built.
+            var originKey = origin?.Key ?? string.Empty;
+            if (cache.ItemPlaylists.TryGetValue((baseItem.Id, originKey), out var cachedPlaylists))
             {
                 return cachedPlaylists;
             }
@@ -3758,17 +3763,12 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                     if (cache.PlaylistMembershipCache.TryGetValue(playlist.Id, out var membershipSet) &&
                         membershipSet.Contains(baseItem.Id))
                     {
-                        // Skip if this playlist matches the origin list (prevent self-reference)
-                        if (!string.IsNullOrEmpty(originListName))
+                        // Skip if this playlist IS the list being built (prevent self-reference)
+                        if (origin?.Matches(playlist) == true)
                         {
-                            var playlistBaseName = NameFormatter.StripPrefixAndSuffix(playlist.Name);
-                            var originBaseName = NameFormatter.StripPrefixAndSuffix(originListName);
-                            if (playlistBaseName.Equals(originBaseName, StringComparison.OrdinalIgnoreCase))
-                            {
-                                logger?.LogDebug("Skipping playlist '{PlaylistName}' for item '{ItemName}' - matches origin list '{OriginName}' (preventing self-reference)",
-                                    playlist.Name, baseItem.Name, originListName);
-                                continue;
-                            }
+                            logger?.LogDebug("Skipping playlist '{PlaylistName}' for item '{ItemName}' - it is the list being built (preventing self-reference)",
+                                playlist.Name, baseItem.Name);
+                            continue;
                         }
 
                         playlists.Add(playlist.Name);
@@ -3788,7 +3788,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             }
 
             // Cache the result
-            cache.ItemPlaylists[baseItem.Id] = playlists;
+            cache.ItemPlaylists[(baseItem.Id, originKey)] = playlists;
             logger?.LogDebug("Cached {Count} playlists for item '{ItemName}'", playlists.Count, baseItem.Name);
             return playlists;
         }

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/FieldRegistry.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/FieldRegistry.cs
@@ -43,7 +43,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
     /// - AudioQuality: MediaStreamsCache
     /// - VideoQuality: MediaStreamsCache
     /// - People: ItemPeople
-    /// - Collections: ItemCollections, CollectionMembershipCache
+    /// - Collections: ItemCollectionsWithDepth, CollectionMembershipCache
     /// - Playlists: ItemPlaylists, PlaylistMembershipCache
     /// - NextUnwatched: NextUnwatched cache
     /// - SeriesName: SeriesNameById
@@ -64,7 +64,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         AudioQuality = 1 << 1,        // Fields: AudioBitrate, AudioSampleRate, AudioBitDepth, AudioCodec, AudioProfile, AudioChannels | Cache: MediaStreamsCache
         VideoQuality = 1 << 2,        // Fields: Resolution, Framerate, VideoCodec, VideoProfile, VideoRange, VideoRangeType | Cache: MediaStreamsCache
         People = 1 << 3,              // Fields: All people roles (Actors, Directors, etc.) | Cache: ItemPeople
-        Collections = 1 << 4,         // Fields: Collections | Cache: ItemCollections, CollectionMembershipCache
+        Collections = 1 << 4,         // Fields: Collections | Cache: ItemCollectionsWithDepth, CollectionMembershipCache
         Playlists = 1 << 5,           // Fields: Playlists | Cache: ItemPlaylists, PlaylistMembershipCache
         NextUnwatched = 1 << 6,       // Fields: NextUnwatched | Cache: NextUnwatched
         SeriesName = 1 << 7,          // Fields: SeriesName | Cache: SeriesNameById

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/ListOrigin.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/ListOrigin.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.SmartLists.Core.Constants;
-using Jellyfin.Plugin.SmartLists.Utilities;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Model.Entities;
 
@@ -11,37 +9,28 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
     /// <summary>
     /// Identifies the smart list currently being built, so that list can be kept out of its own
     /// Collections/Playlists results (self-reference prevention).
-    /// Matching is by Jellyfin item id whenever one is known; base-name comparison is only a fallback
-    /// for the very first refresh, before the Jellyfin playlist/collection has been created, and even
-    /// then only against containers of this list's own kind. Matching by id means a separate, manually
-    /// created list that merely shares the name is no longer excluded.
+    /// Matching is by identity only - the SmartLists provider-ID tether, or a stored Jellyfin item
+    /// id - never by name. A separate list that merely shares the name is therefore matched
+    /// normally, and renaming the Jellyfin playlist/collection does not break the exclusion.
     /// </summary>
     public sealed class ListOrigin
     {
         private readonly HashSet<Guid> _jellyfinItemIds;
-        private readonly BaseItemKind _itemKind;
-        private readonly string _baseName;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ListOrigin"/> class describing the list being built.
         /// </summary>
-        /// <param name="key">Stable identifier for this list (the plugin's own list id). Also used as part of the
+        /// <param name="key">The plugin's own list id. This is what the plugin writes into the
+        /// SmartLists provider-ID tether on the Jellyfin item, and it is also used as part of the
         /// per-item extraction cache keys so origin-filtered results are never shared between lists.</param>
-        /// <param name="name">The list name; used only for the base-name fallback.</param>
-        /// <param name="itemKind">What this list is rendered as in Jellyfin: <see cref="BaseItemKind.Playlist"/>
-        /// or <see cref="BaseItemKind.BoxSet"/>. Bounds the base-name fallback to that kind.</param>
         /// <param name="jellyfinItemIds">Every Jellyfin playlist/collection id belonging to this list
-        /// (an AllUsers playlist has one per user).</param>
-        public ListOrigin(string key, string? name, BaseItemKind itemKind, IEnumerable<Guid> jellyfinItemIds)
+        /// (an AllUsers playlist has one per user). Empty until the list has been created in Jellyfin.</param>
+        public ListOrigin(string key, IEnumerable<Guid> jellyfinItemIds)
         {
             ArgumentNullException.ThrowIfNull(jellyfinItemIds);
 
             Key = key;
-            _itemKind = itemKind;
             _jellyfinItemIds = [.. jellyfinItemIds];
-
-            // Stripped once here rather than per candidate inside the extraction loops.
-            _baseName = NameFormatter.StripPrefixAndSuffix(name ?? string.Empty);
         }
 
         /// <summary>
@@ -62,24 +51,17 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             // stored Jellyfin id can be stale, and the recovery that repairs it (PlaylistService /
             // CollectionService) runs *after* filtering - so during a recovery refresh the id set
             // alone would miss the real container and let the list see itself again.
+            // Every list this plugin creates is tethered at creation.
             if (!string.IsNullOrEmpty(Key)
                 && string.Equals(candidate.GetProviderId(ProviderKeys.SmartLists), Key, StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
 
-            if (_jellyfinItemIds.Count > 0)
-            {
-                return _jellyfinItemIds.Contains(candidate.Id);
-            }
-
-            // No Jellyfin id yet (first refresh): fall back to comparing base names, but only against
-            // candidates of this list's own kind. A playlist never IS a collection, so excluding a
-            // same-named container of the other kind would hide something the user never asked to hide.
-            return _baseName.Length > 0
-                && candidate.GetBaseItemKind() == _itemKind
-                && NameFormatter.StripPrefixAndSuffix(candidate.Name ?? string.Empty)
-                    .Equals(_baseName, StringComparison.OrdinalIgnoreCase);
+            // Before the list exists in Jellyfin this set is empty and nothing matches, which is
+            // correct: there is no container of ours yet for an item to be a member of. Matching on
+            // name instead would only ever hit somebody else's identically named list.
+            return _jellyfinItemIds.Contains(candidate.Id);
         }
     }
 }

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/ListOrigin.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/ListOrigin.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
 using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.SmartLists.Core.Constants;
 using Jellyfin.Plugin.SmartLists.Utilities;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Model.Entities;
 
 namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
 {
@@ -55,6 +57,16 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         public bool Matches(BaseItem candidate)
         {
             ArgumentNullException.ThrowIfNull(candidate);
+
+            // The provider-ID tether is the authoritative identity. It is checked first because the
+            // stored Jellyfin id can be stale, and the recovery that repairs it (PlaylistService /
+            // CollectionService) runs *after* filtering - so during a recovery refresh the id set
+            // alone would miss the real container and let the list see itself again.
+            if (!string.IsNullOrEmpty(Key)
+                && string.Equals(candidate.GetProviderId(ProviderKeys.SmartLists), Key, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
 
             if (_jellyfinItemIds.Count > 0)
             {

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/ListOrigin.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/ListOrigin.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.SmartLists.Utilities;
+using MediaBrowser.Controller.Entities;
+
+namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
+{
+    /// <summary>
+    /// Identifies the smart list currently being built, so that list can be kept out of its own
+    /// Collections/Playlists results (self-reference prevention).
+    /// Matching is by Jellyfin item id whenever one is known; base-name comparison is only a fallback
+    /// for the very first refresh, before the Jellyfin playlist/collection has been created, and even
+    /// then only against containers of this list's own kind. Matching by id means a separate, manually
+    /// created list that merely shares the name is no longer excluded.
+    /// </summary>
+    public sealed class ListOrigin
+    {
+        private readonly HashSet<Guid> _jellyfinItemIds;
+        private readonly BaseItemKind _itemKind;
+        private readonly string _baseName;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ListOrigin"/> class describing the list being built.
+        /// </summary>
+        /// <param name="key">Stable identifier for this list (the plugin's own list id). Also used as part of the
+        /// per-item extraction cache keys so origin-filtered results are never shared between lists.</param>
+        /// <param name="name">The list name; used only for the base-name fallback.</param>
+        /// <param name="itemKind">What this list is rendered as in Jellyfin: <see cref="BaseItemKind.Playlist"/>
+        /// or <see cref="BaseItemKind.BoxSet"/>. Bounds the base-name fallback to that kind.</param>
+        /// <param name="jellyfinItemIds">Every Jellyfin playlist/collection id belonging to this list
+        /// (an AllUsers playlist has one per user).</param>
+        public ListOrigin(string key, string? name, BaseItemKind itemKind, IEnumerable<Guid> jellyfinItemIds)
+        {
+            ArgumentNullException.ThrowIfNull(jellyfinItemIds);
+
+            Key = key;
+            _itemKind = itemKind;
+            _jellyfinItemIds = [.. jellyfinItemIds];
+
+            // Stripped once here rather than per candidate inside the extraction loops.
+            _baseName = NameFormatter.StripPrefixAndSuffix(name ?? string.Empty);
+        }
+
+        /// <summary>
+        /// Stable identifier for the list being built. Part of the per-item cache keys in RefreshCache.
+        /// </summary>
+        public string Key { get; }
+
+        /// <summary>
+        /// Returns true when the candidate playlist/collection IS the list currently being built.
+        /// </summary>
+        /// <param name="candidate">The playlist/collection encountered while extracting membership.</param>
+        /// <returns>True if the candidate is this list and must be skipped.</returns>
+        public bool Matches(BaseItem candidate)
+        {
+            ArgumentNullException.ThrowIfNull(candidate);
+
+            if (_jellyfinItemIds.Count > 0)
+            {
+                return _jellyfinItemIds.Contains(candidate.Id);
+            }
+
+            // No Jellyfin id yet (first refresh): fall back to comparing base names, but only against
+            // candidates of this list's own kind. A playlist never IS a collection, so excluding a
+            // same-named container of the other kind would hide something the user never asked to hide.
+            return _baseName.Length > 0
+                && candidate.GetBaseItemKind() == _itemKind
+                && NameFormatter.StripPrefixAndSuffix(candidate.Name ?? string.Empty)
+                    .Equals(_baseName, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -1924,7 +1924,6 @@ namespace Jellyfin.Plugin.SmartLists.Core
 
                 // Track visited collections to prevent duplicates and circular references
                 var visitedCollectionIds = new HashSet<Guid>();
-                var currentListBaseName = NameFormatter.StripPrefixAndSuffix(Name);
 
                 // Prepare the rule groups containing collection-only rules - the whole group
                 // (name rules + sibling rules) must match for a collection to be included
@@ -1937,9 +1936,8 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 {
                     if (collection == null) continue;
 
-                    // Skip if this collection is the same as the one we're currently building (prevent self-reference)
-                    var collectionBaseName = NameFormatter.StripPrefixAndSuffix(collection.Name);
-                    if (collectionBaseName.Equals(currentListBaseName, StringComparison.OrdinalIgnoreCase))
+                    // Skip if this collection is the one we're currently building (prevent self-reference)
+                    if (Origin.Matches(collection))
                     {
                         logger?.LogDebug("Skipping collection '{CollectionName}' - matches current collection being built (preventing self-reference)", collection.Name);
                         continue;
@@ -1977,7 +1975,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                             logger,
                             0,  // Start at depth 0 (root level)
                             maxRecursionDepth,
-                            currentListBaseName,
+                            Origin,
                             encounteredIds);
 
                         if (encounteredIds != null)
@@ -2020,7 +2018,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
             ILogger? logger,
             int currentDepth,
             int maxDepth,
-            string currentListBaseName,
+            ListOrigin origin,
             HashSet<Guid>? encounteredIds = null)
         {
             bool alreadyAdded = visitedCollectionIds.Contains(collection.Id);
@@ -2055,9 +2053,8 @@ namespace Jellyfin.Plugin.SmartLists.Core
                     // Check if child is a collection
                     if (child.GetBaseItemKind() == BaseItemKind.BoxSet && allCollectionsById.ContainsKey(child.Id))
                     {
-                        // Skip if matches current list being built
-                        var childBaseName = NameFormatter.StripPrefixAndSuffix(child.Name);
-                        if (childBaseName.Equals(currentListBaseName, StringComparison.OrdinalIgnoreCase))
+                        // Skip if this child is the list being built (prevent self-reference)
+                        if (origin.Matches(child))
                         {
                             continue;
                         }
@@ -2071,7 +2068,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                             logger,
                             currentDepth + 1,
                             maxDepth,
-                            currentListBaseName,
+                            origin,
                             encounteredIds);
                     }
                 }
@@ -2243,8 +2240,6 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 var allPlaylists = libraryManager.GetItemsResult(playlistQuery).Items;
                 logger?.LogDebug("Found {Count} total playlists to check against Playlists rules with IncludePlaylistOnly=true", allPlaylists.Count);
 
-                var currentListBaseName = NameFormatter.StripPrefixAndSuffix(Name);
-
                 // Prepare the rule groups containing playlist-only rules - the whole group
                 // (name rules + sibling rules) must match for a playlist to be included
                 var includeOnlyRuleSets = BuildIncludeOnlyRuleSets("Playlists", user, logger);
@@ -2256,9 +2251,8 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 {
                     if (playlist == null) continue;
 
-                    // Skip if this playlist is the same as the one we're currently building (prevent self-reference)
-                    var playlistBaseName = NameFormatter.StripPrefixAndSuffix(playlist.Name);
-                    if (playlistBaseName.Equals(currentListBaseName, StringComparison.OrdinalIgnoreCase))
+                    // Skip if this playlist is the one we're currently building (prevent self-reference)
+                    if (Origin.Matches(playlist))
                     {
                         logger?.LogDebug("Skipping playlist '{PlaylistName}' - matches current list being built (preventing self-reference)", playlist.Name);
                         continue;

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -81,7 +81,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
             // DEPRECATED: dto.UserId is for backwards compatibility with old single-user playlists.
             // It is planned to be removed in version 10.12. Use UserPlaylists array instead.
             UserId = Guid.TryParse(dto.UserId, out var userId) ? userId : Guid.Empty;
-            Origin = new ListOrigin(Id, Name, BaseItemKind.Playlist, CollectJellyfinPlaylistIds(dto));
+            Origin = new ListOrigin(Id, CollectJellyfinPlaylistIds(dto));
 
             // Initialize properties before calling InitializeFromDto
             Orders = [];
@@ -101,7 +101,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
             // It is planned to be removed in version 10.12. Use UserPlaylists array instead.
             // Note: Collections still use UserId for owner context (IsPlayed, IsFavorite, etc.)
             UserId = Guid.TryParse(dto.UserId, out var userId) ? userId : Guid.Empty; // Owner user for rule context (IsPlayed, IsFavorite, etc.)
-            Origin = new ListOrigin(Id, Name, BaseItemKind.BoxSet, CollectJellyfinCollectionIds(dto));
+            Origin = new ListOrigin(Id, CollectJellyfinCollectionIds(dto));
 
             // Initialize properties before calling InitializeFromDto
             Orders = [];

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -25,6 +25,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
     {
         public string Id { get; set; } = null!;
         public string Name { get; set; } = null!;
+        public ListOrigin Origin { get; private set; }  // Identifies this list so it stays out of its own Collections/Playlists results
         public string? FileName { get; set; }
         public Guid UserId { get; set; }
         public List<Order> Orders { get; set; }
@@ -80,6 +81,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
             // DEPRECATED: dto.UserId is for backwards compatibility with old single-user playlists.
             // It is planned to be removed in version 10.12. Use UserPlaylists array instead.
             UserId = Guid.TryParse(dto.UserId, out var userId) ? userId : Guid.Empty;
+            Origin = new ListOrigin(Id, Name, BaseItemKind.Playlist, CollectJellyfinPlaylistIds(dto));
 
             // Initialize properties before calling InitializeFromDto
             Orders = [];
@@ -99,12 +101,48 @@ namespace Jellyfin.Plugin.SmartLists.Core
             // It is planned to be removed in version 10.12. Use UserPlaylists array instead.
             // Note: Collections still use UserId for owner context (IsPlayed, IsFavorite, etc.)
             UserId = Guid.TryParse(dto.UserId, out var userId) ? userId : Guid.Empty; // Owner user for rule context (IsPlayed, IsFavorite, etc.)
+            Origin = new ListOrigin(Id, Name, BaseItemKind.BoxSet, CollectJellyfinCollectionIds(dto));
 
             // Initialize properties before calling InitializeFromDto
             Orders = [];
             ExpressionSets = [];
 
             InitializeFromDto(dto);
+        }
+
+        /// <summary>
+        /// Every Jellyfin playlist id that IS this smart list. An AllUsers/multi-user playlist has one
+        /// Jellyfin playlist per user, and each of them is a copy of this same list, so all of them must
+        /// be excluded from this list's own Playlists results.
+        /// </summary>
+        private static IEnumerable<Guid> CollectJellyfinPlaylistIds(SmartPlaylistDto dto)
+        {
+            if (Guid.TryParse(dto.JellyfinPlaylistId, out var legacyId) && legacyId != Guid.Empty)
+            {
+                yield return legacyId;
+            }
+
+            if (dto.UserPlaylists != null)
+            {
+                foreach (var mapping in dto.UserPlaylists)
+                {
+                    if (Guid.TryParse(mapping.JellyfinPlaylistId, out var userPlaylistId) && userPlaylistId != Guid.Empty)
+                    {
+                        yield return userPlaylistId;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// The Jellyfin collection (BoxSet) id that IS this smart list, if it has been created yet.
+        /// </summary>
+        private static IEnumerable<Guid> CollectJellyfinCollectionIds(SmartCollectionDto dto)
+        {
+            if (Guid.TryParse(dto.JellyfinCollectionId, out var collectionId) && collectionId != Guid.Empty)
+            {
+                yield return collectionId;
+            }
         }
 
         private void InitializeFromDto(SmartListDto dto)
@@ -1253,7 +1291,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 {
                     RequiredGroups = requiredGroup,
                     IncludeUnwatchedSeries = true,
-                    OriginListName = Name,
+                    Origin = this.Origin,
                 };
 
                 var groups = new Dictionary<string, List<BaseItem>>(StringComparer.OrdinalIgnoreCase);
@@ -1711,7 +1749,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 CollectionRecursionDepth = Math.Max(1, CollectionSearchDepth),
                 IncludeUnwatchedSeries = fieldReqs.IncludeUnwatchedSeries,
                 AdditionalUserIds = fieldReqs.AdditionalUserIds,
-                OriginListName = Name,
+                Origin = this.Origin,
             };
         }
 
@@ -2331,7 +2369,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                     ExtractSeriesName = false,
                     IncludeUnwatchedSeries = true,
                     AdditionalUserIds = [],
-                    OriginListName = Name,
+                    Origin = this.Origin,
                 },
                 refreshCache);
                 bool matchesCollectionsRule = DoCollectionsMatchRules(collectionsOperand.Collections);
@@ -2524,7 +2562,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 logger?.LogDebug("Filtering {EpisodeCount} episodes against playlist rules", episodes.Count);
 
                 // Create extraction options from field requirements (DRY - single source of truth)
-                var extractionOptions = MediaTypeExtractionOptions.FromRequirements(fieldReqs, Name, CollectionSearchDepth);
+                var extractionOptions = MediaTypeExtractionOptions.FromRequirements(fieldReqs, Origin, CollectionSearchDepth);
 
                 foreach (var episode in episodes)
                 {
@@ -2874,7 +2912,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                                 ExtractSeriesName = false,
                                 IncludeUnwatchedSeries = true,
                                 AdditionalUserIds = [],
-                                OriginListName = Name,
+                                Origin = this.Origin,
                             },
                             refreshCache);
                             itemMinutes = operand.RuntimeMinutes;
@@ -3038,7 +3076,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                         logger?.LogDebug("Processing {Count} items sequentially (expensive-only path)", itemList.Count);
 
                         // Create extraction options from field requirements (DRY - single source of truth)
-                        var extractionOptions = MediaTypeExtractionOptions.FromRequirements(fieldReqs, Name, CollectionSearchDepth);
+                        var extractionOptions = MediaTypeExtractionOptions.FromRequirements(fieldReqs, Origin, CollectionSearchDepth);
 
                         foreach (var item in itemList)
                         {
@@ -3171,7 +3209,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                                     RequiredGroups = phase1Groups, // Only cheap extraction groups for Phase 1
                                     IncludeUnwatchedSeries = true,
                                     AdditionalUserIds = [.. fieldReqs.AdditionalUserIds],
-                                    OriginListName = Name,
+                                    Origin = this.Origin,
                                 }, refreshCache);
 
                                 // Check if item passes all non-expensive rules for any rule set that has non-expensive rules
@@ -3249,7 +3287,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                         logger?.LogDebug("Processing {Count} Phase 1 survivors sequentially (Phase 2)", phase1Survivors.Count);
 
                         // Create extraction options from field requirements for Phase 2 (DRY - single source of truth)
-                        var phase2Options = MediaTypeExtractionOptions.FromRequirements(fieldReqs, Name, CollectionSearchDepth);
+                        var phase2Options = MediaTypeExtractionOptions.FromRequirements(fieldReqs, Origin, CollectionSearchDepth);
 
                         foreach (var item in phase1Survivors)
                         {
@@ -3415,7 +3453,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
             logger?.LogDebug("Processing {Count} items sequentially (simple path)", itemList.Count);
 
             // Create extraction options from field requirements (DRY - single source of truth)
-            var extractionOptions = MediaTypeExtractionOptions.FromRequirements(fieldReqs, Name, CollectionSearchDepth);
+            var extractionOptions = MediaTypeExtractionOptions.FromRequirements(fieldReqs, Origin, CollectionSearchDepth);
 
             try
             {

--- a/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
@@ -1335,6 +1335,11 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                     MediaTypes = bumpers.MediaTypes ?? [],
                     Order = new OrderDto { SortOptions = [sortOption] },
 
+                    // The bumper pool builds part of the parent playlist, so the parent's Jellyfin
+                    // playlist(s) must stay out of the pool's own Playlists results (self-reference).
+                    JellyfinPlaylistId = dto.JellyfinPlaylistId,
+                    UserPlaylists = dto.UserPlaylists,
+
                     // Extras (trailers, interstitials, etc.) are the archetypal bumper
                     // content, so bumper pools always fetch them; bumper rules still filter.
                     IncludeExtras = true,

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
@@ -739,10 +739,17 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
             public ConcurrentDictionary<(Guid SeasonId, Guid UserId), BaseItem[]> SeasonEpisodes { get; } = new();
             public ConcurrentDictionary<(Guid AlbumId, Guid UserId), BaseItem[]> AlbumTracks { get; } = new();
             public ConcurrentDictionary<(Guid SeriesId, Guid UserId, bool IncludeUnwatchedSeries), (Guid? NextEpisodeId, int Season, int Episode)> NextUnwatched { get; } = new();
-            public ConcurrentDictionary<Guid, List<string>> ItemCollections { get; } = new();
             public BaseItem[]? AllCollections { get; set; } = null;
             public ConcurrentDictionary<Guid, HashSet<Guid>> CollectionMembershipCache { get; } = new();
-            public ConcurrentDictionary<Guid, List<string>> ItemPlaylists { get; } = new();
+
+            /// <summary>
+            /// Playlist names an item belongs to, ALREADY FILTERED for the list being built (a list never
+            /// sees itself). The origin key is therefore part of the key: this cache is per-user and lives
+            /// until the whole refresh queue drains, so without it a later list in the same drain would
+            /// inherit an earlier list's exclusions and silently go blind to that playlist.
+            /// </summary>
+            public ConcurrentDictionary<(Guid ItemId, string OriginKey), List<string>> ItemPlaylists { get; } = new();
+
             public BaseItem[]? AllPlaylists { get; set; } = null;
             public ConcurrentDictionary<Guid, HashSet<Guid>> PlaylistMembershipCache { get; } = new();
             public ConcurrentDictionary<Guid, string> SeriesNameById { get; } = new();
@@ -782,8 +789,10 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
             // Outer key is recursion depth, inner maps Collection ID → set of all member IDs at that depth
             public ConcurrentDictionary<int, Dictionary<Guid, HashSet<Guid>>> CollectionMembershipCacheByDepth { get; } = new();
 
-            // Item membership cache with depth key for collections - maps (ItemId, Depth) → list of collection names
-            public ConcurrentDictionary<(Guid ItemId, int Depth), List<string>> ItemCollectionsWithDepth { get; } = new();
+            // Item membership cache for collections - maps (ItemId, Depth, OriginKey) → list of collection names.
+            // Like ItemPlaylists, the stored names are already filtered for the list being built, so the origin
+            // MUST be part of the key: this cache is per-user and lives until the whole refresh queue drains.
+            public ConcurrentDictionary<(Guid ItemId, int Depth, string OriginKey), List<string>> ItemCollectionsWithDepth { get; } = new();
 
             // Last episode air date cache for Series items - maps SeriesId → Unix timestamp of most recent episode
             public ConcurrentDictionary<Guid, double> LastEpisodeAirDateById { get; } = new();

--- a/docs/content/changelog/rc.md
+++ b/docs/content/changelog/rc.md
@@ -18,7 +18,7 @@ itself (`v10.10.10.0-rc3`), which is the scheme used before the number moved int
 **Bug Fixes**
 
 - Smart collections no longer see themselves when a rule checks **Collection name**. Previously a collection whose own name matched its rule — which the default `[Smart]` suffix makes easy, for example a "not contains smart" rule meant to list uncollected items — flipped between full and empty on every refresh, because its own contents fed back into its own rule. Smart playlists already had this protection; collections did not ([#499](https://github.com/jyourstone/jellyfin-smartlists-plugin/issues/499)).
-- A list is now recognised by identity rather than by name, so a separate collection or playlist that merely shares the name is matched normally, and renaming the Jellyfin list does not break the exclusion.
+- A list is now recognised by identity rather than by name, so a separate collection or playlist that merely shares the name is matched normally, and renaming the Jellyfin list does not break the exclusion. A list that has not been created in Jellyfin yet has no identity to match on, so its very first refresh still falls back to matching on name.
 - Fixed **Collection name** and **Playlist name** rules returning wrong results when several lists were refreshed in one batch. The first list's self-exclusion leaked into the lists refreshed after it, making them blind to that list.
 
 **Existing lists may change**

--- a/docs/content/changelog/rc.md
+++ b/docs/content/changelog/rc.md
@@ -18,7 +18,7 @@ itself (`v10.10.10.0-rc3`), which is the scheme used before the number moved int
 **Bug Fixes**
 
 - Smart collections no longer see themselves when a rule checks **Collection name**. Previously a collection whose own name matched its rule — which the default `[Smart]` suffix makes easy, for example a "not contains smart" rule meant to list uncollected items — flipped between full and empty on every refresh, because its own contents fed back into its own rule. Smart playlists already had this protection; collections did not ([#499](https://github.com/jyourstone/jellyfin-smartlists-plugin/issues/499)).
-- A list is now recognised by identity rather than by name, so a separate collection or playlist that merely shares the name is matched normally, and renaming the Jellyfin list does not break the exclusion. A list that has not been created in Jellyfin yet has no identity to match on, so its very first refresh still falls back to matching on name.
+- A list is now recognised by identity rather than by name, so a separate collection or playlist that merely shares the name is matched normally, and renaming the Jellyfin list does not break the exclusion.
 - Fixed **Collection name** and **Playlist name** rules returning wrong results when several lists were refreshed in one batch. The first list's self-exclusion leaked into the lists refreshed after it, making them blind to that list.
 
 **Existing lists may change**

--- a/docs/content/changelog/rc.md
+++ b/docs/content/changelog/rc.md
@@ -13,6 +13,19 @@ A non-zero final segment is the RC number — older entries instead number the R
 itself (`v10.10.10.0-rc3`), which is the scheme used before the number moved into the version.
 
 
+## Unreleased
+
+**Bug Fixes**
+
+- Smart collections no longer see themselves when a rule checks **Collection name**. Previously a collection whose own name matched its rule — which the default `[Smart]` suffix makes easy, for example a "not contains smart" rule meant to list uncollected items — flipped between full and empty on every refresh, because its own contents fed back into its own rule. Smart playlists already had this protection; collections did not ([#499](https://github.com/jyourstone/jellyfin-smartlists-plugin/issues/499)).
+- A list is now recognised by identity rather than by name, so a separate collection or playlist that merely shares the name is matched normally, and renaming the Jellyfin list does not break the exclusion.
+- Fixed **Collection name** and **Playlist name** rules returning wrong results when several lists were refreshed in one batch. The first list's self-exclusion leaked into the lists refreshed after it, making them blind to that list.
+
+**Existing lists may change**
+
+- Collections with a **Collection name** rule that matched their own name will settle on the correct contents instead of alternating. Lists affected by the batch-refresh problem above may gain items they were previously missing.
+
+
 ## v12.0.0.16-rc
 
 *2026-08-15 · [release notes](https://github.com/jyourstone/jellyfin-smartlists-plugin/releases/tag/v12.0.0.16-rc)*

--- a/docs/content/user-guide/fields-and-operators.md
+++ b/docs/content/user-guide/fields-and-operators.md
@@ -260,7 +260,7 @@ How deep to traverse nested collections (default: 0):
     Higher search depths require more database queries. Start with depth 0 and increase only if needed.
 
 !!! note "Self-Reference Prevention"
-    Smart collections never include themselves in results, even if they match the rule criteria.
+    Smart collections never include themselves in results, even if they match the rule criteria. The collection is recognised by identity, not by name, so a separate collection or playlist that merely shares the name is still matched normally, and renaming the Jellyfin collection does not break the exclusion.
 
 #### Playlist Name
 
@@ -284,7 +284,7 @@ Filter items based on Jellyfin playlist membership.
     Only playlists you own or that are marked as public are accessible.
 
 !!! note "Self-Reference Prevention"
-    Smart playlists never include themselves in results, even if they match the rule criteria.
+    Smart playlists never include themselves in results, even if they match the rule criteria. The playlist is recognised by identity, not by name, so a separate playlist or collection that merely shares the name is still matched normally, and renaming the Jellyfin playlist does not break the exclusion.
 
 #### External List
 

--- a/docs/content/user-guide/fields-and-operators.md
+++ b/docs/content/user-guide/fields-and-operators.md
@@ -262,8 +262,6 @@ How deep to traverse nested collections (default: 0):
 !!! note "Self-Reference Prevention"
     Smart collections never include themselves in results, even if they match the rule criteria. The collection is recognised by identity, not by name, so a separate collection or playlist that merely shares the name is still matched normally, and renaming the Jellyfin collection does not break the exclusion.
 
-    The one exception is a smart collection that has not been created in Jellyfin yet — on that first refresh it has no identity to match on, so it falls back to skipping collections whose name matches its own.
-
 #### Playlist Name
 
 JSON name: `Playlists`
@@ -287,8 +285,6 @@ Filter items based on Jellyfin playlist membership.
 
 !!! note "Self-Reference Prevention"
     Smart playlists never include themselves in results, even if they match the rule criteria. The playlist is recognised by identity, not by name, so a separate playlist or collection that merely shares the name is still matched normally, and renaming the Jellyfin playlist does not break the exclusion.
-
-    The one exception is a smart playlist that has not been created in Jellyfin yet — on that first refresh it has no identity to match on, so it falls back to skipping playlists whose name matches its own.
 
 #### External List
 

--- a/docs/content/user-guide/fields-and-operators.md
+++ b/docs/content/user-guide/fields-and-operators.md
@@ -262,6 +262,8 @@ How deep to traverse nested collections (default: 0):
 !!! note "Self-Reference Prevention"
     Smart collections never include themselves in results, even if they match the rule criteria. The collection is recognised by identity, not by name, so a separate collection or playlist that merely shares the name is still matched normally, and renaming the Jellyfin collection does not break the exclusion.
 
+    The one exception is a smart collection that has not been created in Jellyfin yet — on that first refresh it has no identity to match on, so it falls back to skipping collections whose name matches its own.
+
 #### Playlist Name
 
 JSON name: `Playlists`
@@ -285,6 +287,8 @@ Filter items based on Jellyfin playlist membership.
 
 !!! note "Self-Reference Prevention"
     Smart playlists never include themselves in results, even if they match the rule criteria. The playlist is recognised by identity, not by name, so a separate playlist or collection that merely shares the name is still matched normally, and renaming the Jellyfin playlist does not break the exclusion.
+
+    The one exception is a smart playlist that has not been created in Jellyfin yet — on that first refresh it has no identity to match on, so it falls back to skipping playlists whose name matches its own.
 
 #### External List
 


### PR DESCRIPTION
## What

A smart **collection** saw itself in the `Collections` rule field, so its own contents fed back into its own rule and it alternated between full and empty on every refresh. This fixes that, and fixes a second, latent defect the same change would otherwise have replicated.

Fixes #499

## Why

The default `PlaylistNameSuffix` is `[Smart]` and is shared by playlists and collections, so every smart list's Jellyfin name contains "smart". A rule like `Collections not contains "smart"` — the natural way to build an "everything not already in a collection" list, and exactly what the reporter did — therefore matches the collection's own name. No custom configuration is needed to hit this.

The guard already existed for playlists: `ExtractPlaylists` took an `originListName` and skipped the list being built. `ExtractCollections` was simply never passed the origin, even though `MediaTypeExtractionOptions.OriginListName` was populated at every call site. The docs already claimed both list types exclude themselves; for collections that was not true.

Reproduced against a dev Jellyfin, movie collection, four consecutive refreshes:

```
65 items → 0 items → 65 items → 0 items
```

The reporter's stranger symptom — "now it only contains the removed items" — is the same alternation seen from a different starting state: when an item elsewhere becomes newly eligible, the refresh that follows returns only that item (everything else is still inside the list and so fails), and the next one returns everything else.

### The second bug

`RefreshQueueService.RefreshCache` is created per user and survives until the whole refresh queue drains (only `AncestorValuesById` is cleared per queue item). But `ItemPlaylists` and `ItemCollectionsWithDepth` store origin-**filtered** results under keys that carry no origin. A list refreshed after another in the same drain inherited the earlier list's exclusions and went blind to that list.

Reproduced with two smart playlists — `Alpha` (rule `Playlists not contains "zzzzzz"`, which matches everything *and* invokes the extractor, the precondition for seeding the cache) and `Beta` (rule `Playlists contains "Alpha"`):

| | before | after |
|---|---|---|
| Beta refreshed alone | 65 items | 65 items |
| Beta refreshed right after Alpha, one drain | **0 items** | **65 items** |

Fixing collections without this would have shipped the same defect on the collections side.

## Changes

- **New `Core/QueryEngine/ListOrigin.cs`** — identifies the list being built. Matches on **Jellyfin item id** whenever one is known; base-name comparison survives only as a fallback for the first refresh, before the list exists in Jellyfin, and only against containers of the list's own kind.
  - Matching by id fixes a pre-existing flaw in the playlist guard: a manually created list that merely shares the name was excluded too, as was a list of the *other* type with the same name. Renaming the Jellyfin list no longer breaks the exclusion either.
  - The kind check on the fallback closes a regression found in review: without it, a smart *playlist* with no id yet would blank out a same-named *collection* for every item — and with `HideWhenEmpty` the id is never stored, so it would never self-heal.
  - An `AllUsers` playlist has one Jellyfin playlist per user, so all of its ids are collected, not just the one for the refreshing user.
- **`MediaTypeExtractionOptions.OriginListName` → `Origin`** (`ListOrigin`), threaded through all nine construction sites in `SmartList.cs`. `SmartList` now carries `Origin`, built in both constructors from the DTO's `JellyfinPlaylistId` / `UserPlaylists[].JellyfinPlaylistId` / `JellyfinCollectionId`.
- **`ExtractCollections` now applies the guard**, via the same `origin.Matches(candidate)` call `ExtractPlaylists` uses. One guard, both fields.
- **Cache keys carry the origin**: `ItemPlaylists` is now keyed `(ItemId, OriginKey)` and `ItemCollectionsWithDepth` `(ItemId, Depth, OriginKey)`. The redundant legacy `ItemCollections` dictionary is removed — it was written and read only alongside an identical `(id, 1)` entry in `ItemCollectionsWithDepth`, so its read could never hit when the primary missed.
- **`PlaylistService`**: a bumper pool builds part of its parent playlist, so it inherits the parent's Jellyfin ids for the same self-reference reason.
- **Docs**: `fields-and-operators.md` now states that the exclusion is by identity, not name; changelog `Unreleased` entry added.

## Verification

- Build clean on **both** target frameworks (net9.0 and net10.0), 0 warnings / 0 errors.
- Unit tests **1221 passing**, 0 failed (baseline 1208, +13 in the new `ListOriginTests.cs`), covering the #499 regression, the same-name-different-list case, cross-origin cache isolation, depth-vs-origin key independence, and AllUsers per-user ids.
- End-to-end against a dev Jellyfin container: collection now stable at 65 items across consecutive refreshes instead of alternating; batched Beta returns 65 instead of 0.

## Known limitation, not addressed here

`AllPlaylists` / `AllCollections` are snapshotted once per drain, so a list **created** earlier in the same drain is still invisible to a list refreshed later in it. That is a stale-snapshot problem rather than wrong-origin filtering, and fixing it means re-querying per queue item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDJnQyHXcbGFUoGYXitjY3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented smart collections and playlists from including themselves.
  * Improved matching across renames, duplicate names, and user-specific playlist copies.
  * Fixed refresh-state leakage between lists and collection nesting levels.
  * Preserved correct identity for generated playlists.
  * Helped affected lists stabilize and restore previously missing items.

* **Documentation**
  * Clarified identity-based self-exclusion and first-refresh behavior for smart collections and playlists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->