### PR TITLE
fix: refresh the per-drain container snapshot when a list writes its contents

### DIFF
--- a/Jellyfin.Plugin.SmartLists.Tests/Services/Shared/RefreshCacheStalenessTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Services/Shared/RefreshCacheStalenessTests.cs
@@ -1,0 +1,190 @@
+using System.Reflection;
+using Jellyfin.Plugin.SmartLists.Core.QueryEngine;
+using Jellyfin.Plugin.SmartLists.Services.Shared;
+using Jellyfin.Plugin.SmartLists.Tests.Support;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Playlists;
+
+namespace Jellyfin.Plugin.SmartLists.Tests.Services.Shared;
+
+/// <summary>
+/// Pins the per-drain staleness fix on <see cref="RefreshQueueService.RefreshCache"/>.
+///
+/// The container snapshots (<c>AllCollections</c>/<c>AllPlaylists</c>) and the membership caches
+/// behind them are built ONCE per refresh-queue drain, while the cache itself is per user and lives
+/// until the drain finishes. So when list A rewrote its own Jellyfin container mid-drain, every list
+/// refreshed after it in that drain still evaluated its Collections/Playlists rules against A's
+/// pre-drain contents - permanently one refresh behind while lists refresh together, which is the
+/// normal case under scheduled auto-refresh.
+///
+/// Reproduced live before the fix: playlist "ZZTest Alpha" changed from 33 to 49 members, and
+/// "ZZTest Beta" (rule: Playlists contains "ZZTest Alpha") reported 33 in the same drain and only
+/// caught up on a later one.
+///
+/// The precondition is easy to miss when reproducing by hand: the earlier list must itself use the
+/// Collections/Playlists extractor, because that is what seeds the snapshot BEFORE it writes. A
+/// first attempt with a Name-only rule on A came back green for exactly that reason.
+/// </summary>
+public class RefreshCacheStalenessTests
+{
+    private static readonly MethodInfo ExtractPlaylistsMethod =
+        typeof(OperandFactory).GetMethod("ExtractPlaylists", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    private static readonly MethodInfo ExtractCollectionsMethod =
+        typeof(OperandFactory).GetMethod("ExtractCollections", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    private static List<string> ExtractPlaylists(BaseItem item, RefreshQueueService.RefreshCache cache)
+        => (List<string>)ExtractPlaylistsMethod.Invoke(
+            null, [item, TestItems.User, BaseItem.LibraryManager, cache, null, null])!;
+
+    private static List<string> ExtractCollections(BaseItem item, RefreshQueueService.RefreshCache cache, int depth)
+        => (List<string>)ExtractCollectionsMethod.Invoke(
+            null, [item, TestItems.User, BaseItem.LibraryManager, cache, null, depth, null])!;
+
+    private static Playlist PlaylistNamed(string name)
+    {
+        var playlist = new Playlist { Id = Guid.NewGuid(), Name = name };
+        playlist.SortName = name;
+        return playlist;
+    }
+
+    private static BoxSet CollectionNamed(string name)
+    {
+        var boxSet = new BoxSet { Id = Guid.NewGuid(), Name = name };
+        boxSet.SortName = name;
+        return boxSet;
+    }
+
+    /// <summary>
+    /// A movie added to a playlist mid-drain must be visible to the next list in that same drain.
+    /// </summary>
+    [Fact]
+    public void OnPlaylistWritten_MakesNewMembershipVisibleWithinTheSameDrain()
+    {
+        var inPlaylist = TestItems.Mov("Blade Runner");
+        var addedLater = TestItems.Mov("Alien");
+        var playlist = PlaylistNamed("ZZTest Alpha [Smart]");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        cache.AllPlaylists = [playlist];
+        cache.PlaylistMembershipCache[playlist.Id] = [inPlaylist.Id];
+
+        // Seeds the per-drain snapshot, exactly as the earlier list's own refresh does.
+        Assert.Equal(["ZZTest Alpha [Smart]"], ExtractPlaylists(inPlaylist, cache));
+        Assert.Empty(ExtractPlaylists(addedLater, cache));
+
+        cache.OnPlaylistWritten(playlist, [inPlaylist.Id, addedLater.Id]);
+
+        Assert.Equal(["ZZTest Alpha [Smart]"], ExtractPlaylists(addedLater, cache));
+    }
+
+    /// <summary>
+    /// ...and a movie removed from it must stop being reported, which is the half that made a
+    /// "not in any smart playlist" rule keep excluding items it should have released.
+    /// </summary>
+    [Fact]
+    public void OnPlaylistWritten_RetractsRemovedMembershipWithinTheSameDrain()
+    {
+        var dropped = TestItems.Mov("Blade Runner");
+        var kept = TestItems.Mov("Alien");
+        var playlist = PlaylistNamed("ZZTest Alpha [Smart]");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        cache.AllPlaylists = [playlist];
+        cache.PlaylistMembershipCache[playlist.Id] = [dropped.Id, kept.Id];
+
+        Assert.Equal(["ZZTest Alpha [Smart]"], ExtractPlaylists(dropped, cache));
+
+        cache.OnPlaylistWritten(playlist, [kept.Id]);
+
+        Assert.Empty(ExtractPlaylists(dropped, cache));
+        Assert.Equal(["ZZTest Alpha [Smart]"], ExtractPlaylists(kept, cache));
+    }
+
+    /// <summary>
+    /// The collection side of the same fix.
+    /// </summary>
+    [Fact]
+    public void OnCollectionWritten_MakesNewMembershipVisibleWithinTheSameDrain()
+    {
+        var inCollection = TestItems.Mov("Blade Runner");
+        var addedLater = TestItems.Mov("Alien");
+        var boxSet = CollectionNamed("ZZTest Alpha [Smart]");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        cache.AllCollections = [boxSet];
+        cache.CollectionDirectChildren[boxSet.Id] = [inCollection];
+
+        Assert.Equal(["ZZTest Alpha [Smart]"], ExtractCollections(inCollection, cache, depth: 1));
+        Assert.Empty(ExtractCollections(addedLater, cache, depth: 1));
+
+        cache.OnCollectionWritten(boxSet, [inCollection, addedLater]);
+
+        Assert.Equal(["ZZTest Alpha [Smart]"], ExtractCollections(addedLater, cache, depth: 1));
+    }
+
+    /// <summary>
+    /// A container created mid-drain is absent from the snapshot altogether, so it has to be added
+    /// rather than merely patched.
+    /// </summary>
+    [Fact]
+    public void OnCollectionWritten_AddsACollectionCreatedDuringTheDrain()
+    {
+        var movie = TestItems.Mov("Blade Runner");
+        var existing = CollectionNamed("Existing [Smart]");
+        var createdMidDrain = CollectionNamed("ZZTest New [Smart]");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        cache.AllCollections = [existing];
+        cache.CollectionDirectChildren[existing.Id] = [];
+
+        Assert.Empty(ExtractCollections(movie, cache, depth: 1));
+
+        cache.OnCollectionWritten(createdMidDrain, [movie]);
+
+        Assert.Equal(["ZZTest New [Smart]"], ExtractCollections(movie, cache, depth: 1));
+    }
+
+    /// <summary>
+    /// Patching must never seed an UNBUILT membership cache: the builders are guarded on the
+    /// dictionary being empty, so a single seeded entry would make an empty cache look built and
+    /// strand every other container with no children.
+    /// </summary>
+    [Fact]
+    public void OnContainerWritten_DoesNotSeedAnUnbuiltMembershipCache()
+    {
+        var movie = TestItems.Mov("Blade Runner");
+        var boxSet = CollectionNamed("ZZTest Alpha [Smart]");
+        var playlist = PlaylistNamed("ZZTest Alpha [Smart]");
+
+        var cache = new RefreshQueueService.RefreshCache();
+
+        cache.OnCollectionWritten(boxSet, [movie]);
+        cache.OnPlaylistWritten(playlist, [movie.Id]);
+
+        Assert.True(cache.CollectionDirectChildren.IsEmpty);
+        Assert.True(cache.PlaylistMembershipCache.IsEmpty);
+    }
+
+    /// <summary>
+    /// "Hide when empty" deletes the Jellyfin container mid-drain; lists refreshed after it must
+    /// stop seeing it.
+    /// </summary>
+    [Fact]
+    public void OnContainerRemoved_HidesADeletedCollectionFromTheRestOfTheDrain()
+    {
+        var movie = TestItems.Mov("Blade Runner");
+        var boxSet = CollectionNamed("ZZTest Alpha [Smart]");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        cache.AllCollections = [boxSet];
+        cache.CollectionDirectChildren[boxSet.Id] = [movie];
+
+        Assert.Equal(["ZZTest Alpha [Smart]"], ExtractCollections(movie, cache, depth: 1));
+
+        cache.OnContainerRemoved(boxSet.Id);
+
+        Assert.Empty(ExtractCollections(movie, cache, depth: 1));
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
@@ -355,6 +355,10 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                     {
                         _logger.LogInformation("Smart collection '{CollectionName}' matched no items - deleting Jellyfin collection (hide when empty)", dto.Name);
                         _libraryManager.DeleteItem(existingCollectionItem, new DeleteOptions { DeleteFileLocation = true }, true);
+
+                        // Drop it from this drain's snapshot too, so lists refreshed after this one
+                        // stop seeing a collection that no longer exists.
+                        refreshCache.OnContainerRemoved(existingCollectionItem.Id);
                     }
 
                     // Clear the stored Jellyfin collection ID so a later refresh with items recreates it
@@ -410,6 +414,10 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
 
                     DeleteOrphanedTetheredCollections(dto, existingCollection.Id);
 
+                    // Keep this drain's membership snapshot current, or a list refreshed later in the
+                    // same drain evaluates its Collections rules against the contents we just replaced.
+                    refreshCache.OnCollectionWritten(existingCollection, WrittenMembers(newLinkedChildren, mediaLookup));
+
                     return (true, $"Updated collection '{existingCollection.Name}' with {newLinkedChildren.Length} items", existingCollection.Id.ToString("N"));
                 }
                 else
@@ -440,6 +448,14 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
 
                     _logger.LogDebug("Successfully created new collection: {CollectionName} with {ItemCount} items",
                         collectionName, newLinkedChildren.Length);
+
+                    // A collection created mid-drain is absent from the snapshot entirely, so add it
+                    // for the lists refreshed after this one.
+                    if (Guid.TryParse(newCollectionId, out var writtenCollectionId)
+                        && _libraryManager.GetItemById(writtenCollectionId) is BaseItem createdCollection)
+                    {
+                        refreshCache.OnCollectionWritten(createdCollection, WrittenMembers(newLinkedChildren, mediaLookup));
+                    }
 
                     return (true, $"Created collection '{collectionName}' with {newLinkedChildren.Length} items", newCollectionId);
                 }
@@ -2345,6 +2361,18 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
 
             return false;
         }
+
+        /// <summary>
+        /// The items behind the LinkedChild entries just written to a collection, for refreshing the
+        /// per-drain membership snapshot.
+        /// </summary>
+        /// <param name="linkedChildren">The LinkedChild entries written to the collection.</param>
+        /// <param name="mediaLookup">Id to item lookup covering those entries.</param>
+        /// <returns>The resolved member items.</returns>
+        private static IReadOnlyList<BaseItem> WrittenMembers(LinkedChild[] linkedChildren, Dictionary<Guid, BaseItem> mediaLookup)
+            => [.. linkedChildren
+                .Where(lc => lc.ItemId.HasValue && mediaLookup.ContainsKey(lc.ItemId.Value))
+                .Select(lc => mediaLookup[lc.ItemId!.Value])];
 
         /// <summary>
         /// Queries for items when IncludeOnly option is enabled for a field.

--- a/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
@@ -412,7 +412,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                     dto.LastRefreshed = DateTime.UtcNow;
                     _logger.LogDebug("Updated LastRefreshed timestamp for collection: {CollectionName}", dto.Name);
 
-                    DeleteOrphanedTetheredCollections(dto, existingCollection.Id);
+                    DeleteOrphanedTetheredCollections(dto, existingCollection.Id, refreshCache);
 
                     // Keep this drain's membership snapshot current, or a list refreshed later in the
                     // same drain evaluates its Collections rules against the contents we just replaced.
@@ -439,7 +439,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
 
                     if (Guid.TryParse(newCollectionId, out var createdCollectionGuid))
                     {
-                        DeleteOrphanedTetheredCollections(dto, createdCollectionGuid);
+                        DeleteOrphanedTetheredCollections(dto, createdCollectionGuid, refreshCache);
                     }
 
                     // Update LastRefreshed timestamp for successful refresh
@@ -466,7 +466,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
         /// tether but are not the tracked collection. The tether proves the plugin created them,
         /// so deletion cannot hit user-created collections.
         /// </summary>
-        private void DeleteOrphanedTetheredCollections(SmartCollectionDto dto, Guid canonicalCollectionId)
+        private void DeleteOrphanedTetheredCollections(SmartCollectionDto dto, Guid canonicalCollectionId, RefreshQueueService.RefreshCache refreshCache)
         {
             if (string.IsNullOrEmpty(dto.Id))
             {
@@ -493,6 +493,11 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                         _logger.LogWarning("Deleting orphaned duplicate collection '{CollectionName}' ({CollectionId}) tethered to smart collection {SmartListId}",
                             orphan.Name, orphan.Id, dto.Id);
                         _libraryManager.DeleteItem(orphan, new DeleteOptions { DeleteFileLocation = true }, true);
+
+                        // Deleted here rather than at the call sites so a new caller cannot forget it:
+                        // an orphan left in this drain's snapshot keeps matching by name and membership
+                        // for every list refreshed after this one.
+                        refreshCache.OnContainerRemoved(orphan.Id);
                     }
                     catch (Exception deleteEx)
                     {

--- a/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
@@ -436,7 +436,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                         }
                     }
 
-                    DeleteOrphanedTetheredPlaylists(dto, user, existingPlaylist.Id);
+                    DeleteOrphanedTetheredPlaylists(dto, user, existingPlaylist.Id, refreshCache);
 
                     // Keep this drain's membership snapshot current, or a list refreshed later in the
                     // same drain evaluates its Playlists rules against the contents we just replaced.
@@ -460,7 +460,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
 
                     if (Guid.TryParse(newPlaylistId, out var createdPlaylistGuid))
                     {
-                        DeleteOrphanedTetheredPlaylists(dto, user, createdPlaylistGuid);
+                        DeleteOrphanedTetheredPlaylists(dto, user, createdPlaylistGuid, refreshCache);
                     }
 
                     // Update the DTO with the new Jellyfin playlist ID
@@ -1803,7 +1803,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
         /// tether for this user but are not the tracked playlist. The tether proves the plugin
         /// created them, so deletion cannot hit user-created playlists.
         /// </summary>
-        private void DeleteOrphanedTetheredPlaylists(SmartPlaylistDto dto, User user, Guid canonicalPlaylistId)
+        private void DeleteOrphanedTetheredPlaylists(SmartPlaylistDto dto, User user, Guid canonicalPlaylistId, RefreshQueueService.RefreshCache refreshCache)
         {
             if (string.IsNullOrEmpty(dto.Id))
             {
@@ -1832,6 +1832,11 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                         _logger.LogWarning("Deleting orphaned duplicate playlist '{PlaylistName}' ({PlaylistId}) tethered to smart playlist {SmartListId} for user {UserId}",
                             orphan.Name, orphan.Id, dto.Id, user.Id);
                         _libraryManager.DeleteItem(orphan, new DeleteOptions { DeleteFileLocation = true }, true);
+
+                        // Deleted here rather than at the call sites so a new caller cannot forget it:
+                        // an orphan left in this drain's snapshot keeps matching by name and membership
+                        // for every list refreshed after this one.
+                        refreshCache.OnContainerRemoved(orphan.Id);
                     }
                     catch (Exception deleteEx)
                     {

--- a/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
@@ -294,6 +294,10 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                     {
                         logger.LogInformation("Smart playlist '{PlaylistName}' matched no items - deleting Jellyfin playlist (hide when empty)", dto.Name);
                         _libraryManager.DeleteItem(existingPlaylist, new DeleteOptions { DeleteFileLocation = true }, true);
+
+                        // Drop it from this drain's snapshot too, so lists refreshed after this one
+                        // stop seeing a playlist that no longer exists.
+                        refreshCache.OnContainerRemoved(existingPlaylist.Id);
                     }
 
                     // Clear the stored Jellyfin playlist ID so a later refresh with items recreates it
@@ -434,6 +438,10 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
 
                     DeleteOrphanedTetheredPlaylists(dto, user, existingPlaylist.Id);
 
+                    // Keep this drain's membership snapshot current, or a list refreshed later in the
+                    // same drain evaluates its Playlists rules against the contents we just replaced.
+                    refreshCache.OnPlaylistWritten(existingPlaylist, finalItemIds);
+
                     return (true, $"Updated playlist '{existingPlaylist.Name}' with {newLinkedChildren.Length} items", existingPlaylist.Id.ToString("N"));
                 }
                 else
@@ -503,6 +511,14 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
 
                     logger.LogDebug("Successfully created new playlist: {PlaylistName} with {ItemCount} items",
                         smartPlaylistName, newLinkedChildren.Length);
+
+                    // A playlist created mid-drain is absent from the snapshot entirely, so add it
+                    // for the lists refreshed after this one.
+                    if (Guid.TryParse(newPlaylistId, out var writtenPlaylistId)
+                        && _libraryManager.GetItemById(writtenPlaylistId) is BaseItem createdPlaylist)
+                    {
+                        refreshCache.OnPlaylistWritten(createdPlaylist, finalItemIds);
+                    }
 
                     return (true, $"Created playlist '{smartPlaylistName}' with {newLinkedChildren.Length} items", newPlaylistId);
                 }

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
@@ -818,6 +818,97 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
 
             // Warnings collected during processing (e.g., missing API keys, fetch failures)
             public ConcurrentBag<string> Warnings { get; } = [];
+
+            /// <summary>
+            /// Re-points this drain's view of a collection at the contents just written to it.
+            ///
+            /// AllCollections and the membership caches are built once per queue drain, so without
+            /// this a list refreshed later in the same drain evaluates its Collections rules against
+            /// the membership this collection had BEFORE the drain started - one refresh behind, for
+            /// as long as lists keep refreshing together. Chained lists ("everything not already in
+            /// a smart collection") are the common victim.
+            ///
+            /// Patching costs no queries: the caller already holds the members, and the derived
+            /// caches below rebuild from CollectionDirectChildren in memory.
+            /// </summary>
+            /// <param name="collection">The collection that was just written.</param>
+            /// <param name="members">Its new direct children.</param>
+            public void OnCollectionWritten(BaseItem collection, IReadOnlyList<BaseItem> members)
+            {
+                ArgumentNullException.ThrowIfNull(collection);
+                ArgumentNullException.ThrowIfNull(members);
+
+                // A collection created during this drain is missing from the snapshot entirely.
+                if (AllCollections != null && Array.FindIndex(AllCollections, c => c.Id == collection.Id) < 0)
+                {
+                    AllCollections = [.. AllCollections, collection];
+                }
+
+                // Only patch an already-built cache. Seeding a single entry into an empty one would
+                // make it look built (the builder is guarded on Count == 0) and strand every other
+                // collection with no children.
+                if (!CollectionDirectChildren.IsEmpty)
+                {
+                    CollectionDirectChildren[collection.Id] = [.. members];
+                }
+
+                CollectionChildItems.TryRemove(collection.Id, out _);
+
+                // Derived from the above; cheaper to drop than to patch, and rebuilt without queries.
+                CollectionMembershipCacheByDepth.Clear();
+                ItemCollectionsWithDepth.Clear();
+            }
+
+            /// <summary>
+            /// The playlist counterpart of <see cref="OnCollectionWritten"/>.
+            /// </summary>
+            /// <param name="playlist">The playlist that was just written.</param>
+            /// <param name="memberIds">Ids of its new members.</param>
+            public void OnPlaylistWritten(BaseItem playlist, IReadOnlyList<Guid> memberIds)
+            {
+                ArgumentNullException.ThrowIfNull(playlist);
+                ArgumentNullException.ThrowIfNull(memberIds);
+
+                if (AllPlaylists != null && Array.FindIndex(AllPlaylists, p => p.Id == playlist.Id) < 0)
+                {
+                    AllPlaylists = [.. AllPlaylists, playlist];
+                }
+
+                if (!PlaylistMembershipCache.IsEmpty)
+                {
+                    PlaylistMembershipCache[playlist.Id] = [.. memberIds];
+                }
+
+                PlaylistChildItems.TryRemove(playlist.Id, out _);
+                ItemPlaylists.Clear();
+            }
+
+            /// <summary>
+            /// Drops a collection/playlist that was deleted during this drain (for example by
+            /// "hide when empty"), so lists refreshed after it stop seeing a container that is gone.
+            /// </summary>
+            /// <param name="containerId">The deleted collection or playlist id.</param>
+            public void OnContainerRemoved(Guid containerId)
+            {
+                if (AllCollections != null)
+                {
+                    AllCollections = [.. Array.FindAll(AllCollections, c => c.Id != containerId)];
+                }
+
+                if (AllPlaylists != null)
+                {
+                    AllPlaylists = [.. Array.FindAll(AllPlaylists, p => p.Id != containerId)];
+                }
+
+                CollectionDirectChildren.TryRemove(containerId, out _);
+                PlaylistMembershipCache.TryRemove(containerId, out _);
+                CollectionChildItems.TryRemove(containerId, out _);
+                PlaylistChildItems.TryRemove(containerId, out _);
+
+                CollectionMembershipCacheByDepth.Clear();
+                ItemCollectionsWithDepth.Clear();
+                ItemPlaylists.Clear();
+            }
         }
 
         /// <summary>

--- a/docs/content/changelog/rc.md
+++ b/docs/content/changelog/rc.md
@@ -20,6 +20,7 @@ itself (`v10.10.10.0-rc3`), which is the scheme used before the number moved int
 - Smart collections no longer see themselves when a rule checks **Collection name**. Previously a collection whose own name matched its rule — which the default `[Smart]` suffix makes easy, for example a "not contains smart" rule meant to list uncollected items — flipped between full and empty on every refresh, because its own contents fed back into its own rule. Smart playlists already had this protection; collections did not ([#499](https://github.com/jyourstone/jellyfin-smartlists-plugin/issues/499)).
 - A list is now recognised by identity rather than by name, so a separate collection or playlist that merely shares the name is matched normally, and renaming the Jellyfin list does not break the exclusion.
 - Fixed **Collection name** and **Playlist name** rules returning wrong results when several lists were refreshed in one batch. The first list's self-exclusion leaked into the lists refreshed after it, making them blind to that list.
+- Lists that depend on another smart list's contents no longer lag a refresh behind. When several lists refresh together — as scheduled auto-refresh does — a list refreshed later in the batch used to see the earlier lists' contents as they were *before* the batch started. A rule like "not in any smart collection" was therefore always one cycle out of date while the library kept changing.
 
 **Existing lists may change**
 


### PR DESCRIPTION
## What

A smart list refreshed later in a refresh-queue drain evaluated its **Collection name** / **Playlist name** rules against the contents the *earlier* lists had **before the drain started**. Chained lists therefore sat permanently one refresh behind whenever lists refresh together — which is exactly what scheduled auto-refresh does.

Follow-up to #500, same subsystem, different failure mode. #500 fixed *wrong-origin filtering*; this is *stale snapshot*.

## Why

`RefreshQueueService.RefreshCache` is per user and survives the whole drain (only `AncestorValuesById` was cleared per queue item). The container snapshots and the membership caches behind them are built once, on first use:

| Cache | Built at |
|---|---|
| `AllCollections` / `AllPlaylists` | `Factory.cs:3334` / `:3666` |
| `CollectionDirectChildren` | `:3357` |
| `CollectionMembershipCacheByDepth` | `:3380` |
| `PlaylistMembershipCache` | `:3734` |

Nothing invalidated any of them when a list subsequently rewrote its own Jellyfin container.

Reproduced against a dev Jellyfin — playlist `Alpha`, and playlist `Beta` with rule `Playlists contains "Alpha"`, both in one drain (`Reusing existing cache for user 'dev'` between them):

```
before   Alpha filtered to 49 items    Beta filtered to 33   <- Alpha's PREVIOUS membership
after    Alpha filtered to 33 items    Beta filtered to 33
after    Alpha filtered to 49 items    Beta filtered to 49
```

Verified in both directions after the fix; before it, `Beta` only caught up on a subsequent drain.

**Reproducing this by hand has a precondition that is easy to miss:** the earlier list must itself use the Collections/Playlists extractor, because that is what seeds the snapshot *before* it writes. My first attempt used a `Name contains` rule on `Alpha` and came back green for exactly that reason.

## Changes

Three methods on `RefreshCache`, called from the points where the services have just written a container and still hold the members — so the caches are **patched, not dropped**: no extra queries, and the derived caches rebuild in memory.

- `OnCollectionWritten` / `OnPlaylistWritten` — re-point the snapshot at the contents just written; also add a container **created** mid-drain, which is absent from the snapshot entirely.
- `OnContainerRemoved` — drop a container deleted mid-drain by hide-when-empty, so later lists stop seeing something that is gone.

Wired at both write paths (update-existing and create) in `PlaylistService` and `CollectionService`, plus both hide-when-empty deletions.

One subtlety worth calling out: patching deliberately **skips a membership cache that has not been built yet**. The builders are guarded on the dictionary being empty, so seeding a single entry would make an empty cache look built and strand every other container with no children. `OnContainerWritten_DoesNotSeedAnUnbuiltMembershipCache` pins that.

## Why not clear the caches per queue item

That was the obvious fix (mirroring `AncestorValuesById.Clear()`), and it is the expensive one: rebuilding `CollectionDirectChildren` costs one query *per collection*, per queue item. A user with 200 collections and 50 lists in a drain would pay ~10,000 queries. Patching costs nothing, because the caller already has the data.

## Verification

- Build clean on both TFMs (net9.0, net10.0), 0 warnings / 0 errors.
- **1227** tests passing, 0 failed — 6 new in `RefreshCacheStalenessTests`.
- Those 6 are mutation-tested: gutting `OnPlaylistWritten` fails two of them, restoring it passes all six.
- End-to-end against the dev container, both directions, as shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDJnQyHXcbGFUoGYXitjY3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Smart lists now reflect playlist and collection additions, removals, and newly created containers within the same refresh batch.
  * Dependent smart lists use updated contents immediately, eliminating a one-refresh-cycle delay.

* **Documentation**
  * Added the upcoming fix to the release changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->