### PR TITLE
Add user rating rule support

### DIFF
--- a/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/EngineOperatorTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/EngineOperatorTests.cs
@@ -730,6 +730,49 @@ public class EngineOperatorTests
     }
 
     /// <summary>
+    /// Rating is nullable per user. Zero is a valid rating; an unrated item must not
+    /// satisfy either positive or negative rating comparisons.
+    /// </summary>
+    [Theory]
+    [InlineData(10d, "GreaterThan", "8", true)]
+    [InlineData(8d, "GreaterThan", "8", false)]
+    [InlineData(8d, "GreaterThanOrEqual", "8", true)]
+    [InlineData(7.5, "LessThan", "8", true)]
+    [InlineData(8d, "LessThanOrEqual", "8", true)]
+    [InlineData(8.5, "Equal", "8.5", true)]
+    [InlineData(8d, "NotEqual", "8.5", true)]
+    [InlineData(0d, "Equal", "0", true)]
+    [InlineData(null, "Equal", "0", false)]
+    [InlineData(null, "NotEqual", "8", false)]
+    [InlineData(null, "LessThan", "8", false)]
+    public void CompileRule_Rating_ResolvesPerUserAndExcludesUnratedItems(
+        double? stored,
+        string op,
+        string target,
+        bool expected)
+    {
+        var operand = new Operand("item");
+        if (stored.HasValue)
+        {
+            operand.RatingByUser[UserIdN] = stored.Value;
+        }
+
+        var rule = Compile(new Expression("Rating", op, target) { UserId = UserIdDashed });
+
+        Assert.Equal(expected, rule(operand));
+    }
+
+    [Theory]
+    [InlineData("not-a-number")]
+    [InlineData("NaN")]
+    [InlineData("Infinity")]
+    public void CompileRule_Rating_RejectsInvalidNumericTarget(string target)
+    {
+        Assert.Throws<ArgumentException>(
+            () => Compile(new Expression("Rating", "GreaterThan", target) { UserId = UserIdDashed }));
+    }
+
+    /// <summary>
     /// GetLastPlayedDateByUser returns -1 for "never played", and the engine ANDs a
     /// "!= -1" guard onto every LastPlayedDate rule - so a never-played item fails even Before,
     /// which -1 would otherwise satisfy numerically.

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-core.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-core.js
@@ -41,13 +41,13 @@
     // Field type constants to avoid duplication
     SmartLists.FIELD_TYPES = {
         LIST_FIELDS: ['Collections', 'People', 'Actors', 'Directors', 'Writers', 'Producers', 'GuestStars', 'Genres', 'Studios', 'Tags', 'Artists', 'AlbumArtists', 'AudioLanguages', 'SubtitleLanguages', 'ProductionLocations'],
-        NUMERIC_FIELDS: ['ProductionYear', 'CommunityRating', 'CriticRating', 'RuntimeMinutes', 'PlayCount', 'Framerate', 'AudioBitrate', 'AudioSampleRate', 'AudioBitDepth', 'AudioChannels'],
+        NUMERIC_FIELDS: ['ProductionYear', 'CommunityRating', 'CriticRating', 'RuntimeMinutes', 'PlayCount', 'Rating', 'Framerate', 'AudioBitrate', 'AudioSampleRate', 'AudioBitDepth', 'AudioChannels'],
         DATE_FIELDS: ['DateCreated', 'DateLastRefreshed', 'DateLastSaved', 'DateModified', 'ReleaseDate', 'LastPlayedDate', 'LastEpisodeAirDate'],
         BOOLEAN_FIELDS: ['IsFavorite', 'NextUnwatched'],
         SIMPLE_FIELDS: ['ItemType', 'SeriesStatus'],
         RESOLUTION_FIELDS: ['Resolution'],
         STRING_FIELDS: ['SimilarTo', 'Name', 'Album', 'SeriesName', 'OfficialRating', 'Overview', 'FileName', 'FolderPath', 'AudioCodec', 'AudioProfile', 'VideoCodec', 'VideoProfile', 'VideoRange', 'VideoRangeType', 'PlaybackStatus', 'CustomRating', 'ImdbId', 'TmdbId', 'TvdbId'],
-        USER_DATA_FIELDS: ['PlaybackStatus', 'IsFavorite', 'PlayCount', 'NextUnwatched', 'LastPlayedDate']
+        USER_DATA_FIELDS: ['PlaybackStatus', 'IsFavorite', 'PlayCount', 'Rating', 'NextUnwatched', 'LastPlayedDate']
     };
 
     // Date fields where metadata can be missing - these get the "unknown date" option

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-rules.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-rules.js
@@ -326,7 +326,7 @@
         input.style.width = '100%';
 
         // Set appropriate step for decimal fields like Framerate
-        if (fieldValue === 'Framerate' || fieldValue === 'CommunityRating' || fieldValue === 'CriticRating' || fieldValue === 'RuntimeMinutes') {
+        if (fieldValue === 'Framerate' || fieldValue === 'CommunityRating' || fieldValue === 'CriticRating' || fieldValue === 'Rating' || fieldValue === 'RuntimeMinutes') {
             input.step = 'any'; // Allow any decimal precision
         } else {
             input.step = '1'; // Integer fields like ProductionYear and PlayCount

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
@@ -380,6 +380,10 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             {
                 return BuildUserSpecificLastPlayedDateExpression(r, methodCall, logger);
             }
+            else if (returnType == typeof(double) && r.MemberName == "Rating")
+            {
+                return BuildUserSpecificRatingExpression(r, methodCall, logger);
+            }
             else if (returnType == typeof(string))
             {
                 return BuildUserSpecificStringExpression(r, methodCall, logger);
@@ -470,6 +474,54 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                 var supportedOperators = Operators.GetSupportedOperatorsString(r.MemberName);
                 throw new ArgumentException($"Operator '{r.Operator}' is not supported for integer user-specific field '{r.MemberName}'. Supported operators: {supportedOperators}");
             }
+        }
+
+        /// <summary>
+        /// Builds expressions for the optional per-user rating.
+        /// Unrated items use -1 internally and must not match rating rules.
+        /// </summary>
+        private static BinaryExpression BuildUserSpecificRatingExpression(
+            Expression r,
+            System.Linq.Expressions.Expression methodCall,
+            ILogger? logger)
+        {
+            if (!double.TryParse(
+                    r.TargetValue,
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
+                    out var value) ||
+                double.IsNaN(value) ||
+                double.IsInfinity(value))
+            {
+                logger?.LogError(
+                    "SmartLists numeric comparison failed: Invalid numeric value '{Value}' for field '{Field}'",
+                    r.TargetValue,
+                    r.MemberName);
+                throw new ArgumentException(
+                    $"Invalid numeric value '{r.TargetValue}' for field '{r.MemberName}'. Expected a decimal number.");
+            }
+
+            if (!Enum.TryParse(r.Operator, out ExpressionType binaryOperator))
+            {
+                logger?.LogError(
+                    "SmartLists unsupported operator '{Operator}' for numeric user-specific field '{Field}'",
+                    r.Operator,
+                    r.MemberName);
+                var supportedOperators = Operators.GetSupportedOperatorsString(r.MemberName);
+                throw new ArgumentException(
+                    $"Operator '{r.Operator}' is not supported for numeric user-specific field '{r.MemberName}'. Supported operators: {supportedOperators}");
+            }
+
+            var right = System.Linq.Expressions.Expression.Constant(value);
+            var comparison = System.Linq.Expressions.Expression.MakeBinary(
+                binaryOperator,
+                methodCall,
+                right);
+            var hasRating = System.Linq.Expressions.Expression.GreaterThanOrEqual(
+                methodCall,
+                System.Linq.Expressions.Expression.Constant(0d));
+
+            return System.Linq.Expressions.Expression.AndAlso(hasRating, comparison);
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Expression.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Expression.cs
@@ -127,6 +127,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                 "PlaybackStatus" => "GetPlaybackStatusByUser",
                 "IsPlayed" => "GetPlaybackStatusByUser", // Legacy field - treat as PlaybackStatus
                 "PlayCount" => "GetPlayCountByUser",
+                "Rating" => "GetRatingByUser",
                 "IsFavorite" => "GetIsFavoriteByUser",
                 "NextUnwatched" => "GetNextUnwatchedByUser",
                 "LastPlayedDate" => "GetLastPlayedDateByUser",
@@ -141,6 +142,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                 "PlaybackStatus" => true,
                 "IsPlayed" => true, // Legacy field - treat as user-specific
                 "PlayCount" => true,
+                "Rating" => true,
                 "IsFavorite" => true,
                 "NextUnwatched" => true,
                 "LastPlayedDate" => true,

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
@@ -936,6 +936,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         {
             operand.PlaybackStatusByUser[userId] = playbackStatus;
             operand.PlayCountByUser[userId] = playbackStatus == "Played" ? 1 : 0;
+            operand.RatingByUser[userId] = -1;
             operand.IsFavoriteByUser[userId] = false;
             operand.LastPlayedDateByUser[userId] = -1; // Never played,
         }
@@ -1262,6 +1263,11 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                 }
             }
 
+            // Extract Rating. Jellyfin uses null for unrated items; 0 is a valid rating.
+            var ratingProp = userDataType.GetProperty("Rating");
+            var rating = ExtractDoubleValue(ratingProp?.GetValue(userData));
+            operand.RatingByUser[userId] = rating.GetValueOrDefault(-1);
+
             // Extract IsFavorite
             var isFavoriteProp = userDataType.GetProperty("IsFavorite");
             if (isFavoriteProp != null)
@@ -1394,6 +1400,31 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                 return Convert.ToInt32(value, System.Globalization.CultureInfo.InvariantCulture);
             }
             catch
+            {
+                return null;
+            }
+        }
+
+        private static double? ExtractDoubleValue(object? value)
+        {
+            if (value is double doubleValue)
+                return doubleValue;
+            if (value == null)
+                return null;
+
+            try
+            {
+                return Convert.ToDouble(value, System.Globalization.CultureInfo.InvariantCulture);
+            }
+            catch (FormatException)
+            {
+                return null;
+            }
+            catch (InvalidCastException)
+            {
+                return null;
+            }
+            catch (OverflowException)
             {
                 return null;
             }

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/FieldRegistry.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/FieldRegistry.cs
@@ -85,7 +85,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         
         // Optimization Groups: Cheap but Conditional (Tier 1)
         ItemLists = 1 << 17,          // Fields: Genres, Tags, Studios | Array allocations
-        UserData = 1 << 18,           // Fields: IsFavorite, PlayCount, PlaybackStatus, LastPlayedDate | UserDataManager lookup
+        UserData = 1 << 18,           // Fields: IsFavorite, PlayCount, Rating, PlaybackStatus, LastPlayedDate | UserDataManager lookup
         Dates = 1 << 19,              // Fields: PremiereDate, DateCreated, ProductionYear, etc. | Struct copying
     }
 
@@ -257,6 +257,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             AddField(fields, "LastPlayedDate", "Last Played", FieldType.Date, FieldCategory.RatingsPlayback, DateOperators, ExtractionGroup.UserData, isUserSpecific: true);
             AddField(fields, "NextUnwatched", "Next Unwatched", FieldType.Boolean, FieldCategory.RatingsPlayback, BooleanOperators, ExtractionGroup.NextUnwatched, isUserSpecific: true);
             AddField(fields, "PlayCount", "Play Count", FieldType.Numeric, FieldCategory.RatingsPlayback, NumericOperators, ExtractionGroup.UserData, isUserSpecific: true);
+            AddField(fields, "Rating", "User Rating", FieldType.Numeric, FieldCategory.RatingsPlayback, NumericOperators, ExtractionGroup.UserData, isUserSpecific: true);
             AddField(fields, "RuntimeMinutes", "Runtime", FieldType.Numeric, FieldCategory.RatingsPlayback, NumericOperators, ExtractionGroup.TextContent);
 
             // File Fields - conditionally extracted via ExtractionGroup.FileInfo

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Operand.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Operand.cs
@@ -124,6 +124,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         // These will be populated based on which users are referenced in rules
         public Dictionary<string, string> PlaybackStatusByUser { get; set; } = [];
         public Dictionary<string, int> PlayCountByUser { get; set; } = [];
+        public Dictionary<string, double> RatingByUser { get; set; } = [];
         public Dictionary<string, bool> IsFavoriteByUser { get; set; } = [];
         public Dictionary<string, bool> NextUnwatchedByUser { get; set; } = [];
         public Dictionary<string, double> LastPlayedDateByUser { get; set; } = [];
@@ -141,6 +142,11 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         public int GetPlayCountByUser(string userId)
         {
             return PlayCountByUser.TryGetValue(userId, out var value) ? value : 0;
+        }
+
+        public double GetRatingByUser(string userId)
+        {
+            return RatingByUser.TryGetValue(userId, out var value) ? value : -1;
         }
 
         public bool GetIsFavoriteByUser(string userId)

--- a/docs/content/user-guide/fields-and-operators.md
+++ b/docs/content/user-guide/fields-and-operators.md
@@ -97,6 +97,7 @@ The following fields track per-user data and support an optional **user selector
 |-------|-----------|-------------|
 | **Is Favorite** | `IsFavorite` | Whether the item is marked as a favorite |
 | **Play Count** | `PlayCount` | Number of times the item has been played |
+| **User Rating** | `Rating` | The personal rating the user gave the item (0-10) |
 | **Last Played** | `LastPlayedDate` | When the item was last played |
 | **Playback Status** | `PlaybackStatus` | Played, In Progress, or Unplayed |
 | **Next Unwatched** | `NextUnwatched` | Shows only the next unwatched episode for each series |
@@ -117,6 +118,10 @@ The following fields track per-user data and support an optional **user selector
 
     - **Playback Status**: Played = all episodes watched, In Progress = some watched, Unplayed = none watched
     - **Last Played**: Uses the most recent episode watch date (excludes season 0 specials)
+
+!!! note "Unrated items"
+    Items the user hasn't rated never match a **User Rating** rule - not even `not equal` or
+    `less than`. A rating of `0` is a real rating and does match.
 
 **Next Unwatched options:**
 


### PR DESCRIPTION
## Summary

Adds Jellyfin's native per-user Rating value as a numeric SmartLists rule field.

Ratings are read from Jellyfin user data and evaluated for the user selected by the rule.

Unrated items are kept distinct from a valid rating of 0 and do not match rating comparisons.

Supported operators:
- Equal
- NotEqual
- GreaterThan
- GreaterThanOrEqual
- LessThan
- LessThanOrEqual

## Implementation

- Adds Rating to the user-data field registry
- Reads Rating from Jellyfin UserData
- Stores ratings per user in Operand
- Adds GetRatingByUser()
- Adds numeric comparison support for per-user ratings
- Uses invariant numeric parsing
- Excludes unrated items from rating comparisons
- Adds coverage for numeric operators, decimal ratings and invalid numeric targets

## Validation

- Builds successfully for net9.0 and net10.0
- 1203/1203 tests pass
- Tested against Jellyfin 12 with a real music library

## Development note

AI-assisted development was used during implementation and review. The final changes were manually reviewed, built and tested before submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for filtering items by each user’s personal rating.
  - Supports numeric comparison operators, including zero ratings.
  - Rating filters can distinguish rated items from unrated items.
  - Unrated items are excluded from rating-based results.

- **Bug Fixes**
  - Invalid rating values, including non-numeric, infinite, and `NaN` targets, are now rejected.
  - Missing or unavailable ratings are handled consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->