### PR TITLE
perf: DB-backed prefilters for expensive rule fields

### DIFF
--- a/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/CandidateSetBuilderTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/CandidateSetBuilderTests.cs
@@ -73,9 +73,10 @@ public class CandidateSetBuilderTests
     }
 
     [Fact]
-    public void CreateDefault_HasNoResolversYet_ReturnsNull()
+    public void CreateDefault_WithoutLibraryManager_ReturnsNull()
     {
-        // Foundation stage guarantee: until field resolvers register, the prefilter is a no-op.
+        // The production resolvers all need ILibraryManager for their candidate queries;
+        // without one they must degrade to "no shrink possible", never throw or guess.
         var result = CandidateSetBuilder.CreateDefault().Build([Set(Rule("People"))], Context());
 
         Assert.Null(result);

--- a/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/CandidateSetBuilderTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/CandidateSetBuilderTests.cs
@@ -1,0 +1,347 @@
+using Jellyfin.Plugin.SmartLists.Core.Models;
+using Jellyfin.Plugin.SmartLists.Core.QueryEngine;
+using Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters;
+
+namespace Jellyfin.Plugin.SmartLists.Tests.Core.QueryEngine;
+
+/// <summary>
+/// Covers the pure set math of <see cref="CandidateSetBuilder"/> - the shared
+/// union-of-set-intersections machinery every DB-prefilter field resolver plugs into.
+///
+/// The safety contract under test:
+/// - Within one rule set (AND): intersection over the set's pushdownable rules only;
+///   a rule no resolver can bound simply does not participate.
+/// - Across rule sets (OR): union; a set with ZERO pushdownable rules may match any
+///   item and therefore forces the overall result to null (= no shrink possible).
+/// - Negative operators (NotEqual/NotContains/IsNotIn) never reach a resolver unless
+///   it opts in via SupportsNegativeOperators.
+/// - MatchRegex whose pattern matches "" never rides (empty-list semantics test
+///   against the empty string), nor does an invalid pattern.
+/// - An empty per-rule set is a hard "nothing matches" claim and short-circuits the
+///   rest of that set's rules.
+///
+/// Resolvers are fakes; the builder never touches ILibraryManager itself, so the
+/// context carries nulls.
+/// </summary>
+public class CandidateSetBuilderTests
+{
+    private static readonly Guid A = Guid.NewGuid();
+    private static readonly Guid B = Guid.NewGuid();
+    private static readonly Guid C = Guid.NewGuid();
+    private static readonly Guid D = Guid.NewGuid();
+
+    private static PrefilterContext Context() => new(null!, null!, null, null);
+
+    private static Expression Rule(string field, string op = "Equal", string value = "x") => new(field, op, value);
+
+    private static ExpressionSet Set(params Expression[] expressions) => new() { Expressions = [.. expressions] };
+
+    /// <summary>
+    /// Fake resolver: maps field name to the ID set it returns (a fresh copy per call,
+    /// since the builder takes ownership and mutates). Unknown fields resolve to null
+    /// (= cannot bound). Counts calls so tests can assert consultation behavior.
+    /// </summary>
+    private sealed class FakeResolver : IRulePrefilterResolver
+    {
+        private readonly Dictionary<string, Guid[]> _byField;
+
+        public FakeResolver(Dictionary<string, Guid[]> byField, bool supportsNegativeOperators = false)
+        {
+            _byField = byField;
+            SupportsNegativeOperators = supportsNegativeOperators;
+        }
+
+        public bool SupportsNegativeOperators { get; }
+
+        public int CallCount { get; private set; }
+
+        public HashSet<Guid>? Resolve(Expression expression, PrefilterContext context)
+        {
+            CallCount++;
+            return _byField.TryGetValue(expression.MemberName, out var ids) ? [.. ids] : null;
+        }
+    }
+
+    [Fact]
+    public void Build_WithNoResolvers_ReturnsNull()
+    {
+        var builder = new CandidateSetBuilder([]);
+
+        var result = builder.Build([Set(Rule("People"))], Context());
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void CreateDefault_HasNoResolversYet_ReturnsNull()
+    {
+        // Foundation stage guarantee: until field resolvers register, the prefilter is a no-op.
+        var result = CandidateSetBuilder.CreateDefault().Build([Set(Rule("People"))], Context());
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Build_WithNullOrEmptySets_ReturnsNull()
+    {
+        var resolver = new FakeResolver(new() { ["People"] = [A] });
+        var builder = new CandidateSetBuilder([resolver]);
+
+        Assert.Null(builder.Build(null, Context()));
+        Assert.Null(builder.Build([], Context()));
+        Assert.Equal(0, resolver.CallCount);
+    }
+
+    [Fact]
+    public void Build_SingleBoundedRule_ReturnsItsSet()
+    {
+        var builder = new CandidateSetBuilder([new FakeResolver(new() { ["People"] = [A, B] })]);
+
+        var result = builder.Build([Set(Rule("People"))], Context());
+
+        Assert.NotNull(result);
+        Assert.Equal(new HashSet<Guid> { A, B }, result);
+    }
+
+    [Fact]
+    public void Build_AndRulesWithinOneSet_Intersect()
+    {
+        var resolver = new FakeResolver(new()
+        {
+            ["People"] = [A, B, C],
+            ["Genres"] = [B, C, D],
+        });
+        var builder = new CandidateSetBuilder([resolver]);
+
+        var result = builder.Build([Set(Rule("People"), Rule("Genres"))], Context());
+
+        Assert.NotNull(result);
+        Assert.Equal(new HashSet<Guid> { B, C }, result);
+    }
+
+    [Fact]
+    public void Build_UnboundedRuleInSet_DoesNotParticipateInIntersection()
+    {
+        // "Framerate" is unknown to the resolver (null = all items); the set is still
+        // bounded by the People rule alone.
+        var builder = new CandidateSetBuilder([new FakeResolver(new() { ["People"] = [A, B] })]);
+
+        var result = builder.Build([Set(Rule("People"), Rule("Framerate"))], Context());
+
+        Assert.NotNull(result);
+        Assert.Equal(new HashSet<Guid> { A, B }, result);
+    }
+
+    [Fact]
+    public void Build_SetWithZeroPushdownableRules_ForcesNullOverall()
+    {
+        // OR-union with an unbounded branch is unbounded, even when another set is bounded.
+        var builder = new CandidateSetBuilder([new FakeResolver(new() { ["People"] = [A] })]);
+
+        var result = builder.Build([Set(Rule("People")), Set(Rule("Framerate"))], Context());
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Build_OrSets_Union()
+    {
+        var resolver = new FakeResolver(new()
+        {
+            ["People"] = [A, B],
+            ["Genres"] = [C],
+        });
+        var builder = new CandidateSetBuilder([resolver]);
+
+        var result = builder.Build([Set(Rule("People")), Set(Rule("Genres"))], Context());
+
+        Assert.NotNull(result);
+        Assert.Equal(new HashSet<Guid> { A, B, C }, result);
+    }
+
+    [Theory]
+    [InlineData("NotEqual")]
+    [InlineData("NotContains")]
+    [InlineData("IsNotIn")]
+    public void Build_NegativeOperator_NeverReachesResolverWithoutOptIn(string op)
+    {
+        var resolver = new FakeResolver(new() { ["People"] = [A] });
+        var builder = new CandidateSetBuilder([resolver]);
+
+        var result = builder.Build([Set(Rule("People", op))], Context());
+
+        Assert.Null(result); // Rule did not participate -> set unbounded -> no shrink.
+        Assert.Equal(0, resolver.CallCount);
+    }
+
+    [Fact]
+    public void Build_NegativeOperator_ParticipatesWhenResolverOptsIn()
+    {
+        var resolver = new FakeResolver(new() { ["SeriesName"] = [A, B] }, supportsNegativeOperators: true);
+        var builder = new CandidateSetBuilder([resolver]);
+
+        var result = builder.Build([Set(Rule("SeriesName", "NotEqual"))], Context());
+
+        Assert.NotNull(result);
+        Assert.Equal(new HashSet<Guid> { A, B }, result);
+        Assert.Equal(1, resolver.CallCount);
+    }
+
+    [Theory]
+    [InlineData(".*")] // matches ""
+    [InlineData("a?")] // matches ""
+    [InlineData("(")] // invalid pattern
+    public void Build_MatchRegexMatchingEmptyStringOrInvalid_NeverRides(string pattern)
+    {
+        var resolver = new FakeResolver(new() { ["Name"] = [A] });
+        var builder = new CandidateSetBuilder([resolver]);
+
+        var result = builder.Build([Set(new Expression("Name", "MatchRegex", pattern))], Context());
+
+        Assert.Null(result);
+        Assert.Equal(0, resolver.CallCount);
+    }
+
+    [Fact]
+    public void Build_MatchRegexNotMatchingEmptyString_IsConsulted()
+    {
+        var resolver = new FakeResolver(new() { ["Name"] = [A] });
+        var builder = new CandidateSetBuilder([resolver]);
+
+        var result = builder.Build([Set(new Expression("Name", "MatchRegex", "abc"))], Context());
+
+        Assert.NotNull(result);
+        Assert.Equal(new HashSet<Guid> { A }, result);
+    }
+
+    [Fact]
+    public void Build_EmptyIntersection_ShortCircuitsRemainingRulesInSet()
+    {
+        // People={A}, Genres={B}: intersection empty after rule 2; rule 3 must not be consulted.
+        var resolver = new FakeResolver(new()
+        {
+            ["People"] = [A],
+            ["Genres"] = [B],
+            ["Studios"] = [C],
+        });
+        var builder = new CandidateSetBuilder([resolver]);
+
+        var result = builder.Build([Set(Rule("People"), Rule("Genres"), Rule("Studios"))], Context());
+
+        Assert.NotNull(result);
+        Assert.Empty(result);
+        Assert.Equal(2, resolver.CallCount);
+    }
+
+    [Fact]
+    public void Build_EmptySetBranch_ContributesNothingToUnion()
+    {
+        // Set 1 intersects to empty (hard "nothing matches"); set 2 is bounded - the
+        // union is exactly set 2's candidates.
+        var resolver = new FakeResolver(new()
+        {
+            ["People"] = [A],
+            ["Genres"] = [B],
+            ["Studios"] = [C, D],
+        });
+        var builder = new CandidateSetBuilder([resolver]);
+
+        var result = builder.Build([Set(Rule("People"), Rule("Genres")), Set(Rule("Studios"))], Context());
+
+        Assert.NotNull(result);
+        Assert.Equal(new HashSet<Guid> { C, D }, result);
+    }
+
+    [Fact]
+    public void Build_AllSetsEmpty_ReturnsEmptySetNotNull()
+    {
+        // Empty (non-null) is a hard claim distinct from null (= no shrink possible).
+        var resolver = new FakeResolver(new()
+        {
+            ["People"] = [A],
+            ["Genres"] = [B],
+        });
+        var builder = new CandidateSetBuilder([resolver]);
+
+        var result = builder.Build([Set(Rule("People"), Rule("Genres"))], Context());
+
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Build_FirstResolverWithResultWins()
+    {
+        var first = new FakeResolver(new() { ["People"] = [A] });
+        var second = new FakeResolver(new() { ["People"] = [B] });
+        var builder = new CandidateSetBuilder([first, second]);
+
+        var result = builder.Build([Set(Rule("People"))], Context());
+
+        Assert.NotNull(result);
+        Assert.Equal(new HashSet<Guid> { A }, result);
+        Assert.Equal(0, second.CallCount);
+    }
+
+    [Fact]
+    public void Build_ResolverThatCannotBound_FallsThroughToNextResolver()
+    {
+        var first = new FakeResolver(new() { ["Genres"] = [B] }); // knows nothing about People
+        var second = new FakeResolver(new() { ["People"] = [A] });
+        var builder = new CandidateSetBuilder([first, second]);
+
+        var result = builder.Build([Set(Rule("People"))], Context());
+
+        Assert.NotNull(result);
+        Assert.Equal(new HashSet<Guid> { A }, result);
+    }
+
+    [Fact]
+    public void Build_ThrowingResolver_DegradesToNoShrinkForThatRule()
+    {
+        var throwing = new ThrowingResolver();
+        var builder = new CandidateSetBuilder([throwing]);
+
+        var result = builder.Build([Set(Rule("People"))], Context());
+
+        Assert.Null(result); // Rule stays per-item -> set unbounded -> no shrink.
+        Assert.Equal(1, throwing.CallCount);
+    }
+
+    [Fact]
+    public void Build_NullExpressionEntries_AreSkipped()
+    {
+        var resolver = new FakeResolver(new() { ["People"] = [A] });
+        var builder = new CandidateSetBuilder([resolver]);
+        var set = new ExpressionSet { Expressions = [null!, Rule("People")] };
+
+        var result = builder.Build([set], Context());
+
+        Assert.NotNull(result);
+        Assert.Equal(new HashSet<Guid> { A }, result);
+    }
+
+    [Fact]
+    public void Build_SetWithNullExpressionsList_ForcesNullOverall()
+    {
+        // A malformed set is treated conservatively as "may match anything".
+        var resolver = new FakeResolver(new() { ["People"] = [A] });
+        var builder = new CandidateSetBuilder([resolver]);
+        var malformed = new ExpressionSet { Expressions = null };
+
+        var result = builder.Build([Set(Rule("People")), malformed], Context());
+
+        Assert.Null(result);
+    }
+
+    private sealed class ThrowingResolver : IRulePrefilterResolver
+    {
+        public int CallCount { get; private set; }
+
+        public HashSet<Guid>? Resolve(Expression expression, PrefilterContext context)
+        {
+            CallCount++;
+            throw new InvalidOperationException("boom");
+        }
+    }
+}

--- a/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/LastEpisodeAirDatePrefilterResolverTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/LastEpisodeAirDatePrefilterResolverTests.cs
@@ -1,0 +1,243 @@
+using Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
+
+namespace Jellyfin.Plugin.SmartLists.Tests.Core.QueryEngine;
+
+/// <summary>
+/// Covers the pure logic of <see cref="LastEpisodeAirDatePrefilterResolver"/>: the
+/// operator-to-query-plan mapping (including the unknown-dates gate and the moving-cutoff
+/// margin for OlderThan), the episode-to-series attribution, and the complement set math.
+/// Its contract:
+///
+/// - After/NewerThan ride directly (candidates = series with an episode at/after the bound),
+///   Before/OlderThan ride as an exact complement (pool series MINUS series with an episode
+///   at/after the bound), Equal rides as a [day, day+1] superset window.
+/// - NotEqual and Weekday need the actual max date, not existence - they never ride.
+/// - IncludeUnknownDates = true disables the resolver entirely: the compiled rule then
+///   matches every dateless operand, which no date range can bound.
+/// - Value parsing is EXACTLY the per-item semantics (strict yyyy-MM-dd absolute dates,
+///   number:unit relative values); anything the compiled rule would reject stays per-item.
+/// - Relative bounds are floored to whole unix seconds, mirroring the ToUnixTimeSeconds
+///   truncation on both sides of the per-item comparison.
+///
+/// The GetCount/GetItemList steps need a live Jellyfin and are exercised there, not here.
+/// </summary>
+public class LastEpisodeAirDatePrefilterResolverTests
+{
+    private static readonly DateTime FixedUtcNow = new(2026, 8, 16, 10, 30, 45, 500, DateTimeKind.Utc);
+
+    // ---- Unknown-dates gate ----
+
+    [Theory]
+    [InlineData("After", "2024-06-15")]
+    [InlineData("NewerThan", "3:days")]
+    [InlineData("Before", "2024-06-15")]
+    [InlineData("OlderThan", "2:years")]
+    [InlineData("Equal", "2024-06-15")]
+    public void IncludeUnknownDates_DisablesEveryOperator(string ruleOperator, string targetValue)
+    {
+        Assert.Null(LastEpisodeAirDatePrefilterResolver.TryBuildPlan(ruleOperator, targetValue, includeUnknownDates: true, FixedUtcNow));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(false)]
+    public void DefaultUnknownDates_Rides(bool? includeUnknownDates)
+    {
+        Assert.NotNull(LastEpisodeAirDatePrefilterResolver.TryBuildPlan("After", "2024-06-15", includeUnknownDates, FixedUtcNow));
+    }
+
+    // ---- Operator -> query-plan mapping ----
+
+    [Fact]
+    public void After_MapsToDirectLowerBound()
+    {
+        var plan = LastEpisodeAirDatePrefilterResolver.TryBuildPlan("After", "2024-06-15", null, FixedUtcNow);
+
+        Assert.NotNull(plan);
+        Assert.Equal(new DateTime(2024, 6, 15, 0, 0, 0, DateTimeKind.Utc), plan.MinPremiereDate);
+        Assert.Null(plan.MaxPremiereDate);
+        Assert.False(plan.IsComplement);
+    }
+
+    [Fact]
+    public void Before_MapsToComplementLowerBound()
+    {
+        var plan = LastEpisodeAirDatePrefilterResolver.TryBuildPlan("Before", "2024-06-15", null, FixedUtcNow);
+
+        Assert.NotNull(plan);
+        Assert.Equal(new DateTime(2024, 6, 15, 0, 0, 0, DateTimeKind.Utc), plan.MinPremiereDate);
+        Assert.Null(plan.MaxPremiereDate);
+        Assert.True(plan.IsComplement);
+    }
+
+    [Fact]
+    public void Equal_MapsToDayWindow()
+    {
+        var plan = LastEpisodeAirDatePrefilterResolver.TryBuildPlan("Equal", "2024-06-15", null, FixedUtcNow);
+
+        Assert.NotNull(plan);
+        Assert.Equal(new DateTime(2024, 6, 15, 0, 0, 0, DateTimeKind.Utc), plan.MinPremiereDate);
+        Assert.Equal(new DateTime(2024, 6, 16, 0, 0, 0, DateTimeKind.Utc), plan.MaxPremiereDate);
+        Assert.False(plan.IsComplement);
+    }
+
+    [Fact]
+    public void NewerThan_UsesCutoffFlooredToWholeSeconds()
+    {
+        var plan = LastEpisodeAirDatePrefilterResolver.TryBuildPlan("NewerThan", "3:days", null, FixedUtcNow);
+
+        Assert.NotNull(plan);
+        // utcNow - 3 days, sub-second component truncated.
+        Assert.Equal(new DateTime(2026, 8, 13, 10, 30, 45, DateTimeKind.Utc), plan.MinPremiereDate);
+        Assert.Null(plan.MaxPremiereDate);
+        Assert.False(plan.IsComplement);
+    }
+
+    [Theory]
+    [InlineData("6:hours", 2026, 8, 16, 4, 30, 45)]
+    [InlineData("2:weeks", 2026, 8, 2, 10, 30, 45)]
+    [InlineData("1:months", 2026, 7, 16, 10, 30, 45)]
+    [InlineData("1:years", 2025, 8, 16, 10, 30, 45)]
+    [InlineData("3:DAYS", 2026, 8, 13, 10, 30, 45)] // unit is lower-cased, mirroring the engine
+    public void NewerThan_UnitTable_MirrorsEngine(string targetValue, int year, int month, int day, int hour, int minute, int second)
+    {
+        var plan = LastEpisodeAirDatePrefilterResolver.TryBuildPlan("NewerThan", targetValue, null, FixedUtcNow);
+
+        Assert.NotNull(plan);
+        Assert.Equal(new DateTime(year, month, day, hour, minute, second, DateTimeKind.Utc), plan.MinPremiereDate);
+    }
+
+    [Fact]
+    public void NewerThan_MonthClamping_MirrorsEngine()
+    {
+        var endOfMonth = new DateTime(2026, 3, 31, 12, 0, 0, DateTimeKind.Utc);
+        var plan = LastEpisodeAirDatePrefilterResolver.TryBuildPlan("NewerThan", "1:months", null, endOfMonth);
+
+        Assert.NotNull(plan);
+        Assert.Equal(new DateTime(2026, 2, 28, 12, 0, 0, DateTimeKind.Utc), plan.MinPremiereDate);
+    }
+
+    [Fact]
+    public void OlderThan_MapsToComplementWithSafetyMargin()
+    {
+        var plan = LastEpisodeAirDatePrefilterResolver.TryBuildPlan("OlderThan", "2:years", null, FixedUtcNow);
+
+        Assert.NotNull(plan);
+        // The per-item cutoff is recomputed from UtcNow at every evaluation, so the exclusion
+        // threshold carries the margin: cutoff-at-build-time + margin, floored to seconds.
+        var expected = new DateTime(2024, 8, 16, 10, 30, 45, DateTimeKind.Utc)
+            + LastEpisodeAirDatePrefilterResolver.OlderThanComplementMargin;
+        Assert.Equal(expected, plan.MinPremiereDate);
+        Assert.Null(plan.MaxPremiereDate);
+        Assert.True(plan.IsComplement);
+    }
+
+    // ---- Non-riding operators ----
+
+    [Theory]
+    [InlineData("NotEqual", "2024-06-15")] // day-window negation needs the actual max
+    [InlineData("Weekday", "3")] // day-of-week OF the max needs the actual max
+    [InlineData("GreaterThan", "2024-06-15")]
+    [InlineData("Contains", "2024")]
+    [InlineData("after", "2024-06-15")] // operator comparison is Ordinal, mirroring the engine switch
+    [InlineData("", "2024-06-15")]
+    [InlineData(null, "2024-06-15")]
+    public void NonRidingOperators_StayPerItem(string? ruleOperator, string targetValue)
+    {
+        Assert.Null(LastEpisodeAirDatePrefilterResolver.TryBuildPlan(ruleOperator, targetValue, null, FixedUtcNow));
+    }
+
+    // ---- Values the compiled rule would reject ----
+
+    [Theory]
+    [InlineData("After", "junk")]
+    [InlineData("After", "2024-6-15")] // strict yyyy-MM-dd only
+    [InlineData("After", "15-06-2024")]
+    [InlineData("After", "")]
+    [InlineData("After", null)]
+    [InlineData("Equal", "2024-06-15T00:00:00")]
+    [InlineData("NewerThan", "3days")]
+    [InlineData("NewerThan", "-1:days")]
+    [InlineData("NewerThan", "3:fortnights")]
+    [InlineData("NewerThan", ":days")]
+    [InlineData("NewerThan", "3:")]
+    [InlineData("NewerThan", "3:days:extra")]
+    [InlineData("NewerThan", null)]
+    [InlineData("OlderThan", "2 years")]
+    public void UnparsableValues_StayPerItem(string ruleOperator, string? targetValue)
+    {
+        Assert.Null(LastEpisodeAirDatePrefilterResolver.TryBuildPlan(ruleOperator, targetValue, null, FixedUtcNow));
+    }
+
+    // ---- Episode -> series attribution ----
+
+    [Fact]
+    public void MapToSeriesIds_CollapsesToDistinctSeries()
+    {
+        var seriesA = Guid.NewGuid();
+        var seriesB = Guid.NewGuid();
+        var episodes = new BaseItem[]
+        {
+            new Episode { Id = Guid.NewGuid(), SeriesId = seriesA },
+            new Episode { Id = Guid.NewGuid(), SeriesId = seriesA },
+            new Episode { Id = Guid.NewGuid(), SeriesId = seriesB },
+        };
+
+        var result = LastEpisodeAirDatePrefilterResolver.MapToSeriesIds(episodes);
+
+        Assert.Equal(new HashSet<Guid> { seriesA, seriesB }, result);
+    }
+
+    [Fact]
+    public void MapToSeriesIds_SkipsUnattributableAndNonEpisodes()
+    {
+        var seriesA = Guid.NewGuid();
+        var episodes = new BaseItem[]
+        {
+            new Episode { Id = Guid.NewGuid(), SeriesId = seriesA },
+            // No SeriesId and no parent chain: FindSeriesId() yields Guid.Empty - the
+            // per-series extraction cannot see this episode either.
+            new Episode { Id = Guid.NewGuid() },
+            new Movie { Id = Guid.NewGuid() },
+        };
+
+        var result = LastEpisodeAirDatePrefilterResolver.MapToSeriesIds(episodes);
+
+        Assert.Equal(new HashSet<Guid> { seriesA }, result);
+    }
+
+    // ---- Complement set math ----
+
+    [Fact]
+    public void Complement_IsPoolSeriesMinusExcluded()
+    {
+        var recentSeries = new Series { Id = Guid.NewGuid() };
+        var oldSeries = new Series { Id = Guid.NewGuid() };
+        var datelessSeries = new Series { Id = Guid.NewGuid() };
+        var movie = new Movie { Id = Guid.NewGuid() };
+        var pool = new BaseItem[] { recentSeries, oldSeries, datelessSeries, movie };
+
+        var excluded = new HashSet<Guid> { recentSeries.Id };
+
+        var result = LastEpisodeAirDatePrefilterResolver.ComplementOverPoolSeries(pool, excluded);
+
+        // Series with no episode at/after the bound stay candidates - including dateless
+        // series, whose 0 sentinel the final per-item evaluation still rejects. Non-Series
+        // pool items can never match the rule under the unknown-dates gate.
+        Assert.Equal(new HashSet<Guid> { oldSeries.Id, datelessSeries.Id }, result);
+    }
+
+    [Fact]
+    public void Complement_AllPoolSeriesExcluded_IsEmptyHardClaim()
+    {
+        var series = new Series { Id = Guid.NewGuid() };
+        var pool = new BaseItem[] { series, new Movie { Id = Guid.NewGuid() } };
+
+        var result = LastEpisodeAirDatePrefilterResolver.ComplementOverPoolSeries(pool, [series.Id]);
+
+        Assert.Empty(result);
+    }
+}

--- a/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/NextUnwatchedPrefilterResolverTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/NextUnwatchedPrefilterResolverTests.cs
@@ -1,0 +1,83 @@
+using Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters;
+
+namespace Jellyfin.Plugin.SmartLists.Tests.Core.QueryEngine;
+
+/// <summary>
+/// Covers the pure operator/value gate of <see cref="NextUnwatchedPrefilterResolver"/> - the
+/// decision whether a NextUnwatched rule may ride the unplayed-episode prefilter. Its contract:
+///
+/// - Only "Equal true" and the logically identical "NotEqual false" ride (both mean "IS the
+///   next unwatched episode", which is provably a subset of the user's unplayed episodes).
+/// - The complement ("Equal false" / "NotEqual true") matches played episodes, later unplayed
+///   episodes and every non-episode - no unplayed-episode set can bound it, so it never rides.
+/// - Value parsing is EXACTLY the per-item semantics (it delegates to the same
+///   Engine.ValidateAndParseBooleanValue the compiled rules use): trim whitespace, strip
+///   surrounding quotes, case-insensitive bool parse.
+/// - Anything the compiled rule would reject (unsupported operator, empty or unparsable
+///   value) stays per-item - the gate never guesses.
+///
+/// The user resolution and GetItemIds steps need a live Jellyfin and are exercised there, not here.
+/// </summary>
+public class NextUnwatchedPrefilterResolverTests
+{
+    // ---- Riding combinations ----
+
+    [Theory]
+    [InlineData("Equal", "true")]
+    [InlineData("Equal", "True")]
+    [InlineData("Equal", "TRUE")]
+    [InlineData("Equal", " true ")]
+    [InlineData("Equal", "\"true\"")]
+    [InlineData("Equal", "'true'")]
+    [InlineData("NotEqual", "false")]
+    [InlineData("NotEqual", "False")]
+    [InlineData("NotEqual", " \"false\" ")]
+    public void EqualTrue_And_NotEqualFalse_Ride(string ruleOperator, string targetValue)
+    {
+        Assert.True(NextUnwatchedPrefilterResolver.RidesPrefilter(ruleOperator, targetValue));
+    }
+
+    // ---- Complement combinations never ride ----
+
+    [Theory]
+    [InlineData("Equal", "false")]
+    [InlineData("Equal", "False")]
+    [InlineData("Equal", "\"false\"")]
+    [InlineData("NotEqual", "true")]
+    [InlineData("NotEqual", "True")]
+    [InlineData("NotEqual", "'true'")]
+    public void ComplementCombinations_StayPerItem(string ruleOperator, string targetValue)
+    {
+        Assert.False(NextUnwatchedPrefilterResolver.RidesPrefilter(ruleOperator, targetValue));
+    }
+
+    // ---- Unsupported operators never ride ----
+
+    [Theory]
+    [InlineData("Contains")]
+    [InlineData("IsIn")]
+    [InlineData("GreaterThan")]
+    [InlineData("MatchRegex")]
+    [InlineData("equal")] // operator comparison is Ordinal, mirroring the engine switch
+    [InlineData("")]
+    [InlineData(null)]
+    public void UnsupportedOperators_StayPerItem(string? ruleOperator)
+    {
+        Assert.False(NextUnwatchedPrefilterResolver.RidesPrefilter(ruleOperator, "true"));
+    }
+
+    // ---- Values the compiled rule would reject never ride ----
+
+    [Theory]
+    [InlineData("yes")]
+    [InlineData("1")]
+    [InlineData("truthy")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void UnparsableValues_StayPerItem(string? targetValue)
+    {
+        Assert.False(NextUnwatchedPrefilterResolver.RidesPrefilter("Equal", targetValue));
+        Assert.False(NextUnwatchedPrefilterResolver.RidesPrefilter("NotEqual", targetValue));
+    }
+}

--- a/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/ParentValuesPrefilterResolverTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/ParentValuesPrefilterResolverTests.cs
@@ -1,0 +1,290 @@
+using Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters;
+
+namespace Jellyfin.Plugin.SmartLists.Tests.Core.QueryEngine;
+
+/// <summary>
+/// Covers the pure decision logic of <see cref="ParentValuesPrefilterResolver"/> - the
+/// per-group operator gating and the normalized name matching that decide what (if
+/// anything) a parent-aware Tags/Genres/Studios rule pushes into the candidate queries.
+/// Its contract:
+///
+/// - Tags push Equal ONLY (raw value; the server-side Tags filter is a cleaned exact
+///   match, and no tag-name dump API exists to expand substring operators against).
+/// - Genre/studio dump matching is deliberately BROADER than plugin per-item semantics:
+///   the dumps hold one representative raw variant per server-cleaned group, so matching
+///   runs on MatchNormalize (diacritics folded, case folded, all non-alphanumerics
+///   dropped) - coarser than both ABIs' cleans, which is exactly what makes one
+///   representative safely stand in for its whole group. Broader matching only ever adds
+///   candidates.
+/// - MatchRegex never rides these fields (plugin regex is case-sensitive on raw variants;
+///   no lone representative is a sound superset), nor do negative operators.
+/// - Studio resolution additionally requires every rule-matching ItemValues name to have
+///   a materialized by-name Studio item under the same CleanValue key (the server's
+///   RemoveDiacritics + lowercase - the FINEST clean either ABI applies, so key equality
+///   implies StudioIds-join reachability on both). A matching name without one means the
+///   per-item path could match items no StudioIds query can reach - fall back.
+///
+/// The two-query ancestor expansion and the CollectionFolder guard need a live Jellyfin
+/// and are exercised there, not here.
+/// </summary>
+public class ParentValuesPrefilterResolverTests
+{
+    // ---- PrefilterValueCleaner ----
+
+    [Theory]
+    [InlineData("Pathé", "pathe")]
+    [InlineData("WARNER", "warner")]
+    [InlineData("Sci-Fi", "sci-fi")]
+    public void CleanValue_FoldsDiacriticsAndCase_KeepsPunctuation(string input, string expected)
+    {
+        Assert.Equal(expected, PrefilterValueCleaner.CleanValue(input));
+    }
+
+    [Theory]
+    [InlineData("Sci-Fi ", "scifi")]
+    [InlineData("Warner Bros.", "warnerbros")]
+    [InlineData("Pathé!", "pathe")]
+    [InlineData("Blade Runner 2049", "bladerunner2049")]
+    [InlineData("!!!", "")]
+    public void MatchNormalize_DropsEveryNonAlphanumeric(string input, string expected)
+    {
+        Assert.Equal(expected, PrefilterValueCleaner.MatchNormalize(input));
+    }
+
+    // ---- Tags gating ----
+
+    [Fact]
+    public void Tags_EqualRides_WithRawValue()
+    {
+        var push = ParentValuesPrefilterResolver.ResolveTagPushdownValues("Equal", "Halloween");
+
+        Assert.NotNull(push);
+        Assert.Equal(["Halloween"], push);
+    }
+
+    [Theory]
+    [InlineData("Contains")]
+    [InlineData("IsIn")]
+    [InlineData("MatchRegex")]
+    [InlineData("NotEqual")]
+    [InlineData("NotContains")]
+    [InlineData("IsNotIn")]
+    public void Tags_OnlyEqualRides(string ruleOperator)
+    {
+        Assert.Null(ParentValuesPrefilterResolver.ResolveTagPushdownValues(ruleOperator, "Halloween"));
+    }
+
+    [Fact]
+    public void Tags_WhitespaceValueStaysPerItem()
+    {
+        Assert.Null(ParentValuesPrefilterResolver.ResolveTagPushdownValues("Equal", "   "));
+    }
+
+    // ---- Dump name matching (Genres Contains/IsIn, Studios all positive operators) ----
+
+    [Fact]
+    public void Equal_MatchesDiacriticVariantRepresentative()
+    {
+        // Plugin-side an item can carry "Pathé" while the dump representative is "Pathe"
+        // (one row per server-cleaned group) - plugin-exact OrdinalIgnoreCase matching
+        // would miss the group, normalized matching must not.
+        var matched = ParentValuesPrefilterResolver.ResolveMatchingNames(["Pathe", "Warner"], "Equal", "Pathé");
+
+        Assert.NotNull(matched);
+        Assert.Equal(["Pathe"], matched);
+    }
+
+    [Fact]
+    public void Equal_MatchesPunctuationVariantRepresentative()
+    {
+        // Jellyfin 12's clean also collapses punctuation, so "Sci-Fi" and "Sci Fi" share
+        // one group there and either spelling can be the dumped representative.
+        var matched = ParentValuesPrefilterResolver.ResolveMatchingNames(["Sci Fi"], "Equal", "Sci-Fi");
+
+        Assert.NotNull(matched);
+        Assert.Equal(["Sci Fi"], matched);
+    }
+
+    [Fact]
+    public void Equal_DoesNotSubstringMatch()
+    {
+        var matched = ParentValuesPrefilterResolver.ResolveMatchingNames(["Action", "Action-Packed"], "Equal", "Action");
+
+        Assert.NotNull(matched);
+        Assert.Equal(["Action"], matched);
+    }
+
+    [Fact]
+    public void Equal_NoMatchReturnsEmpty_NotNull()
+    {
+        var matched = ParentValuesPrefilterResolver.ResolveMatchingNames(["Action"], "Equal", "Comedy");
+
+        Assert.NotNull(matched);
+        Assert.Empty(matched);
+    }
+
+    [Fact]
+    public void Contains_SubstringOnNormalizedForm()
+    {
+        var matched = ParentValuesPrefilterResolver.ResolveMatchingNames(["Sci-Fi Thriller", "Drama"], "Contains", "SciFi");
+
+        Assert.NotNull(matched);
+        Assert.Equal(["Sci-Fi Thriller"], matched);
+    }
+
+    [Fact]
+    public void Contains_EmptyNormalizedNeedleStaysPerItem()
+    {
+        // "!!!" normalizes to "" and would match every dumped name.
+        Assert.Null(ParentValuesPrefilterResolver.ResolveMatchingNames(["Action"], "Contains", "!!!"));
+    }
+
+    [Fact]
+    public void IsIn_PerTermSubstringSemantics()
+    {
+        // Mirrors Engine.AnyItemIsInList: semicolon terms, each a substring match -
+        // "Com" must also match "Comedy".
+        var matched = ParentValuesPrefilterResolver.ResolveMatchingNames(["Action", "Drama", "Comedy"], "IsIn", "Drama; Com");
+
+        Assert.NotNull(matched);
+        Assert.Equal(["Drama", "Comedy"], matched);
+    }
+
+    [Fact]
+    public void IsIn_AllTermsEmptyStaysPerItem()
+    {
+        Assert.Null(ParentValuesPrefilterResolver.ResolveMatchingNames(["Action"], "IsIn", " ; ;!"));
+    }
+
+    [Fact]
+    public void IsIn_AnyEmptyNormalizedTermStaysPerItem()
+    {
+        // "!!" is a live plugin-side substring term against raw values; silently dropping
+        // it would under-match, so its presence must force the whole rule per-item.
+        Assert.Null(ParentValuesPrefilterResolver.ResolveMatchingNames(["Action", "Drama"], "IsIn", "Drama;!!"));
+    }
+
+    [Theory]
+    [InlineData("MatchRegex")]
+    [InlineData("NotEqual")]
+    [InlineData("NotContains")]
+    [InlineData("IsNotIn")]
+    public void UnsupportedOperatorsStayPerItem(string ruleOperator)
+    {
+        Assert.Null(ParentValuesPrefilterResolver.ResolveMatchingNames(["Action"], ruleOperator, "Action"));
+    }
+
+    [Fact]
+    public void MatchedWhitespaceOnlyNameAbortsPushdown()
+    {
+        // " " normalizes to "" and matches Equal "!!!" - but a blank value cannot be
+        // pushed as a query value, and skipping a matched name could drop a true match.
+        Assert.Null(ParentValuesPrefilterResolver.ResolveMatchingNames([" "], "Equal", "!!!"));
+    }
+
+    [Fact]
+    public void MoreThanMaxMatchedNamesStaysPerItem()
+    {
+        var names = Enumerable.Range(0, ParentValuesPrefilterResolver.MaxMatchedNames + 1)
+            .Select(i => $"Genre {i}")
+            .ToList();
+
+        Assert.Null(ParentValuesPrefilterResolver.ResolveMatchingNames(names, "Contains", "Genre"));
+    }
+
+    // ---- Studio id resolution (materialization coverage) ----
+
+    [Fact]
+    public void Studios_ResolvesIdsWhenEveryMatchingNameIsMaterialized()
+    {
+        var id = Guid.NewGuid();
+        var ids = ParentValuesPrefilterResolver.ResolveStudioIds(
+            ["Warner Bros."],
+            [(id, "Warner Bros.")],
+            "Equal",
+            "warner bros");
+
+        Assert.NotNull(ids);
+        Assert.Equal([id], ids);
+    }
+
+    [Fact]
+    public void Studios_DiacriticVariantStillCoveredViaCleanValueKey()
+    {
+        var id = Guid.NewGuid();
+        var ids = ParentValuesPrefilterResolver.ResolveStudioIds(
+            ["Pathé"],
+            [(id, "Pathe")],
+            "Equal",
+            "Pathé");
+
+        Assert.NotNull(ids);
+        Assert.Equal([id], ids);
+    }
+
+    [Fact]
+    public void Studios_UnmaterializedMatchingNameForcesFallback()
+    {
+        // "Warhol Films" exists in ItemValues (items carry the string) but its by-name
+        // Studio item was never created - a StudioIds query can never reach those items.
+        var ids = ParentValuesPrefilterResolver.ResolveStudioIds(
+            ["Warner Bros.", "Warhol Films"],
+            [(Guid.NewGuid(), "Warner Bros.")],
+            "Contains",
+            "War");
+
+        Assert.Null(ids);
+    }
+
+    [Fact]
+    public void Studios_PunctuationVariantIsNotAssumedCovered()
+    {
+        // CleanValue keeps punctuation (the 10.11 clean, the finest either ABI applies):
+        // "Sci-Fi" vs "Sci Fi" may share a group on Jellyfin 12 but not on 10.11, so
+        // coverage cannot be claimed and the rule must stay per-item.
+        var ids = ParentValuesPrefilterResolver.ResolveStudioIds(
+            ["Sci-Fi"],
+            [(Guid.NewGuid(), "Sci Fi")],
+            "Equal",
+            "Sci-Fi");
+
+        Assert.Null(ids);
+    }
+
+    [Fact]
+    public void Studios_ZeroMatchesStaysPerItem()
+    {
+        Assert.Null(ParentValuesPrefilterResolver.ResolveStudioIds(
+            ["Warner Bros."],
+            [(Guid.NewGuid(), "Warner Bros.")],
+            "Equal",
+            "Paramount"));
+    }
+
+    [Fact]
+    public void Studios_UnionsAllIdsSharingACleanedName()
+    {
+        var first = Guid.NewGuid();
+        var second = Guid.NewGuid();
+        var ids = ParentValuesPrefilterResolver.ResolveStudioIds(
+            ["Pathe"],
+            [(first, "Pathe"), (second, "Pathé")],
+            "Equal",
+            "pathe");
+
+        Assert.NotNull(ids);
+        Assert.Equal(2, ids.Length);
+        Assert.Contains(first, ids);
+        Assert.Contains(second, ids);
+    }
+
+    [Fact]
+    public void Studios_MatchRegexStaysPerItem()
+    {
+        Assert.Null(ParentValuesPrefilterResolver.ResolveStudioIds(
+            ["Warner Bros."],
+            [(Guid.NewGuid(), "Warner Bros.")],
+            "MatchRegex",
+            "Warner.*"));
+    }
+}

--- a/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/PeoplePrefilterResolverTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/PeoplePrefilterResolverTests.cs
@@ -1,0 +1,228 @@
+using Jellyfin.Plugin.SmartLists.Core.QueryEngine;
+using Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters;
+
+namespace Jellyfin.Plugin.SmartLists.Tests.Core.QueryEngine;
+
+/// <summary>
+/// Covers the pure name-resolution step of <see cref="PeoplePrefilterResolver"/> - the
+/// piece that decides which STORED person names a people rule matches before the per-name
+/// item queries run. Its contract:
+///
+/// - Operator semantics must be EXACTLY the plugin's per-item semantics (it delegates to
+///   the same Engine helpers the compiled rules bind): Equal is whole-name
+///   OrdinalIgnoreCase, Contains is substring OrdinalIgnoreCase, IsIn is a
+///   semicolon-separated substring list, MatchRegex is case-sensitive.
+/// - A pattern that matches the empty string never rides (an empty people list is
+///   evaluated against "", so such patterns match items with NO people - unreachable from
+///   any name-derived set), nor does an invalid pattern or a negative/unknown operator.
+/// - More than MaxMatchedNames matches means the rule is too broad to push down.
+/// - Null/empty stored names are skipped (per-item extraction drops them); a MATCHED
+///   whitespace-only name aborts the pushdown entirely (it cannot be queried, and
+///   silently dropping it could drop a true match).
+/// - An empty (non-null) result is a hard "no stored name matches" claim.
+///
+/// The DB-dump and GetItemIds steps need a live Jellyfin and are exercised there, not here.
+/// </summary>
+public class PeoplePrefilterResolverTests
+{
+    private static readonly string[] DefaultNames = ["Bob Smith", "bob smith", "Bobby Smith", "Alice Jones"];
+
+    // ---- Equal ----
+
+    [Fact]
+    public void Equal_MatchesWholeNameCaseInsensitive()
+    {
+        var matched = PeoplePrefilterResolver.ResolveMatchingNames(DefaultNames, "Equal", "BOB SMITH");
+
+        Assert.NotNull(matched);
+        Assert.Equal(["Bob Smith", "bob smith"], matched);
+    }
+
+    [Fact]
+    public void Equal_DoesNotSubstringMatch()
+    {
+        var matched = PeoplePrefilterResolver.ResolveMatchingNames(DefaultNames, "Equal", "Bob");
+
+        Assert.NotNull(matched);
+        Assert.Empty(matched);
+    }
+
+    // ---- Contains ----
+
+    [Fact]
+    public void Contains_SubstringCaseInsensitive()
+    {
+        var matched = PeoplePrefilterResolver.ResolveMatchingNames(DefaultNames, "Contains", "SMITH");
+
+        Assert.NotNull(matched);
+        Assert.Equal(["Bob Smith", "bob smith", "Bobby Smith"], matched);
+    }
+
+    [Fact]
+    public void Contains_NoMatches_ReturnsEmptyHardClaim()
+    {
+        var matched = PeoplePrefilterResolver.ResolveMatchingNames(DefaultNames, "Contains", "Zebra");
+
+        Assert.NotNull(matched);
+        Assert.Empty(matched);
+    }
+
+    // ---- IsIn ----
+
+    [Fact]
+    public void IsIn_SemicolonListUsesSubstringSemanticsAndTrims()
+    {
+        var matched = PeoplePrefilterResolver.ResolveMatchingNames(DefaultNames, "IsIn", " jones ; BOBBY ");
+
+        Assert.NotNull(matched);
+        Assert.Equal(["Bobby Smith", "Alice Jones"], matched);
+    }
+
+    [Fact]
+    public void IsIn_EmptyOrSeparatorOnlyList_MatchesNothing()
+    {
+        // AnyItemIsInList returns false for every item when the target list parses empty,
+        // so the rule matches nothing - an exact empty claim, not a bail-out.
+        var empty = PeoplePrefilterResolver.ResolveMatchingNames(DefaultNames, "IsIn", "");
+        var separators = PeoplePrefilterResolver.ResolveMatchingNames(DefaultNames, "IsIn", " ; ; ");
+
+        Assert.NotNull(empty);
+        Assert.Empty(empty);
+        Assert.NotNull(separators);
+        Assert.Empty(separators);
+    }
+
+    // ---- MatchRegex ----
+
+    [Fact]
+    public void MatchRegex_IsCaseSensitiveLikePerItemEvaluation()
+    {
+        var matched = PeoplePrefilterResolver.ResolveMatchingNames(DefaultNames, "MatchRegex", "^Bob");
+
+        Assert.NotNull(matched);
+        Assert.Equal(["Bob Smith", "Bobby Smith"], matched);
+    }
+
+    [Theory]
+    [InlineData(".*")]
+    [InlineData("^$")]
+    [InlineData("")]
+    [InlineData("(Bob)?")]
+    public void MatchRegex_PatternMatchingEmptyString_NeverRides(string pattern)
+    {
+        Assert.Null(PeoplePrefilterResolver.ResolveMatchingNames(DefaultNames, "MatchRegex", pattern));
+    }
+
+    [Fact]
+    public void MatchRegex_InvalidPattern_NeverRides()
+    {
+        Assert.Null(PeoplePrefilterResolver.ResolveMatchingNames(DefaultNames, "MatchRegex", "["));
+    }
+
+    // ---- Operator gating ----
+
+    [Theory]
+    [InlineData("NotEqual")]
+    [InlineData("NotContains")]
+    [InlineData("IsNotIn")]
+    [InlineData("GreaterThan")]
+    [InlineData("SimilarTo")]
+    public void NegativeAndUnknownOperators_NeverRide(string ruleOperator)
+    {
+        Assert.Null(PeoplePrefilterResolver.ResolveMatchingNames(DefaultNames, ruleOperator, "Bob Smith"));
+    }
+
+    // ---- Cap ----
+
+    [Fact]
+    public void MatchedNamesAtCap_StillRides()
+    {
+        var names = Enumerable.Range(1, PeoplePrefilterResolver.MaxMatchedNames).Select(i => $"Person {i}").ToList();
+
+        var matched = PeoplePrefilterResolver.ResolveMatchingNames(names, "Contains", "Person");
+
+        Assert.NotNull(matched);
+        Assert.Equal(PeoplePrefilterResolver.MaxMatchedNames, matched.Count);
+    }
+
+    [Fact]
+    public void MatchedNamesOverCap_NeverRides()
+    {
+        var names = Enumerable.Range(1, PeoplePrefilterResolver.MaxMatchedNames + 1).Select(i => $"Person {i}").ToList();
+
+        Assert.Null(PeoplePrefilterResolver.ResolveMatchingNames(names, "Contains", "Person"));
+    }
+
+    [Fact]
+    public void ManyStoredNamesButFewMatches_StillRides()
+    {
+        var names = Enumerable.Range(1, 10_000).Select(i => $"Person {i}").Append("Unique Name").ToList();
+
+        var matched = PeoplePrefilterResolver.ResolveMatchingNames(names, "Equal", "unique name");
+
+        Assert.NotNull(matched);
+        Assert.Equal(["Unique Name"], matched);
+    }
+
+    // ---- Degenerate stored names ----
+
+    [Fact]
+    public void NullAndEmptyStoredNames_AreSkipped()
+    {
+        var matched = PeoplePrefilterResolver.ResolveMatchingNames([null!, "", "Bob Smith"], "Contains", "bob");
+
+        Assert.NotNull(matched);
+        Assert.Equal(["Bob Smith"], matched);
+    }
+
+    [Fact]
+    public void MatchedWhitespaceOnlyName_AbortsThePushdown()
+    {
+        // " " matches Contains " " but cannot be queried (TranslateQuery drops a whitespace
+        // Person clause); dropping just that name could drop a true match, so the whole
+        // rule must stay per-item.
+        Assert.Null(PeoplePrefilterResolver.ResolveMatchingNames([" ", "Bob Smith"], "Contains", " "));
+    }
+
+    [Fact]
+    public void UnmatchedWhitespaceOnlyName_DoesNotAbort()
+    {
+        var matched = PeoplePrefilterResolver.ResolveMatchingNames([" ", "Bob Smith"], "Equal", "Bob Smith");
+
+        Assert.NotNull(matched);
+        Assert.Equal(["Bob Smith"], matched);
+    }
+
+    // ---- Field coverage ----
+
+    [Fact]
+    public void HandlesEveryRegistryPeopleFieldExceptActorRoles()
+    {
+        // ActorRoles is the one people field that can never ride: role strings live on the
+        // people map row and are not filterable in either ABI.
+        foreach (var field in FieldRegistry.GetPeopleRoleFields())
+        {
+            if (field == "ActorRoles")
+            {
+                Assert.False(PeoplePrefilterResolver.HandlesField(field));
+            }
+            else
+            {
+                Assert.True(PeoplePrefilterResolver.HandlesField(field), $"People field '{field}' has no prefilter mapping");
+            }
+        }
+    }
+
+    [Fact]
+    public void Resolve_UnhandledOrUnavailable_ReturnsNull()
+    {
+        var resolver = new PeoplePrefilterResolver();
+        var context = new PrefilterContext(null!, null!, null, null);
+
+        // ActorRoles and non-people fields are not this resolver's to bound; and without a
+        // library manager even a people field must degrade to "no shrink possible".
+        Assert.Null(resolver.Resolve(new Expression("ActorRoles", "Contains", "x"), context));
+        Assert.Null(resolver.Resolve(new Expression("Genres", "Equal", "x"), context));
+        Assert.Null(resolver.Resolve(new Expression("Directors", "Equal", "x"), context));
+    }
+}

--- a/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/PrefilterExemptionTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/PrefilterExemptionTests.cs
@@ -1,0 +1,114 @@
+using Jellyfin.Plugin.SmartLists.Core;
+using Jellyfin.Plugin.SmartLists.Core.Models;
+using Jellyfin.Plugin.SmartLists.Core.QueryEngine;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Model.Entities;
+
+namespace Jellyfin.Plugin.SmartLists.Tests.Core.QueryEngine;
+
+/// <summary>
+/// Covers the consumption-side exemptions of <see cref="SmartList.FilterByCandidateSet"/> -
+/// the items a DB prefilter must never shrink away, per the safety contract:
+/// - Extras enter pools via their owner chain (LibraryManagerHelper.FetchExtras), so a
+///   candidate query over the main library can never return them - they are always kept.
+/// - Series must survive whenever Collections rules are present, so the
+///   DoesSeriesMatchCollectionsRules bypass can still see them.
+/// Everything else intersects with the candidate set normally.
+/// </summary>
+public class PrefilterExemptionTests
+{
+    private static SmartList List(params ExpressionSet[] sets)
+    {
+        var list = new SmartList(new SmartPlaylistDto { Id = "prefilter-exemption-test", Name = "Exemptions" });
+        if (sets.Length > 0)
+        {
+            list.ExpressionSets = [.. sets];
+        }
+
+        return list;
+    }
+
+    private static ExpressionSet Set(string memberName)
+    {
+        return new ExpressionSet { Expressions = [new Expression(memberName, "Equal", "x")] };
+    }
+
+    private static Movie Movie(string name)
+    {
+        return new Movie { Id = Guid.NewGuid(), Name = name };
+    }
+
+    [Fact]
+    public void CandidateMembershipDecidesOrdinaryItems()
+    {
+        var kept = Movie("in-set");
+        var dropped = Movie("outside-set");
+        var list = List(Set("Directors"));
+
+        var result = list.FilterByCandidateSet([kept, dropped], [kept.Id], null, "test");
+
+        Assert.Single(result);
+        Assert.Same(kept, result[0]);
+    }
+
+    [Fact]
+    public void ExtraOutsideCandidateSetIsAlwaysKept()
+    {
+        var extra = new Video { Id = Guid.NewGuid(), Name = "trailer", ExtraType = ExtraType.Trailer };
+        var list = List(Set("Directors"));
+
+        var result = list.FilterByCandidateSet([extra], [], null, "test");
+
+        Assert.Single(result);
+        Assert.Same(extra, result[0]);
+    }
+
+    [Fact]
+    public void SeriesOutsideCandidateSetIsKeptWhenCollectionsRulesPresent()
+    {
+        var series = new Series { Id = Guid.NewGuid(), Name = "series" };
+        var list = List(Set("Collections"), Set("Directors"));
+
+        var result = list.FilterByCandidateSet([series], [], null, "test");
+
+        Assert.Single(result);
+        Assert.Same(series, result[0]);
+    }
+
+    [Fact]
+    public void SeriesOutsideCandidateSetIsDroppedWithoutCollectionsRules()
+    {
+        var series = new Series { Id = Guid.NewGuid(), Name = "series" };
+        var list = List(Set("Directors"));
+
+        var result = list.FilterByCandidateSet([series], [], null, "test");
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void SeriesInsideCandidateSetIsKeptWithoutCollectionsRules()
+    {
+        var series = new Series { Id = Guid.NewGuid(), Name = "series" };
+        var list = List(Set("Directors"));
+
+        var result = list.FilterByCandidateSet([series], [series.Id], null, "test");
+
+        Assert.Single(result);
+        Assert.Same(series, result[0]);
+    }
+
+    [Fact]
+    public void NullItemsAreSkipped()
+    {
+        var kept = Movie("in-set");
+        var list = List(Set("Directors"));
+
+        var result = list.FilterByCandidateSet([null!, kept], [kept.Id], null, "test");
+
+        Assert.Single(result);
+        Assert.Same(kept, result[0]);
+    }
+}

--- a/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/ResolutionPrefilterResolverTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/ResolutionPrefilterResolverTests.cs
@@ -1,0 +1,181 @@
+using Jellyfin.Plugin.SmartLists.Core.Constants;
+using Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters;
+
+namespace Jellyfin.Plugin.SmartLists.Tests.Core.QueryEngine;
+
+/// <summary>
+/// Covers the pure operator/value -> MinHeight/MaxHeight window mapping of
+/// <see cref="ResolutionPrefilterResolver"/> and its media-type gate. The mapping contract:
+///
+/// - The per-item bucketer classifies on max video-stream HEIGHT with upper-inclusive
+///   boundaries (&lt;=480 -> 480p, &lt;=720 -> 720p, &lt;=1080 -> 1080p, &lt;=1440 -> 1440p,
+///   &lt;=2160 -> 4K, else 8K), so each bucket is exactly the height range
+///   (previous bucket height, bucket height].
+/// - The lowest bucket's window starts at height 1: the compiled rule's validity gate
+///   requires a positive extracted height, so height-0 items never match per-item.
+/// - The top bucket (8K) is open-ended above - the bucketer maps EVERY height over 2160
+///   to "8K" - so Equal/GreaterThanOrEqual "8K" must carry NO MaxHeight, and
+///   LessThanOrEqual "8K" (which matches every valid-resolution item) cannot ride at all.
+/// - NotEqual, unsupported operators, and values the compiled rule would reject all stay
+///   per-item (null window).
+///
+/// The GetItemIds query itself needs a live Jellyfin and is exercised there, not here.
+/// </summary>
+public class ResolutionPrefilterResolverTests
+{
+    // ---- Full operator -> window mapping table ----
+
+    [Theory]
+    // Equal: (previous bucket height + 1) .. bucket height; top bucket open-ended above.
+    [InlineData("Equal", "480p", 1, 480)]
+    [InlineData("Equal", "720p", 481, 720)]
+    [InlineData("Equal", "1080p", 721, 1080)]
+    [InlineData("Equal", "1440p", 1081, 1440)]
+    [InlineData("Equal", "4K", 1441, 2160)]
+    [InlineData("Equal", "8K", 2161, null)]
+    // GreaterThan: strictly above the bucket's own height.
+    [InlineData("GreaterThan", "480p", 481, null)]
+    [InlineData("GreaterThan", "720p", 721, null)]
+    [InlineData("GreaterThan", "1080p", 1081, null)]
+    [InlineData("GreaterThan", "1440p", 1441, null)]
+    [InlineData("GreaterThan", "4K", 2161, null)]
+    // Per-item nothing buckets above 8K, so this window's matches are all (harmless) false positives.
+    [InlineData("GreaterThan", "8K", 4321, null)]
+    // GreaterThanOrEqual: from the bucket's own lower boundary.
+    [InlineData("GreaterThanOrEqual", "480p", 1, null)]
+    [InlineData("GreaterThanOrEqual", "720p", 481, null)]
+    [InlineData("GreaterThanOrEqual", "1080p", 721, null)]
+    [InlineData("GreaterThanOrEqual", "1440p", 1081, null)]
+    [InlineData("GreaterThanOrEqual", "4K", 1441, null)]
+    [InlineData("GreaterThanOrEqual", "8K", 2161, null)]
+    // LessThan: up to the previous bucket's height.
+    // 480p edge: previous bucket height is 0 - per-item nothing can match (validity gate),
+    // so the Height<=0 window's matches are all (harmless) false positives.
+    [InlineData("LessThan", "480p", null, 0)]
+    [InlineData("LessThan", "720p", null, 480)]
+    [InlineData("LessThan", "1080p", null, 720)]
+    [InlineData("LessThan", "1440p", null, 1080)]
+    [InlineData("LessThan", "4K", null, 1440)]
+    [InlineData("LessThan", "8K", null, 2160)]
+    // LessThanOrEqual: up to the bucket's own height (top bucket cannot ride, see below).
+    [InlineData("LessThanOrEqual", "480p", null, 480)]
+    [InlineData("LessThanOrEqual", "720p", null, 720)]
+    [InlineData("LessThanOrEqual", "1080p", null, 1080)]
+    [InlineData("LessThanOrEqual", "1440p", null, 1440)]
+    [InlineData("LessThanOrEqual", "4K", null, 2160)]
+    public void OperatorValue_MapsToExactBucketWindow(string ruleOperator, string targetValue, int? expectedMin, int? expectedMax)
+    {
+        var window = ResolutionPrefilterResolver.TryBuildHeightWindow(ruleOperator, targetValue);
+
+        Assert.NotNull(window);
+        Assert.Equal(expectedMin, window.MinHeight);
+        Assert.Equal(expectedMax, window.MaxHeight);
+    }
+
+    // ---- Combinations that stay per-item ----
+
+    [Fact]
+    public void LessThanOrEqualTopBucket_StaysPerItem()
+    {
+        // Matches every valid-resolution item (a >4320-height file buckets to "8K" and
+        // still compares <= 8K per-item) - MaxHeight 4320 would drop it: false negative.
+        Assert.Null(ResolutionPrefilterResolver.TryBuildHeightWindow("LessThanOrEqual", "8K"));
+    }
+
+    [Theory]
+    [InlineData("480p")]
+    [InlineData("1080p")]
+    [InlineData("8K")]
+    public void NotEqual_StaysPerItem(string targetValue)
+    {
+        Assert.Null(ResolutionPrefilterResolver.TryBuildHeightWindow("NotEqual", targetValue));
+    }
+
+    [Theory]
+    [InlineData("Contains")]
+    [InlineData("MatchRegex")]
+    [InlineData("IsIn")]
+    [InlineData("equal")] // operator comparison is Ordinal, mirroring the engine switch
+    [InlineData("")]
+    [InlineData(null)]
+    public void UnsupportedOperators_StayPerItem(string? ruleOperator)
+    {
+        Assert.Null(ResolutionPrefilterResolver.TryBuildHeightWindow(ruleOperator, "1080p"));
+    }
+
+    [Theory]
+    [InlineData("1080")] // bare height - compiled rule rejects it
+    [InlineData("1080P")] // value lookup is ordinal exact, like GetHeightForResolution
+    [InlineData("4k")]
+    [InlineData("SD")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void ValuesTheCompiledRuleRejects_StayPerItem(string? targetValue)
+    {
+        Assert.Null(ResolutionPrefilterResolver.TryBuildHeightWindow("Equal", targetValue));
+        Assert.Null(ResolutionPrefilterResolver.TryBuildHeightWindow("GreaterThan", targetValue));
+    }
+
+    // ---- Media-type gate: exclusively leaf video types ----
+
+    [Theory]
+    [InlineData("Movie")]
+    [InlineData("Episode")]
+    [InlineData("Video")]
+    [InlineData("MusicVideo")]
+    [InlineData("Movie,Episode,Video,MusicVideo")]
+    public void LeafVideoPools_Apply(string mediaTypesCsv)
+    {
+        Assert.True(ResolutionPrefilterResolver.AppliesToMediaTypes(mediaTypesCsv.Split(',')));
+    }
+
+    [Theory]
+    // Folder kinds have no row Width/Height - the window would shrink them to nothing.
+    [InlineData("Series")]
+    [InlineData("Season")]
+    [InlineData("MusicAlbum")]
+    // One folder type poisons the whole pool.
+    [InlineData("Movie,Series")]
+    [InlineData("Episode,Season")]
+    // Non-video leaf types never carry video heights either.
+    [InlineData("Audio")]
+    [InlineData("Photo")]
+    [InlineData("Book")]
+    public void NonLeafVideoPools_Skip(string mediaTypesCsv)
+    {
+        Assert.False(ResolutionPrefilterResolver.AppliesToMediaTypes(mediaTypesCsv.Split(',')));
+    }
+
+    [Fact]
+    public void UnrestrictedPools_Skip()
+    {
+        Assert.False(ResolutionPrefilterResolver.AppliesToMediaTypes(null));
+        Assert.False(ResolutionPrefilterResolver.AppliesToMediaTypes([]));
+    }
+
+    // ---- Window/bucketer coherence ----
+
+    [Fact]
+    public void EqualWindows_TileTheHeightAxisWithoutGapsOrOverlaps()
+    {
+        // The Equal windows must partition [1, +inf) exactly like the bucketer does:
+        // each window starts one above the previous bucket and the top one is open-ended.
+        var expectedNextMin = 1;
+        foreach (var info in ResolutionTypes.AllResolutions)
+        {
+            var window = ResolutionPrefilterResolver.TryBuildHeightWindow("Equal", info.Value);
+
+            Assert.NotNull(window);
+            Assert.Equal(expectedNextMin, window.MinHeight);
+            if (window.MaxHeight != null)
+            {
+                expectedNextMin = window.MaxHeight.Value + 1;
+            }
+        }
+
+        // Exactly one open-ended window, and it is the last bucket's.
+        var top = ResolutionPrefilterResolver.TryBuildHeightWindow("Equal", "8K");
+        Assert.NotNull(top);
+        Assert.Null(top.MaxHeight);
+    }
+}

--- a/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/SeriesNamePrefilterResolverTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/SeriesNamePrefilterResolverTests.cs
@@ -1,0 +1,313 @@
+using Jellyfin.Plugin.SmartLists.Core.Models;
+using Jellyfin.Plugin.SmartLists.Core.QueryEngine;
+using Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters;
+using Jellyfin.Plugin.SmartLists.Tests.Support;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Model.Entities;
+
+namespace Jellyfin.Plugin.SmartLists.Tests.Core.QueryEngine;
+
+/// <summary>
+/// Covers the pure in-memory narrowing of <see cref="SeriesNamePrefilterResolver"/> - the
+/// SeriesName counterpart of the People resolver, which derives its candidate set from the
+/// bulk-warmed series-name dump and the already-fetched pool instead of DB queries.
+///
+/// The safety contract under test:
+/// - Operator semantics are EXACTLY the per-item semantics (the resolver compiles the rule
+///   through the same Engine.CompileRule the compiled rule sets use).
+/// - Episodes resolve through SeriesId; a series ABSENT from the dump is unknown and its
+///   episodes are always kept (the per-miss GetItemById fallback decides per item).
+/// - Seriesless pool items (movies, Series themselves, episodes without a usable SeriesId)
+///   evaluate SeriesName "" - they are kept exactly when the rule matches "", which is what
+///   makes negative operators an EXACT complement rather than an approximation.
+/// - Extras resolve through the owner map, mirroring extraction; unmapped extras evaluate "";
+///   with no map at all every extra is kept.
+/// - Narrowing requires both the pool and the dump; otherwise the rule stays per-item (null).
+///
+/// The warmup query itself needs a live Jellyfin and is exercised there, not here.
+/// </summary>
+public class SeriesNamePrefilterResolverTests
+{
+    private static PrefilterContext Context(
+        IReadOnlyList<BaseItem>? pool,
+        IReadOnlyDictionary<Guid, string>? dump,
+        IReadOnlyDictionary<Guid, Guid>? extras = null)
+        => new(null!, null!, null, null)
+        {
+            PoolItems = pool,
+            SeriesNamesById = dump,
+            ExtraOwnerSeriesIds = extras,
+        };
+
+    private static Expression Rule(string op, string value) => new("SeriesName", op, value);
+
+    private static HashSet<Guid>? Resolve(
+        Expression rule,
+        IReadOnlyList<BaseItem>? pool,
+        IReadOnlyDictionary<Guid, string>? dump,
+        IReadOnlyDictionary<Guid, Guid>? extras = null)
+        => new SeriesNamePrefilterResolver().Resolve(rule, Context(pool, dump, extras));
+
+    private static (Series Series, Episode Episode) ShowWithEpisode(string name)
+    {
+        var series = TestItems.Show(name);
+        return (series, TestItems.Ep(name, 1, 1, show: series));
+    }
+
+    private static Dictionary<Guid, string> Dump(params Series[] series)
+        => series.ToDictionary(s => s.Id, s => s.Name);
+
+    // ---- Gating ----
+
+    [Fact]
+    public void NonSeriesNameField_ReturnsNull()
+    {
+        var (series, episode) = ShowWithEpisode("Breaking Bad");
+
+        var result = new SeriesNamePrefilterResolver()
+            .Resolve(new Expression("Name", "Equal", "x"), Context([episode], Dump(series)));
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void WithoutDump_ReturnsNull()
+    {
+        var (_, episode) = ShowWithEpisode("Breaking Bad");
+
+        Assert.Null(Resolve(Rule("Equal", "Breaking Bad"), [episode], dump: null));
+    }
+
+    [Fact]
+    public void WithoutPool_ReturnsNull()
+    {
+        var (series, _) = ShowWithEpisode("Breaking Bad");
+
+        Assert.Null(Resolve(Rule("Equal", "Breaking Bad"), pool: null, Dump(series)));
+    }
+
+    // ---- Episodes ----
+
+    [Fact]
+    public void Equal_KeepsOnlyEpisodesOfMatchingSeries_CaseInsensitive()
+    {
+        var (bb, epBb) = ShowWithEpisode("Breaking Bad");
+        var (wire, epWire) = ShowWithEpisode("The Wire");
+        var movie = TestItems.Mov("Heat");
+
+        var result = Resolve(Rule("Equal", "BREAKING BAD"), [epBb, epWire, movie], Dump(bb, wire));
+
+        Assert.Equal([epBb.Id], result);
+    }
+
+    [Fact]
+    public void Equal_NothingMatches_ReturnsEmptySet_AsHardClaim()
+    {
+        var (bb, epBb) = ShowWithEpisode("Breaking Bad");
+
+        var result = Resolve(Rule("Equal", "Nonexistent"), [epBb], Dump(bb));
+
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Episode_OfSeriesMissingFromDump_IsAlwaysKept()
+    {
+        // The dump deliberately omits this series: the per-item path would resolve it via
+        // GetItemById, so the resolver may not claim anything about it.
+        var (_, epUnknown) = ShowWithEpisode("Ghost Show");
+        var (bb, epBb) = ShowWithEpisode("Breaking Bad");
+
+        var result = Resolve(Rule("Equal", "Breaking Bad"), [epBb, epUnknown], Dump(bb));
+
+        Assert.NotNull(result);
+        Assert.Contains(epBb.Id, result);
+        Assert.Contains(epUnknown.Id, result);
+        Assert.Equal(2, result.Count);
+    }
+
+    // ---- Seriesless items + negative operators (exact complement) ----
+
+    [Fact]
+    public void NotEqual_IsExactComplement_IncludingSerieslessItems()
+    {
+        var (bb, epBb) = ShowWithEpisode("Breaking Bad");
+        var (wire, epWire) = ShowWithEpisode("The Wire");
+        var movie = TestItems.Mov("Heat");
+        var epNoSeries = TestItems.Ep("Orphan", 1, 1); // no SeriesId -> SeriesName ""
+
+        var result = Resolve(Rule("NotEqual", "Breaking Bad"), [epBb, epWire, movie, bb, epNoSeries], Dump(bb, wire));
+
+        // The Series item itself and the movie evaluate SeriesName "" and "" != "Breaking Bad".
+        Assert.NotNull(result);
+        Assert.DoesNotContain(epBb.Id, result);
+        Assert.Contains(epWire.Id, result);
+        Assert.Contains(movie.Id, result);
+        Assert.Contains(bb.Id, result);
+        Assert.Contains(epNoSeries.Id, result);
+    }
+
+    [Fact]
+    public void Seriesless_AreDroppedWhenRuleDoesNotMatchEmpty()
+    {
+        var (bb, epBb) = ShowWithEpisode("Breaking Bad");
+        var movie = TestItems.Mov("Heat");
+        var epNoSeries = TestItems.Ep("Orphan", 1, 1);
+
+        var result = Resolve(Rule("Contains", "Breaking"), [epBb, movie, epNoSeries], Dump(bb));
+
+        Assert.Equal([epBb.Id], result);
+    }
+
+    // ---- Extras ----
+
+    [Fact]
+    public void Extra_MappedToMatchingOwner_IsKept_AndToNonMatchingOwner_IsDropped()
+    {
+        var (bb, _) = ShowWithEpisode("Breaking Bad");
+        var (wire, _) = ShowWithEpisode("The Wire");
+        var extraOfBb = TestItems.Mov("Making Of BB");
+        extraOfBb.ExtraType = ExtraType.BehindTheScenes;
+        var extraOfWire = TestItems.Mov("Making Of Wire");
+        extraOfWire.ExtraType = ExtraType.BehindTheScenes;
+        var extras = new Dictionary<Guid, Guid> { [extraOfBb.Id] = bb.Id, [extraOfWire.Id] = wire.Id };
+
+        var result = Resolve(Rule("Equal", "Breaking Bad"), [extraOfBb, extraOfWire], Dump(bb, wire), extras);
+
+        Assert.Equal([extraOfBb.Id], result);
+    }
+
+    [Fact]
+    public void Extra_MappedToOwnerMissingFromDump_IsAlwaysKept()
+    {
+        var (bb, _) = ShowWithEpisode("Breaking Bad");
+        var extra = TestItems.Mov("Making Of");
+        extra.ExtraType = ExtraType.BehindTheScenes;
+        var extras = new Dictionary<Guid, Guid> { [extra.Id] = Guid.NewGuid() };
+
+        var result = Resolve(Rule("Equal", "Nonexistent"), [extra], Dump(bb), extras);
+
+        Assert.Equal([extra.Id], result);
+    }
+
+    [Fact]
+    public void Extra_Unmapped_FollowsEmptyStringSemantics()
+    {
+        var (bb, _) = ShowWithEpisode("Breaking Bad");
+        var extra = TestItems.Mov("Making Of");
+        extra.ExtraType = ExtraType.BehindTheScenes;
+        var noOwners = new Dictionary<Guid, Guid>();
+
+        // Extraction leaves SeriesName "" for an unmapped extra.
+        Assert.Empty(Resolve(Rule("Equal", "Breaking Bad"), [extra], Dump(bb), noOwners)!);
+        Assert.Equal([extra.Id], Resolve(Rule("NotEqual", "Breaking Bad"), [extra], Dump(bb), noOwners));
+    }
+
+    [Fact]
+    public void Extra_WithoutOwnerMap_IsAlwaysKept()
+    {
+        var (bb, _) = ShowWithEpisode("Breaking Bad");
+        var extra = TestItems.Mov("Making Of");
+        extra.ExtraType = ExtraType.BehindTheScenes;
+
+        var result = Resolve(Rule("Equal", "Nonexistent"), [extra], Dump(bb), extras: null);
+
+        Assert.Equal([extra.Id], result);
+    }
+
+    [Fact]
+    public void EpisodeThatIsAlsoAnExtra_ResolvesViaSeriesId_MirroringExtractionOrder()
+    {
+        // ExtractSeriesName checks Episode.SeriesId BEFORE the extras branch, so the owner
+        // map must be ignored for an episode with a usable SeriesId.
+        var (bb, epBb) = ShowWithEpisode("Breaking Bad");
+        var (wire, _) = ShowWithEpisode("The Wire");
+        epBb.ExtraType = ExtraType.Trailer;
+        var extras = new Dictionary<Guid, Guid> { [epBb.Id] = wire.Id };
+
+        Assert.Equal([epBb.Id], Resolve(Rule("Equal", "Breaking Bad"), [epBb], Dump(bb, wire), extras));
+        Assert.Empty(Resolve(Rule("Equal", "The Wire"), [epBb], Dump(bb, wire), extras)!);
+    }
+
+    // ---- Remaining operators (semantics come from Engine.CompileRule) ----
+
+    [Fact]
+    public void Contains_IsCaseInsensitiveSubstring()
+    {
+        var (bb, epBb) = ShowWithEpisode("Breaking Bad");
+        var (wire, epWire) = ShowWithEpisode("The Wire");
+
+        var result = Resolve(Rule("Contains", "WIRE"), [epBb, epWire], Dump(bb, wire));
+
+        Assert.Equal([epWire.Id], result);
+    }
+
+    [Fact]
+    public void IsIn_IsSubstringMatchAgainstSemicolonList()
+    {
+        var (bb, epBb) = ShowWithEpisode("Breaking Bad");
+        var (wire, epWire) = ShowWithEpisode("The Wire");
+
+        var result = Resolve(Rule("IsIn", "wire;sopranos"), [epBb, epWire], Dump(bb, wire));
+
+        Assert.Equal([epWire.Id], result);
+    }
+
+    [Fact]
+    public void IsNotIn_KeepsNonMatchingEpisodesAndSerieslessItems()
+    {
+        var (bb, epBb) = ShowWithEpisode("Breaking Bad");
+        var (wire, epWire) = ShowWithEpisode("The Wire");
+        var movie = TestItems.Mov("Heat");
+
+        var result = Resolve(Rule("IsNotIn", "wire"), [epBb, epWire, movie], Dump(bb, wire));
+
+        Assert.NotNull(result);
+        Assert.Contains(epBb.Id, result);
+        Assert.Contains(movie.Id, result); // "" is not in the list -> IsNotIn matches ""
+        Assert.DoesNotContain(epWire.Id, result);
+    }
+
+    [Fact]
+    public void MatchRegex_IsCaseSensitive()
+    {
+        var (bb, epBb) = ShowWithEpisode("Breaking Bad");
+        var (wire, epWire) = ShowWithEpisode("The Wire");
+
+        Assert.Equal([epWire.Id], Resolve(Rule("MatchRegex", "^The"), [epBb, epWire], Dump(bb, wire)));
+        Assert.Empty(Resolve(Rule("MatchRegex", "^the"), [epBb, epWire], Dump(bb, wire))!);
+    }
+
+    // ---- Builder wiring ----
+
+    [Fact]
+    public void CreateDefault_NegativeSeriesNameRule_Narrows()
+    {
+        // Proves SupportsNegativeOperators wiring: NotEqual must reach this resolver
+        // through the builder's central negative-operator gate.
+        var (bb, epBb) = ShowWithEpisode("Breaking Bad");
+        var (wire, epWire) = ShowWithEpisode("The Wire");
+
+        var result = CandidateSetBuilder.CreateDefault().Build(
+            [new ExpressionSet { Expressions = [Rule("NotEqual", "Breaking Bad")] }],
+            Context([epBb, epWire], Dump(bb, wire)));
+
+        Assert.Equal([epWire.Id], result);
+    }
+
+    [Fact]
+    public void CreateDefault_SeriesNameRule_WithoutDump_NoShrink()
+    {
+        // Warmup failed (or never ran): SmartList passes no dump, so the rule must stay
+        // per-item and the whole build degrades to "no shrink possible".
+        var (_, epBb) = ShowWithEpisode("Breaking Bad");
+
+        var result = CandidateSetBuilder.CreateDefault().Build(
+            [new ExpressionSet { Expressions = [Rule("Equal", "Breaking Bad")] }],
+            Context([epBb], dump: null));
+
+        Assert.Null(result);
+    }
+}

--- a/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/StreamLanguagePrefilterResolverTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/StreamLanguagePrefilterResolverTests.cs
@@ -1,0 +1,223 @@
+using Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters;
+
+namespace Jellyfin.Plugin.SmartLists.Tests.Core.QueryEngine;
+
+/// <summary>
+/// Covers the pure code-resolution step of <see cref="StreamLanguagePrefilterResolver"/> -
+/// the piece that decides which RAW stored language codes a language rule matches before
+/// the single item query runs. Its contract:
+///
+/// - Matching runs against each raw code's ISO 639-2 B-to-T NORMALIZED form (the form
+///   per-item extraction sees, because the server's stream read path rewrites B codes to
+///   T codes), while the RETURNED codes are the raw stored forms (the item query compares
+///   the stored Language column byte-exact). The canonical case: a track stored as 'ger'
+///   must ride a rule "Equal deu", and a rule "Equal ger" must match NOTHING (per-item
+///   lists never contain 'ger').
+/// - Operator semantics must be EXACTLY the plugin's per-item semantics (it delegates to
+///   the same Engine helpers the compiled rules bind): Equal is whole-value
+///   OrdinalIgnoreCase, Contains is substring OrdinalIgnoreCase, IsIn is a
+///   semicolon-separated substring list, MatchRegex is case-sensitive.
+/// - A pattern that matches the empty string never rides (an empty stream-language list
+///   is evaluated against "", so such patterns match items with NO such streams -
+///   unreachable from any code-derived set), nor does an invalid pattern or a
+///   negative/unknown operator.
+/// - Null/empty raw codes are skipped (the dump maps null/empty stored languages to
+///   'und'; per-item extraction drops them).
+/// - An empty (non-null) result is a hard "no stored code matches" claim.
+///
+/// The dump and GetItemIds steps need a live Jellyfin 12 and are exercised there, not here.
+/// </summary>
+public class StreamLanguagePrefilterResolverTests
+{
+    /// <summary>
+    /// Raw stored codes as a real mixed library dumps them: Matroska B codes ('ger',
+    /// 'fre'), T codes ('deu'), plain codes with no B/T split ('eng', 'und').
+    /// </summary>
+    private static readonly string[] DefaultCodes = ["ger", "eng", "fre", "und", "deu"];
+
+    /// <summary>
+    /// Fake of the server's ISO 639-2 B-to-T mapping, mirroring
+    /// ILocalizationManager.TryGetISO6392TFromB for the fixture codes.
+    /// </summary>
+    private static bool FakeNormalize(string rawCode, out string? normalized)
+    {
+        switch (rawCode)
+        {
+            case "ger":
+                normalized = "deu";
+                return true;
+            case "fre":
+                normalized = "fra";
+                return true;
+            default:
+                normalized = null;
+                return false;
+        }
+    }
+
+    // ---- Equal (the B-to-T normalization contract) ----
+
+    [Fact]
+    public void Equal_TCode_MatchesBothStoredSpellings()
+    {
+        // 'ger' normalizes to 'deu' and rides ALONGSIDE the natively stored 'deu' -
+        // dropping either raw form would drop true matches.
+        var matched = StreamLanguagePrefilterResolver.ResolveMatchingRawCodes(DefaultCodes, "Equal", "deu", FakeNormalize);
+
+        Assert.NotNull(matched);
+        Assert.Equal(["ger", "deu"], matched);
+    }
+
+    [Fact]
+    public void Equal_BCode_MatchesNothing()
+    {
+        // Per-item extraction never sees 'ger' (the read path rewrote it to 'deu'), so an
+        // "Equal ger" rule matches no item - a hard empty claim, not a fallback.
+        var matched = StreamLanguagePrefilterResolver.ResolveMatchingRawCodes(DefaultCodes, "Equal", "ger", FakeNormalize);
+
+        Assert.NotNull(matched);
+        Assert.Empty(matched);
+    }
+
+    [Fact]
+    public void Equal_IsCaseInsensitive()
+    {
+        var matched = StreamLanguagePrefilterResolver.ResolveMatchingRawCodes(DefaultCodes, "Equal", "DEU", FakeNormalize);
+
+        Assert.Equal(["ger", "deu"], matched);
+    }
+
+    [Fact]
+    public void Equal_DoesNotSubstringMatch()
+    {
+        var matched = StreamLanguagePrefilterResolver.ResolveMatchingRawCodes(DefaultCodes, "Equal", "de", FakeNormalize);
+
+        Assert.NotNull(matched);
+        Assert.Empty(matched);
+    }
+
+    [Fact]
+    public void Equal_UnmappedCodePassesThroughRaw()
+    {
+        var matched = StreamLanguagePrefilterResolver.ResolveMatchingRawCodes(DefaultCodes, "Equal", "eng", FakeNormalize);
+
+        Assert.Equal(["eng"], matched);
+    }
+
+    // ---- Contains ----
+
+    [Fact]
+    public void Contains_SubstringCaseInsensitive_AgainstNormalizedForm()
+    {
+        // 'DE' is a substring of normalized 'deu' (from raw 'ger' and raw 'deu') only.
+        var matched = StreamLanguagePrefilterResolver.ResolveMatchingRawCodes(DefaultCodes, "Contains", "DE", FakeNormalize);
+
+        Assert.Equal(["ger", "deu"], matched);
+    }
+
+    [Fact]
+    public void Contains_DoesNotMatchRawFormOfMappedCode()
+    {
+        // 'fre' normalizes to 'fra'; nothing normalized contains 'fre'.
+        var matched = StreamLanguagePrefilterResolver.ResolveMatchingRawCodes(DefaultCodes, "Contains", "fre", FakeNormalize);
+
+        Assert.NotNull(matched);
+        Assert.Empty(matched);
+    }
+
+    // ---- IsIn ----
+
+    [Fact]
+    public void IsIn_SemicolonSeparatedSubstrings()
+    {
+        var matched = StreamLanguagePrefilterResolver.ResolveMatchingRawCodes(DefaultCodes, "IsIn", "deu; eng", FakeNormalize);
+
+        Assert.Equal(["ger", "eng", "deu"], matched);
+    }
+
+    // ---- MatchRegex ----
+
+    [Fact]
+    public void MatchRegex_CaseSensitive_AgainstNormalizedForm()
+    {
+        var matched = StreamLanguagePrefilterResolver.ResolveMatchingRawCodes(DefaultCodes, "MatchRegex", "^de", FakeNormalize);
+
+        Assert.Equal(["ger", "deu"], matched);
+    }
+
+    [Fact]
+    public void MatchRegex_CaseSensitivityIsPreserved()
+    {
+        var matched = StreamLanguagePrefilterResolver.ResolveMatchingRawCodes(DefaultCodes, "MatchRegex", "^DE", FakeNormalize);
+
+        Assert.NotNull(matched);
+        Assert.Empty(matched);
+    }
+
+    [Fact]
+    public void MatchRegex_EmptyMatchingPattern_DoesNotRide()
+    {
+        // ".*" matches "" - it would match items with no streams of the kind at all.
+        var matched = StreamLanguagePrefilterResolver.ResolveMatchingRawCodes(DefaultCodes, "MatchRegex", ".*", FakeNormalize);
+
+        Assert.Null(matched);
+    }
+
+    [Fact]
+    public void MatchRegex_InvalidPattern_DoesNotRide()
+    {
+        var matched = StreamLanguagePrefilterResolver.ResolveMatchingRawCodes(DefaultCodes, "MatchRegex", "[unclosed", FakeNormalize);
+
+        Assert.Null(matched);
+    }
+
+    // ---- Operators that never ride ----
+
+    [Theory]
+    [InlineData("NotEqual")]
+    [InlineData("NotContains")]
+    [InlineData("IsNotIn")]
+    [InlineData("GreaterThan")]
+    [InlineData("SomethingUnknown")]
+    public void UnsupportedOperators_DoNotRide(string ruleOperator)
+    {
+        var matched = StreamLanguagePrefilterResolver.ResolveMatchingRawCodes(DefaultCodes, ruleOperator, "deu", FakeNormalize);
+
+        Assert.Null(matched);
+    }
+
+    // ---- Dump-code hygiene ----
+
+    [Fact]
+    public void NullAndEmptyRawCodes_AreSkipped()
+    {
+        var matched = StreamLanguagePrefilterResolver.ResolveMatchingRawCodes([null!, string.Empty, "deu"], "Equal", "deu", FakeNormalize);
+
+        Assert.Equal(["deu"], matched);
+    }
+
+    [Fact]
+    public void NormalizerReturningTrueWithEmptyOutput_FallsBackToRawCode()
+    {
+        // Defensive: a normalizer that claims success but yields nothing must not erase
+        // the code (that could drop true matches for the raw form).
+        static bool BadNormalize(string rawCode, out string? normalized)
+        {
+            normalized = string.Empty;
+            return true;
+        }
+
+        var matched = StreamLanguagePrefilterResolver.ResolveMatchingRawCodes(["deu"], "Equal", "deu", BadNormalize);
+
+        Assert.Equal(["deu"], matched);
+    }
+
+    [Fact]
+    public void NoMatch_IsAHardEmptyClaim()
+    {
+        var matched = StreamLanguagePrefilterResolver.ResolveMatchingRawCodes(DefaultCodes, "Equal", "jpn", FakeNormalize);
+
+        Assert.NotNull(matched);
+        Assert.Empty(matched);
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
@@ -403,7 +403,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         /// <param name="logger">Optional logger for error reporting</param>
         /// <returns>The parsed boolean value</returns>
         /// <exception cref="ArgumentException">Thrown when the target value is invalid</exception>
-        private static bool ValidateAndParseBooleanValue(string targetValue, string fieldName, ILogger? logger = null)
+        internal static bool ValidateAndParseBooleanValue(string targetValue, string fieldName, ILogger? logger = null)
         {
             // Validate and parse boolean value safely
             if (string.IsNullOrWhiteSpace(targetValue))

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
@@ -2330,6 +2330,32 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         }
 
         /// <summary>
+        /// Cached reflection lookup for the ABI-shared ILibraryManager.GetPeople(InternalPeopleQuery)
+        /// overload. Shared with the prefilter's people name dump so every caller reuses the
+        /// same MethodInfo cache.
+        /// </summary>
+        /// <param name="libraryManager">The library manager whose concrete type carries the method.</param>
+        /// <returns>The GetPeople method, or null when the lookup fails.</returns>
+        internal static System.Reflection.MethodInfo? GetPeopleQueryMethod(ILibraryManager libraryManager)
+        {
+            var getPeopleMethod = _getPeopleMethodCache;
+            if (getPeopleMethod == null)
+            {
+                lock (_getPeopleMethodLock)
+                {
+                    if (_getPeopleMethodCache == null)
+                    {
+                        _getPeopleMethodCache = libraryManager.GetType().GetMethod("GetPeople", [typeof(InternalPeopleQuery)]);
+                    }
+
+                    getPeopleMethod = _getPeopleMethodCache;
+                }
+            }
+
+            return getPeopleMethod;
+        }
+
+        /// <summary>
         /// Preloads people data for all items in parallel to improve performance.
         /// </summary>
         public static void PreloadPeopleCache(ILibraryManager libraryManager, IEnumerable<BaseItem> items, RefreshQueueServiceRefreshCache cache, ILogger? logger)

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
@@ -1932,8 +1932,9 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         /// <summary>
         /// Helper method to safely extract SeriesId as Guid from episode items.
         /// Handles Guid, Guid?, and string representations.
+        /// Internal so SeriesNamePrefilterResolver can mirror the exact per-item resolution order.
         /// </summary>
-        private static bool TryGetEpisodeSeriesGuid(BaseItem baseItem, out Guid seriesGuid)
+        internal static bool TryGetEpisodeSeriesGuid(BaseItem baseItem, out Guid seriesGuid)
         {
             seriesGuid = Guid.Empty;
             if (baseItem is not Episode) return false;
@@ -1977,6 +1978,65 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         }
 
         /// <summary>
+        /// Bulk-loads every library series' Name and SortName into the refresh cache in ONE
+        /// user-neutral query, replacing the per-distinct-series GetItemById round-trips the
+        /// lazy path would otherwise make (thousands on big TV libraries). Runs at most once
+        /// per refresh cache; the per-miss GetItemById fallback in ResolveAndCacheSeriesName
+        /// stays as-is for series outside the dump scope (virtual/out-of-library).
+        /// Both dictionaries are populated together: a Name-only warmup would permanently
+        /// starve SeriesNameOrder's sort names via the cache-hit early return above.
+        /// </summary>
+        /// <returns>True when the dump completed and the cache covers every in-scope series.</returns>
+        internal static bool WarmSeriesNameCache(ILibraryManager libraryManager, RefreshQueueServiceRefreshCache cache, ILogger? logger)
+        {
+            if (cache.SeriesNameWarmupSucceeded is bool alreadyAttempted)
+            {
+                return alreadyAttempted;
+            }
+
+            try
+            {
+                var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+                // User-neutral on purpose: the GetItemById fallback performs no visibility
+                // filtering, so a user-scoped dump would shunt invisible-but-referenced series
+                // onto the slow per-miss path. Grouping is pinned off per prefilter query
+                // hygiene. Recursive is a repository no-op without ParentId and is not set.
+                var series = libraryManager.GetItemList(new InternalItemsQuery
+                {
+                    IncludeItemTypes = [BaseItemKind.Series],
+                    TopParentIds = LibraryManagerHelper.GetLibraryTopParentIds(libraryManager),
+                    GroupByPresentationUniqueKey = false,
+                });
+
+                foreach (var item in series)
+                {
+                    if (item == null)
+                    {
+                        continue;
+                    }
+
+                    // Read both BEFORE writing either: a partial pair would hit the cache-hit
+                    // early return on Name and leave the sort name permanently missing.
+                    var name = item.Name ?? string.Empty;
+                    var sortName = item.SortName ?? string.Empty;
+                    cache.SeriesNameById[item.Id] = name;
+                    cache.SeriesSortNameById[item.Id] = sortName;
+                }
+
+                cache.SeriesNameWarmupSucceeded = true;
+                logger?.LogDebug("Series name warmup cached {Count} series in {Ms}ms", series.Count, stopwatch.ElapsedMilliseconds);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                cache.SeriesNameWarmupSucceeded = false;
+                logger?.LogDebug(ex, "Series name warmup failed; falling back to per-series resolution");
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Extracts the series name for episodes and extras with per-refresh caching.
         /// For episodes: uses SeriesId property directly.
         /// For extras: walks up the parent chain to find the owning Series.
@@ -1986,6 +2046,10 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             operand.SeriesName = string.Empty;
             try
             {
+                // Bulk warmup (once per refresh cache) replaces the per-distinct-series
+                // GetItemById round-trips; misses below still fall back per item.
+                WarmSeriesNameCache(libraryManager, cache, logger);
+
                 // Use helper to extract SeriesId safely (episodes only)
                 if (TryGetEpisodeSeriesGuid(baseItem, out var seriesGuid))
                 {

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
@@ -2291,18 +2291,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             try
             {
                 // Cache the GetPeople method lookup for better performance
-                var getPeopleMethod = _getPeopleMethodCache;
-                if (getPeopleMethod == null)
-                {
-                    lock (_getPeopleMethodLock)
-                    {
-                        if (_getPeopleMethodCache == null)
-                        {
-                            _getPeopleMethodCache = libraryManager.GetType().GetMethod("GetPeople", [typeof(InternalPeopleQuery)]);
-                        }
-                        getPeopleMethod = _getPeopleMethodCache;
-                    }
-                }
+                var getPeopleMethod = GetPeopleQueryMethod(libraryManager);
 
                 if (getPeopleMethod != null)
                 {
@@ -2395,8 +2384,8 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
 
         /// <summary>
         /// Cached reflection lookup for the ABI-shared ILibraryManager.GetPeople(InternalPeopleQuery)
-        /// overload. Shared with the prefilter's people name dump so every caller reuses the
-        /// same MethodInfo cache.
+        /// overload. Shared by every per-item people extraction path and (on 10.11) the
+        /// prefilter's people name dump so all callers reuse the same MethodInfo cache.
         /// </summary>
         /// <param name="libraryManager">The library manager whose concrete type carries the method.</param>
         /// <returns>The GetPeople method, or null when the lookup fails.</returns>
@@ -2452,18 +2441,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                 try
                 {
                     // Cache the GetPeople method lookup
-                    var getPeopleMethod = _getPeopleMethodCache;
-                    if (getPeopleMethod == null)
-                    {
-                        lock (_getPeopleMethodLock)
-                        {
-                            if (_getPeopleMethodCache == null)
-                            {
-                                _getPeopleMethodCache = libraryManager.GetType().GetMethod("GetPeople", [typeof(InternalPeopleQuery)]);
-                            }
-                            getPeopleMethod = _getPeopleMethodCache;
-                        }
-                    }
+                    var getPeopleMethod = GetPeopleQueryMethod(libraryManager);
 
                     if (getPeopleMethod != null)
                     {
@@ -4328,18 +4306,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                         var peopleQuery = new InternalPeopleQuery { ItemId = item.Id };
 
                         // Reuse cached GetPeople method lookup for better performance
-                        var getPeopleMethod = _getPeopleMethodCache;
-                        if (getPeopleMethod == null)
-                        {
-                            lock (_getPeopleMethodLock)
-                            {
-                                if (_getPeopleMethodCache == null)
-                                {
-                                    _getPeopleMethodCache = libraryManager.GetType().GetMethod("GetPeople", new[] { typeof(InternalPeopleQuery) });
-                                }
-                                getPeopleMethod = _getPeopleMethodCache;
-                            }
-                        }
+                        var getPeopleMethod = GetPeopleQueryMethod(libraryManager);
 
                         if (getPeopleMethod != null)
                         {

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
@@ -1618,13 +1618,15 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         /// <summary>
         /// Extracts framerate from media streams.
         /// </summary>
-        private static void ExtractFramerate(Operand operand, BaseItem baseItem, ILogger? logger)
+        private static void ExtractFramerate(Operand operand, BaseItem baseItem, RefreshQueueServiceRefreshCache cache, ILogger? logger)
         {
             operand.Framerate = null;
             try
             {
-                // Use shared helper to extract media streams
-                var mediaStreams = TryGetAllMediaStreams(baseItem, logger);
+                // Served through the shared MediaStreamsCache like every other stream extractor
+                // (mirrors ExtractResolution) so a Framerate rule doesn't re-read streams that
+                // another stream group already fetched for the same item.
+                var mediaStreams = Utilities.MediaStreamHelper.GetMediaStreams(baseItem, cache, logger);
 
                 // Process found streams to find the first video stream with framerate information
                 foreach (var stream in mediaStreams)
@@ -2827,7 +2829,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                 if (MediaTypes.VideoStreamCapableSet.Contains(operand.ItemType))
                 {
                     ExtractResolution(operand, baseItem, cache, logger);
-                    ExtractFramerate(operand, baseItem, logger);
+                    ExtractFramerate(operand, baseItem, cache, logger);
                     ExtractVideoQuality(operand, baseItem, cache, logger);
                 }
                 else
@@ -3092,6 +3094,17 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         /// </summary>
         private static System.Reflection.PropertyInfo? _extraTypePropertyCache;
         private static bool _extraTypePropertyResolved;
+
+        /// <summary>
+        /// Returns true when the item is an extra (trailer, behind-the-scenes, ...). Extras
+        /// enter list pools via their owner chain (LibraryManagerHelper.FetchExtras), not the
+        /// main library query, so DB-prefilter candidate queries never see them and must
+        /// always keep them.
+        /// </summary>
+        internal static bool IsExtra(BaseItem item)
+        {
+            return GetExtraTypeName(item).Length > 0;
+        }
 
         /// <summary>
         /// Gets the ExtraType name for a BaseItem, or empty string if not an extra.

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/CandidateSetBuilder.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/CandidateSetBuilder.cs
@@ -42,7 +42,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
         /// <returns>The builder with all production resolvers registered.</returns>
         public static CandidateSetBuilder CreateDefault()
         {
-            return new CandidateSetBuilder([new PeoplePrefilterResolver(), new SeriesNamePrefilterResolver(), new NextUnwatchedPrefilterResolver(), new LastEpisodeAirDatePrefilterResolver()]);
+            return new CandidateSetBuilder([new PeoplePrefilterResolver(), new SeriesNamePrefilterResolver(), new NextUnwatchedPrefilterResolver(), new LastEpisodeAirDatePrefilterResolver(), new ResolutionPrefilterResolver()]);
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/CandidateSetBuilder.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/CandidateSetBuilder.cs
@@ -42,7 +42,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
         /// <returns>The builder with all production resolvers registered.</returns>
         public static CandidateSetBuilder CreateDefault()
         {
-            return new CandidateSetBuilder([new PeoplePrefilterResolver(), new SeriesNamePrefilterResolver()]);
+            return new CandidateSetBuilder([new PeoplePrefilterResolver(), new SeriesNamePrefilterResolver(), new NextUnwatchedPrefilterResolver()]);
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/CandidateSetBuilder.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/CandidateSetBuilder.cs
@@ -42,7 +42,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
         /// <returns>The builder with all production resolvers registered.</returns>
         public static CandidateSetBuilder CreateDefault()
         {
-            return new CandidateSetBuilder([new PeoplePrefilterResolver(), new SeriesNamePrefilterResolver(), new NextUnwatchedPrefilterResolver(), new LastEpisodeAirDatePrefilterResolver(), new ResolutionPrefilterResolver()]);
+            return new CandidateSetBuilder([new PeoplePrefilterResolver(), new SeriesNamePrefilterResolver(), new NextUnwatchedPrefilterResolver(), new LastEpisodeAirDatePrefilterResolver(), new ResolutionPrefilterResolver(), new StreamLanguagePrefilterResolver()]);
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/CandidateSetBuilder.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/CandidateSetBuilder.cs
@@ -42,7 +42,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
         /// <returns>The builder with all production resolvers registered.</returns>
         public static CandidateSetBuilder CreateDefault()
         {
-            return new CandidateSetBuilder([new PeoplePrefilterResolver(), new SeriesNamePrefilterResolver(), new NextUnwatchedPrefilterResolver()]);
+            return new CandidateSetBuilder([new PeoplePrefilterResolver(), new SeriesNamePrefilterResolver(), new NextUnwatchedPrefilterResolver(), new LastEpisodeAirDatePrefilterResolver()]);
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/CandidateSetBuilder.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/CandidateSetBuilder.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Text.RegularExpressions;
 using Jellyfin.Plugin.SmartLists.Core.Models;
 using Microsoft.Extensions.Logging;
 
@@ -175,20 +174,10 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
         {
             requiresNegativeSupport = IsNegativeOperator(expression.Operator);
 
-            if (string.Equals(expression.Operator, "MatchRegex", StringComparison.Ordinal))
+            if (string.Equals(expression.Operator, "MatchRegex", StringComparison.Ordinal)
+                && PrefilterStringMatcher.RegexMatchesEmptyOrIsInvalid(expression.TargetValue))
             {
-                try
-                {
-                    if (Regex.IsMatch(string.Empty, expression.TargetValue))
-                    {
-                        return false;
-                    }
-                }
-                catch (ArgumentException)
-                {
-                    // Invalid pattern - leave it to the per-item path.
-                    return false;
-                }
+                return false;
             }
 
             return true;

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/CandidateSetBuilder.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/CandidateSetBuilder.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using Jellyfin.Plugin.SmartLists.Core.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
+{
+    /// <summary>
+    /// Builds a candidate item-ID set for a list's rule sets by pushing individual rules down
+    /// to indexed database queries via registered <see cref="IRulePrefilterResolver"/>s.
+    ///
+    /// The result is always a SUPERSET of the items the per-item evaluation would match, so
+    /// intersecting a phase's input pool with it can never drop a true match:
+    /// - Within one rule set (AND): intersection over that set's pushdownable rules only;
+    ///   rules no resolver can bound simply do not participate (they still evaluate per-item).
+    /// - Across rule sets (OR): union. A set with ZERO pushdownable rules may match any item,
+    ///   which forces the overall result to null (= no shrink possible).
+    ///
+    /// A null result means "no shrink possible" and callers must behave exactly as if no
+    /// prefilter existed. An empty (non-null) result is a hard claim that no item matches.
+    /// </summary>
+    internal sealed class CandidateSetBuilder
+    {
+        private readonly IReadOnlyList<IRulePrefilterResolver> _resolvers;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CandidateSetBuilder"/> class.
+        /// </summary>
+        /// <param name="resolvers">Resolvers consulted per rule, in order; the first non-null result wins.</param>
+        public CandidateSetBuilder(IReadOnlyList<IRulePrefilterResolver> resolvers)
+        {
+            ArgumentNullException.ThrowIfNull(resolvers);
+            _resolvers = resolvers;
+        }
+
+        /// <summary>
+        /// Creates a builder with the production field resolvers. Field support is registered
+        /// here by later stages; with no resolvers <see cref="Build"/> always returns null and
+        /// the filtering pipeline behaves exactly as it did without prefilters.
+        /// </summary>
+        /// <returns>The builder with all production resolvers registered.</returns>
+        public static CandidateSetBuilder CreateDefault()
+        {
+            return new CandidateSetBuilder([]);
+        }
+
+        /// <summary>
+        /// Builds the candidate set for the given rule sets.
+        /// </summary>
+        /// <param name="expressionSets">The list's rule sets (OR of ANDs).</param>
+        /// <param name="context">Query context handed to resolvers.</param>
+        /// <returns>Candidate item IDs, or null when no shrink is possible.</returns>
+        public HashSet<Guid>? Build(IReadOnlyList<ExpressionSet>? expressionSets, PrefilterContext context)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+
+            if (_resolvers.Count == 0 || expressionSets == null || expressionSets.Count == 0)
+            {
+                return null;
+            }
+
+            var stopwatch = Stopwatch.StartNew();
+            HashSet<Guid>? union = null;
+
+            foreach (var set in expressionSets)
+            {
+                var setCandidates = BuildSetCandidates(set, context);
+                if (setCandidates == null)
+                {
+                    // This OR branch has no pushdownable rules, so it may match any item -
+                    // no overall shrink is possible regardless of what other sets contribute.
+                    context.Logger?.LogDebug("Prefilter: a rule set has no pushdownable rules - no candidate shrink possible");
+                    return null;
+                }
+
+                if (union == null)
+                {
+                    union = setCandidates;
+                }
+                else
+                {
+                    union.UnionWith(setCandidates);
+                }
+            }
+
+            if (union != null)
+            {
+                context.Logger?.LogDebug("Prefilter candidate set built: {Count} candidates in {Ms}ms", union.Count, stopwatch.ElapsedMilliseconds);
+            }
+
+            return union;
+        }
+
+        /// <summary>
+        /// Intersection over one set's pushdownable rules; null when none are pushdownable.
+        /// </summary>
+        private HashSet<Guid>? BuildSetCandidates(ExpressionSet? set, PrefilterContext context)
+        {
+            if (set?.Expressions == null)
+            {
+                return null;
+            }
+
+            HashSet<Guid>? candidates = null;
+
+            foreach (var expression in set.Expressions)
+            {
+                if (expression == null || !IsEligible(expression, out var requiresNegativeSupport))
+                {
+                    continue;
+                }
+
+                var ruleCandidates = ResolveRule(expression, requiresNegativeSupport, context);
+                if (ruleCandidates == null)
+                {
+                    // Not pushdownable - the rule still evaluates per-item on survivors.
+                    continue;
+                }
+
+                if (candidates == null)
+                {
+                    candidates = ruleCandidates;
+                }
+                else
+                {
+                    candidates.IntersectWith(ruleCandidates);
+                }
+
+                if (candidates.Count == 0)
+                {
+                    // The AND-intersection is already empty; nothing in this set can match.
+                    return candidates;
+                }
+            }
+
+            return candidates;
+        }
+
+        private HashSet<Guid>? ResolveRule(Expression expression, bool requiresNegativeSupport, PrefilterContext context)
+        {
+            foreach (var resolver in _resolvers)
+            {
+                if (requiresNegativeSupport && !resolver.SupportsNegativeOperators)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var result = resolver.Resolve(expression, context);
+                    if (result != null)
+                    {
+                        return result;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // A failing resolver degrades to "no shrink for this rule" - it must never
+                    // break the refresh or, worse, pretend to have bounded the rule.
+                    context.Logger?.LogDebug(ex, "Prefilter resolver {Resolver} failed for {Field} {Operator}; rule stays per-item",
+                        resolver.GetType().Name, expression.MemberName, expression.Operator);
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Central pushdown gates that apply regardless of field: negative operators only ride
+        /// resolvers that prove an exact complement, and MatchRegex never rides when its
+        /// pattern matches the empty string (empty-list semantics test against "").
+        /// </summary>
+        private static bool IsEligible(Expression expression, out bool requiresNegativeSupport)
+        {
+            requiresNegativeSupport = IsNegativeOperator(expression.Operator);
+
+            if (string.Equals(expression.Operator, "MatchRegex", StringComparison.Ordinal))
+            {
+                try
+                {
+                    if (Regex.IsMatch(string.Empty, expression.TargetValue))
+                    {
+                        return false;
+                    }
+                }
+                catch (ArgumentException)
+                {
+                    // Invalid pattern - leave it to the per-item path.
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool IsNegativeOperator(string? op)
+        {
+            return string.Equals(op, "NotEqual", StringComparison.Ordinal)
+                || string.Equals(op, "NotContains", StringComparison.Ordinal)
+                || string.Equals(op, "IsNotIn", StringComparison.Ordinal);
+        }
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/CandidateSetBuilder.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/CandidateSetBuilder.cs
@@ -41,7 +41,16 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
         /// <returns>The builder with all production resolvers registered.</returns>
         public static CandidateSetBuilder CreateDefault()
         {
-            return new CandidateSetBuilder([new PeoplePrefilterResolver(), new SeriesNamePrefilterResolver(), new NextUnwatchedPrefilterResolver(), new LastEpisodeAirDatePrefilterResolver(), new ResolutionPrefilterResolver(), new StreamLanguagePrefilterResolver(), new ParentValuesPrefilterResolver()]);
+            return new CandidateSetBuilder(
+            [
+                new PeoplePrefilterResolver(),
+                new SeriesNamePrefilterResolver(),
+                new NextUnwatchedPrefilterResolver(),
+                new LastEpisodeAirDatePrefilterResolver(),
+                new ResolutionPrefilterResolver(),
+                new StreamLanguagePrefilterResolver(),
+                new ParentValuesPrefilterResolver(),
+            ]);
         }
 
         /// <summary>
@@ -157,7 +166,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
                 {
                     // A failing resolver degrades to "no shrink for this rule" - it must never
                     // break the refresh or, worse, pretend to have bounded the rule.
-                    context.Logger?.LogDebug(ex, "Prefilter resolver {Resolver} failed for {Field} {Operator}; rule stays per-item",
+                    context.Logger?.LogWarning(ex, "Prefilter resolver {Resolver} failed for {Field} {Operator}; rule stays per-item",
                         resolver.GetType().Name, expression.MemberName, expression.Operator);
                 }
             }

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/CandidateSetBuilder.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/CandidateSetBuilder.cs
@@ -42,7 +42,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
         /// <returns>The builder with all production resolvers registered.</returns>
         public static CandidateSetBuilder CreateDefault()
         {
-            return new CandidateSetBuilder([new PeoplePrefilterResolver()]);
+            return new CandidateSetBuilder([new PeoplePrefilterResolver(), new SeriesNamePrefilterResolver()]);
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/CandidateSetBuilder.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/CandidateSetBuilder.cs
@@ -36,14 +36,13 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
         }
 
         /// <summary>
-        /// Creates a builder with the production field resolvers. Field support is registered
-        /// here by later stages; with no resolvers <see cref="Build"/> always returns null and
-        /// the filtering pipeline behaves exactly as it did without prefilters.
+        /// Creates a builder with the production field resolvers. Fields without a resolver
+        /// here simply never ride the prefilter - their rules evaluate per-item as before.
         /// </summary>
         /// <returns>The builder with all production resolvers registered.</returns>
         public static CandidateSetBuilder CreateDefault()
         {
-            return new CandidateSetBuilder([]);
+            return new CandidateSetBuilder([new PeoplePrefilterResolver()]);
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/CandidateSetBuilder.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/CandidateSetBuilder.cs
@@ -42,7 +42,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
         /// <returns>The builder with all production resolvers registered.</returns>
         public static CandidateSetBuilder CreateDefault()
         {
-            return new CandidateSetBuilder([new PeoplePrefilterResolver(), new SeriesNamePrefilterResolver(), new NextUnwatchedPrefilterResolver(), new LastEpisodeAirDatePrefilterResolver(), new ResolutionPrefilterResolver(), new StreamLanguagePrefilterResolver()]);
+            return new CandidateSetBuilder([new PeoplePrefilterResolver(), new SeriesNamePrefilterResolver(), new NextUnwatchedPrefilterResolver(), new LastEpisodeAirDatePrefilterResolver(), new ResolutionPrefilterResolver(), new StreamLanguagePrefilterResolver(), new ParentValuesPrefilterResolver()]);
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/IRulePrefilterResolver.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/IRulePrefilterResolver.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
+{
+    /// <summary>
+    /// Resolves a single rule expression to a database-backed candidate item-ID set.
+    ///
+    /// Safety invariant (non-negotiable): a resolver may only return a GUARANTEED SUPERSET of
+    /// the items the per-item evaluation would match for the rule. False positives are harmless
+    /// (final compiled-rule evaluation always still runs on survivors); a false negative is a
+    /// correctness bug. When in doubt, return null - the rule then simply stays per-item.
+    /// </summary>
+    internal interface IRulePrefilterResolver
+    {
+        /// <summary>
+        /// Gets a value indicating whether this resolver may be consulted for negative
+        /// operators (NotEqual/NotContains/IsNotIn). Only fields whose complement is provably
+        /// exact qualify (per spec: SeriesName and LastEpisodeAirDate-Before); everything else
+        /// must leave negatives to the per-item path.
+        /// </summary>
+        bool SupportsNegativeOperators => false;
+
+        /// <summary>
+        /// Returns a guaranteed superset of the item IDs matching <paramref name="expression"/>,
+        /// or null when this resolver cannot bound the rule (the rule then does not participate
+        /// in the candidate intersection). An EMPTY set is a hard claim that nothing matches.
+        /// The returned set is owned by the caller and may be mutated - return a fresh set on
+        /// every call.
+        /// </summary>
+        /// <param name="expression">The rule to push down.</param>
+        /// <param name="context">Query context (library manager, user, media types).</param>
+        /// <returns>Superset of matching item IDs, or null when the rule cannot be bounded.</returns>
+        HashSet<Guid>? Resolve(Expression expression, PrefilterContext context);
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/LastEpisodeAirDatePrefilterResolver.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/LastEpisodeAirDatePrefilterResolver.cs
@@ -282,25 +282,36 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
 
             var reference = new DateTimeOffset(DateTime.SpecifyKind(utcNow, DateTimeKind.Utc), TimeSpan.Zero);
             DateTimeOffset cutoffDate;
-            switch (parts[1].ToLowerInvariant())
+            try
             {
-                case "hours":
-                    cutoffDate = reference.AddHours(-num);
-                    break;
-                case "days":
-                    cutoffDate = reference.AddDays(-num);
-                    break;
-                case "weeks":
-                    cutoffDate = reference.AddDays(-num * 7);
-                    break;
-                case "months":
-                    cutoffDate = reference.AddMonths(-num);
-                    break;
-                case "years":
-                    cutoffDate = reference.AddYears(-num);
-                    break;
-                default:
-                    return false;
+                // -(double)num * 7 avoids the int overflow that would silently wrap a huge
+                // week span into a FUTURE cutoff (a NewerThan false negative); the other
+                // units throw ArgumentOutOfRangeException instead, caught below so the
+                // rule degrades to per-item rather than aborting the candidate build.
+                switch (parts[1].ToLowerInvariant())
+                {
+                    case "hours":
+                        cutoffDate = reference.AddHours(-num);
+                        break;
+                    case "days":
+                        cutoffDate = reference.AddDays(-num);
+                        break;
+                    case "weeks":
+                        cutoffDate = reference.AddDays(-(double)num * 7);
+                        break;
+                    case "months":
+                        cutoffDate = reference.AddMonths(-num);
+                        break;
+                    case "years":
+                        cutoffDate = reference.AddYears(-num);
+                        break;
+                    default:
+                        return false;
+                }
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                return false;
             }
 
             cutoff = cutoffDate.UtcDateTime;

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/LastEpisodeAirDatePrefilterResolver.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/LastEpisodeAirDatePrefilterResolver.cs
@@ -1,0 +1,320 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.TV;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
+{
+    /// <summary>
+    /// Prefilter resolver for the LastEpisodeAirDate rule field (Series-only).
+    ///
+    /// The per-item path runs one AncestorIds episode query PER SERIES to compute the max
+    /// PremiereDate (OperandFactory.ExtractLastEpisodeAirDate). This resolver replaces S
+    /// per-series queries with ONE date-range episode query via the max/exists equivalence:
+    /// - After/NewerThan X: "max episode date passes X" iff the series has ANY non-virtual
+    ///   episode with PremiereDate in range - one GetItemList(MinPremiereDate = X) mapped to
+    ///   series ids IS the candidate set. Server Min is inclusive (&gt;=, both ABIs) while
+    ///   plugin After is strict (&gt;), so boundary series are false positives - harmless,
+    ///   the final per-item evaluation always still runs on survivors.
+    /// - Before/OlderThan X: "max &lt; X" iff NOT EXISTS episode &gt;= X - candidates are the
+    ///   pool's Series MINUS the series returned by the same range query. The complement is
+    ///   exact for Before (a series with an episode &gt;= X has max &gt;= X and provably fails
+    ///   the strict &lt;); for OlderThan the cutoff is recomputed from UtcNow at every per-item
+    ///   evaluation, so the exclusion threshold gets <see cref="OlderThanComplementMargin"/>
+    ///   added - excluding only series that stay non-matching for at least that long after the
+    ///   plan is built (boundary series stay as false positives instead).
+    /// - Equal X: superset window [X, X+1day] (Max inclusive per server &lt;=; the plugin's
+    ///   in-day window is [X, X+1day), the extra boundary second is a false positive).
+    /// - NotEqual (day-window negation) and Weekday (day-of-week OF the max) need the actual
+    ///   max date, not existence - they never ride.
+    ///
+    /// GATE: the whole resolver is off when the rule sets IncludeUnknownDates - the compiled
+    /// rule then matches operand 0 (Engine.BuildDateExpression sentinel OR-branch), which every
+    /// series without a dated non-virtual episode and, in mixed pools, every non-Series item
+    /// carries, so no date range can bound the rule. Conversely, at the default setting the
+    /// 0-sentinel AND-branch means only Series can match at all, which is why the candidate
+    /// sets built here contain series ids only.
+    ///
+    /// Query notes (verified against both ABI server sources):
+    /// - User-neutral, GroupByPresentationUniqueKey pinned off, IsVirtualItem = false to mirror
+    ///   the extraction query exactly (upcoming/missing episodes must not contaminate the max).
+    /// - TopParentIds is deliberately NOT set: the per-series extraction query is not
+    ///   library-scoped either, and visibility is restored by intersecting with the pool.
+    /// - Episodes are materialized (GetItemList) because ids alone cannot give SeriesId;
+    ///   <see cref="MaxEpisodeResults"/> caps the materialization (GetCount runs first) - an
+    ///   over-cap query bails to no-shrink rather than loading the world.
+    /// - Episode-to-series attribution uses the SeriesId column with a FindSeriesId() parent
+    ///   walk fallback. Extraction finds episodes via the AncestorIds table instead; both
+    ///   derive from the same parent chain, but a stale AncestorIds row for an orphaned
+    ///   episode could still diverge (spec-documented minor risk).
+    /// </summary>
+    internal sealed class LastEpisodeAirDatePrefilterResolver : IRulePrefilterResolver
+    {
+        /// <summary>
+        /// Materialization cap for the episode range query. Beyond this the resolver bails to
+        /// no-shrink: a window this wide means the rule barely filters anyway, and loading that
+        /// many BaseItems would cost more than the per-series queries it replaces.
+        /// </summary>
+        internal const int MaxEpisodeResults = 50_000;
+
+        /// <summary>
+        /// Safety margin added to the OlderThan exclusion threshold. The per-item cutoff is
+        /// UtcNow-relative and recomputed per evaluation, so it keeps moving forward while the
+        /// filter run progresses; excluding only series with an episode at/after
+        /// cutoff-at-build-time + margin keeps the complement a guaranteed superset for any
+        /// run shorter than the margin (a boundary sliver of extra false positives is the cost).
+        /// </summary>
+        internal static readonly TimeSpan OlderThanComplementMargin = TimeSpan.FromDays(1);
+
+        /// <inheritdoc />
+        public HashSet<Guid>? Resolve(Expression expression, PrefilterContext context)
+        {
+            if (!string.Equals(expression.MemberName, "LastEpisodeAirDate", StringComparison.Ordinal)
+                || context.LibraryManager == null)
+            {
+                return null;
+            }
+
+            var plan = TryBuildPlan(expression.Operator, expression.TargetValue, expression.IncludeUnknownDates, DateTime.UtcNow);
+            if (plan == null)
+            {
+                return null;
+            }
+
+            if (plan.IsComplement && context.PoolItems == null)
+            {
+                // The complement is only exact over a known series universe; without the pool
+                // the rule stays per-item.
+                return null;
+            }
+
+            var stopwatch = Stopwatch.StartNew();
+            var query = new InternalItemsQuery
+            {
+                IncludeItemTypes = [BaseItemKind.Episode],
+                MinPremiereDate = plan.MinPremiereDate,
+                MaxPremiereDate = plan.MaxPremiereDate,
+                IsVirtualItem = false,
+                Recursive = true,
+                GroupByPresentationUniqueKey = false,
+            };
+
+            var episodeCount = context.LibraryManager.GetCount(query);
+            if (episodeCount > MaxEpisodeResults)
+            {
+                context.Logger?.LogDebug(
+                    "LastEpisodeAirDate prefilter: {Operator} '{Value}' range holds {Count} episodes (cap {Cap}) - rule stays per-item",
+                    expression.Operator, expression.TargetValue, episodeCount, MaxEpisodeResults);
+                return null;
+            }
+
+            var episodes = context.LibraryManager.GetItemList(query);
+            var seriesWithEpisodeInRange = MapToSeriesIds(episodes);
+
+            var result = plan.IsComplement
+                ? ComplementOverPoolSeries(context.PoolItems!, seriesWithEpisodeInRange)
+                : seriesWithEpisodeInRange;
+
+            context.Logger?.LogDebug(
+                "LastEpisodeAirDate prefilter: {Operator} '{Value}' -> {EpisodeCount} episodes across {SeriesCount} series -> {CandidateCount} candidate series ({Mode}) in {Ms}ms",
+                expression.Operator, expression.TargetValue, episodes.Count, seriesWithEpisodeInRange.Count, result.Count,
+                plan.IsComplement ? "complement" : "direct", stopwatch.ElapsedMilliseconds);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Immutable description of the episode range query an operator maps to.
+        /// </summary>
+        /// <param name="MinPremiereDate">Inclusive lower bound pushed to the server.</param>
+        /// <param name="MaxPremiereDate">Inclusive upper bound, only set for Equal's day window.</param>
+        /// <param name="IsComplement">True when candidates are pool series MINUS the query's series.</param>
+        internal sealed record QueryPlan(DateTime MinPremiereDate, DateTime? MaxPremiereDate, bool IsComplement);
+
+        /// <summary>
+        /// Maps an operator/value combination to its episode range query, or null when the rule
+        /// cannot ride (unknown-dates gate, non-riding operator, or a value the compiled rule
+        /// would reject). Value parsing mirrors the Engine's per-item semantics exactly:
+        /// absolute dates are strict yyyy-MM-dd (UTC), relative values are number:unit with the
+        /// same unit table BuildRelativeDateCutoffExpression uses.
+        /// </summary>
+        /// <param name="ruleOperator">The rule operator.</param>
+        /// <param name="targetValue">The rule target value.</param>
+        /// <param name="includeUnknownDates">The rule's IncludeUnknownDates option.</param>
+        /// <param name="utcNow">Reference time for relative operators.</param>
+        /// <returns>The query plan, or null when the rule stays per-item.</returns>
+        internal static QueryPlan? TryBuildPlan(string? ruleOperator, string? targetValue, bool? includeUnknownDates, DateTime utcNow)
+        {
+            // With unknown dates included, the compiled rule matches every dateless operand
+            // (series with zero dated non-virtual episodes, non-Series items) regardless of
+            // operator - no date range bounds that, so the rule contributes all items.
+            if (includeUnknownDates == true)
+            {
+                return null;
+            }
+
+            switch (ruleOperator)
+            {
+                case "After":
+                    return TryParseAbsoluteDate(targetValue, out var afterDate)
+                        ? new QueryPlan(afterDate, null, IsComplement: false)
+                        : null;
+
+                case "NewerThan":
+                    // Floored to whole seconds: the per-item comparison floors both sides to
+                    // unix seconds, so a sub-second Min could drop an episode whose truncated
+                    // timestamp still passes the compiled rule.
+                    return TryComputeRelativeCutoff(targetValue, utcNow, out var newerCutoff)
+                        ? new QueryPlan(FloorToWholeSeconds(newerCutoff), null, IsComplement: false)
+                        : null;
+
+                case "Before":
+                    return TryParseAbsoluteDate(targetValue, out var beforeDate)
+                        ? new QueryPlan(beforeDate, null, IsComplement: true)
+                        : null;
+
+                case "OlderThan":
+                    return TryComputeRelativeCutoff(targetValue, utcNow, out var olderCutoff)
+                        ? new QueryPlan(FloorToWholeSeconds(olderCutoff + OlderThanComplementMargin), null, IsComplement: true)
+                        : null;
+
+                case "Equal":
+                    return TryParseAbsoluteDate(targetValue, out var day)
+                        ? new QueryPlan(day, day.AddDays(1), IsComplement: false)
+                        : null;
+
+                default:
+                    // NotEqual and Weekday need the actual max date; anything else is not a
+                    // date operator. Operator comparison is Ordinal, mirroring the engine switch.
+                    return null;
+            }
+        }
+
+        /// <summary>
+        /// Attributes materialized episodes to their series ids: SeriesId column first, then
+        /// the FindSeriesId() parent walk (the same chain AncestorIds rows derive from). An
+        /// episode with no series ancestor is skipped - the per-series extraction cannot see
+        /// it either.
+        /// </summary>
+        /// <param name="episodes">Materialized items from the range query.</param>
+        /// <returns>Distinct series ids owning at least one of the episodes.</returns>
+        internal static HashSet<Guid> MapToSeriesIds(IReadOnlyList<BaseItem> episodes)
+        {
+            var result = new HashSet<Guid>();
+            foreach (var item in episodes)
+            {
+                if (item is not Episode episode)
+                {
+                    continue;
+                }
+
+                var seriesId = episode.SeriesId;
+                if (seriesId == Guid.Empty)
+                {
+                    seriesId = episode.FindSeriesId();
+                }
+
+                if (seriesId != Guid.Empty)
+                {
+                    result.Add(seriesId);
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Exact complement for Before/OlderThan: every pool Series without an episode at/after
+        /// the threshold. Series with no dated episodes at all stay candidates (they carry the
+        /// 0 sentinel and fail the compiled rule - a harmless false positive); non-Series pool
+        /// items cannot match the rule under the unknown-dates gate and are never candidates.
+        /// </summary>
+        /// <param name="poolItems">The already user-scoped item pool.</param>
+        /// <param name="excludedSeriesIds">Series with an episode at/after the threshold.</param>
+        /// <returns>Candidate series ids.</returns>
+        internal static HashSet<Guid> ComplementOverPoolSeries(IReadOnlyList<BaseItem> poolItems, HashSet<Guid> excludedSeriesIds)
+        {
+            var result = new HashSet<Guid>();
+            foreach (var item in poolItems)
+            {
+                if (item is Series && !excludedSeriesIds.Contains(item.Id))
+                {
+                    result.Add(item.Id);
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Parses an absolute rule date with the Engine's exact format (strict yyyy-MM-dd,
+        /// invariant culture, treated as UTC midnight).
+        /// </summary>
+        private static bool TryParseAbsoluteDate(string? targetValue, out DateTime result)
+        {
+            if (DateTime.TryParseExact(targetValue, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed))
+            {
+                result = DateTime.SpecifyKind(parsed, DateTimeKind.Utc);
+                return true;
+            }
+
+            result = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Computes the relative cutoff (UtcNow minus the rule's number:unit span) with the
+        /// exact unit table of Engine.BuildRelativeDateCutoffExpression.
+        /// </summary>
+        private static bool TryComputeRelativeCutoff(string? targetValue, DateTime utcNow, out DateTime cutoff)
+        {
+            cutoff = default;
+
+            var parts = (targetValue ?? string.Empty).Split(':');
+            if (parts.Length != 2 || !int.TryParse(parts[0], out int num) || num < 0)
+            {
+                return false;
+            }
+
+            var reference = new DateTimeOffset(DateTime.SpecifyKind(utcNow, DateTimeKind.Utc), TimeSpan.Zero);
+            DateTimeOffset cutoffDate;
+            switch (parts[1].ToLowerInvariant())
+            {
+                case "hours":
+                    cutoffDate = reference.AddHours(-num);
+                    break;
+                case "days":
+                    cutoffDate = reference.AddDays(-num);
+                    break;
+                case "weeks":
+                    cutoffDate = reference.AddDays(-num * 7);
+                    break;
+                case "months":
+                    cutoffDate = reference.AddMonths(-num);
+                    break;
+                case "years":
+                    cutoffDate = reference.AddYears(-num);
+                    break;
+                default:
+                    return false;
+            }
+
+            cutoff = cutoffDate.UtcDateTime;
+            return true;
+        }
+
+        /// <summary>
+        /// Truncates to whole unix seconds, matching how both the per-item cutoff and the
+        /// extracted max date are floored via ToUnixTimeSeconds.
+        /// </summary>
+        private static DateTime FloorToWholeSeconds(DateTime value)
+        {
+            var seconds = new DateTimeOffset(DateTime.SpecifyKind(value, DateTimeKind.Utc), TimeSpan.Zero).ToUnixTimeSeconds();
+            return DateTimeOffset.FromUnixTimeSeconds(seconds).UtcDateTime;
+        }
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/NextUnwatchedPrefilterResolver.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/NextUnwatchedPrefilterResolver.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Jellyfin.Data.Enums;
+using Jellyfin.Database.Implementations.Entities;
+using MediaBrowser.Controller.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
+{
+    /// <summary>
+    /// Prefilter resolver for the NextUnwatched rule field.
+    ///
+    /// Only "Equal true" (and the logically identical "NotEqual false") rides: every item that
+    /// rule matches is by definition an episode the rule's target user has NOT played - the
+    /// plugin's watched test is BaseItem.IsPlayed(user, userData), which in both server ABIs is
+    /// exactly "userData is not null &amp;&amp; userData.Played", the same predicate the DB
+    /// IsPlayed=false translation applies (a missing userdata row counts as unplayed in both).
+    /// One user-scoped GetItemIds(IsPlayed = false, IncludeItemTypes = [Episode]) per target
+    /// user is therefore a guaranteed superset of the rule's matches. The complement ("is NOT
+    /// the next unwatched" - played episodes, later unplayed ones, and every non-episode)
+    /// cannot shrink anything, so all other operator/value combinations stay per-item.
+    ///
+    /// Query notes (verified against both ABI server sources):
+    /// - User is MANDATORY on this query - the IsPlayed translation dereferences filter.User
+    ///   in BOTH ABIs (10.11 BaseItemRepository and 12 TranslateQuery). This is the one
+    ///   prefilter query that takes a user; GroupByPresentationUniqueKey is still pinned off
+    ///   (grouping only removes ids, and the calculated next episode's id must survive).
+    ///   Access filtering is symmetric with the per-item path, which fetches each series'
+    ///   episodes with an InternalItemsQuery(user) for the same target user.
+    /// - IsVirtualItem is deliberately NOT set: the pool may include virtual episodes and a
+    ///   virtual episode can be the calculated next-unwatched (the per-item episodes fetch for
+    ///   NextUnwatched does not filter virtual either).
+    /// - TopParentIds is deliberately NOT set: the pool query drops its TopParentIds scope
+    ///   when a LibraryName rule includes virtual items, and the resolver cannot see which
+    ///   variant ran - the unscoped query is the safe superset of both (visibility is restored
+    ///   by intersecting with the pool).
+    ///
+    /// The rule's target user mirrors Engine.BuildExpr: Expression.UserId ?? the list's user.
+    /// Additional users are resolved through the user manager; the missing-referenced-user
+    /// guard has already aborted the list before the prefilter builds, so an unresolvable user
+    /// here just conservatively leaves the rule per-item.
+    ///
+    /// SupportsNegativeOperators is true solely so "NotEqual false" can ride; the boolean
+    /// complement proof above is what the central negative-operator gate demands, and
+    /// <see cref="RidesPrefilter"/> rejects every other negative combination.
+    /// </summary>
+    internal sealed class NextUnwatchedPrefilterResolver : IRulePrefilterResolver
+    {
+        /// <summary>
+        /// Per-target-user unplayed-episode id sets for this filter run (the resolver lives
+        /// for one CandidateSetBuilder.Build call): the riding combinations all map to the
+        /// same query, so shared lists with several NextUnwatched rules query once per user.
+        /// </summary>
+        private readonly Dictionary<Guid, IReadOnlyList<Guid>> _unplayedEpisodeIdsByUser = [];
+
+        /// <inheritdoc />
+        public bool SupportsNegativeOperators => true;
+
+        /// <inheritdoc />
+        public HashSet<Guid>? Resolve(Expression expression, PrefilterContext context)
+        {
+            if (!string.Equals(expression.MemberName, "NextUnwatched", StringComparison.Ordinal)
+                || context.LibraryManager == null
+                || !RidesPrefilter(expression.Operator, expression.TargetValue))
+            {
+                return null;
+            }
+
+            var targetUser = ResolveTargetUser(expression, context);
+            if (targetUser == null)
+            {
+                return null;
+            }
+
+            if (!_unplayedEpisodeIdsByUser.TryGetValue(targetUser.Id, out var ids))
+            {
+                var stopwatch = Stopwatch.StartNew();
+                ids = context.LibraryManager.GetItemIds(new InternalItemsQuery(targetUser)
+                {
+                    IncludeItemTypes = [BaseItemKind.Episode],
+                    IsPlayed = false,
+                    Recursive = true,
+                    GroupByPresentationUniqueKey = false,
+                });
+                _unplayedEpisodeIdsByUser[targetUser.Id] = ids;
+
+                context.Logger?.LogDebug("NextUnwatched prefilter: {Count} unplayed episodes for user {UserId} in {Ms}ms",
+                    ids.Count, targetUser.Id, stopwatch.ElapsedMilliseconds);
+            }
+
+            // Fresh set per call - the caller owns and mutates the result.
+            return [.. ids];
+        }
+
+        /// <summary>
+        /// Decides whether an operator/value combination may ride the unplayed-episode
+        /// prefilter: only "Equal true" and "NotEqual false" qualify. The value is parsed with
+        /// the exact per-item semantics (Engine.ValidateAndParseBooleanValue - trim, strip
+        /// quotes, case-insensitive bool parse); a value the compiled rule would reject stays
+        /// per-item rather than guessing.
+        /// </summary>
+        /// <param name="ruleOperator">The rule operator.</param>
+        /// <param name="targetValue">The rule target value.</param>
+        /// <returns>True when the combination is provably "is the next unwatched episode".</returns>
+        internal static bool RidesPrefilter(string? ruleOperator, string? targetValue)
+        {
+            var isEqual = string.Equals(ruleOperator, "Equal", StringComparison.Ordinal);
+            if (!isEqual && !string.Equals(ruleOperator, "NotEqual", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(targetValue))
+            {
+                return false;
+            }
+
+            bool boolValue;
+            try
+            {
+                boolValue = Engine.ValidateAndParseBooleanValue(targetValue, "NextUnwatched");
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+
+            // Equal true, or NotEqual false - both mean "IS the next unwatched episode".
+            return isEqual == boolValue;
+        }
+
+        /// <summary>
+        /// Resolves the rule's target user the same way Engine.BuildExpr does:
+        /// Expression.UserId when set (an additional user), else the list's user.
+        /// </summary>
+        private static User? ResolveTargetUser(Expression expression, PrefilterContext context)
+        {
+            if (string.IsNullOrEmpty(expression.UserId))
+            {
+                return context.User;
+            }
+
+            if (!Guid.TryParse(expression.UserId, out var userGuid))
+            {
+                return null;
+            }
+
+            if (context.User != null && userGuid == context.User.Id)
+            {
+                return context.User;
+            }
+
+            return context.UserManager == null ? null : OperandFactory.GetUserById(context.UserManager, userGuid);
+        }
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/ParentValuesPrefilterResolver.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/ParentValuesPrefilterResolver.cs
@@ -1,0 +1,481 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
+{
+    /// <summary>
+    /// Prefilter resolver for parent-aware Tags/Genres/Studios rules (IncludeParent* /
+    /// OnlyParent*), whose per-item path runs the AncestorValueResolver walk over the pool.
+    ///
+    /// Shared two-query shape per rule:
+    /// 1. A value-filtered GetItemIds over ALL item types. The Tags/Genres/StudioIds filters
+    ///    match any BaseItem row including folders (Series/Season/library folders), so this
+    ///    yields both leaf matches and value-carrying containers.
+    /// 2. GetItemIds(AncestorIds = containerIds) for everything physically under the matched
+    ///    containers - the DB's transitive parent chain + GetCollectionFolders, the same
+    ///    edges the plugin walk follows.
+    /// Candidates = direct matches UNION descendants. Superset holds because OnlyParent*
+    /// only narrows the plugin match and final per-item evaluation always still runs.
+    ///
+    /// Inheritance edges the DB does NOT model, and how each is kept safe:
+    /// - Extras inherit via GetOwner(), which writes no AncestorIds rows. Extras are
+    ///   unconditionally exempt at the consumption points (SmartList.IsPrefilterExempt),
+    ///   so no extra can ever be shrunk away by this resolver.
+    /// - Symlinked/plugin-created virtual libraries: the plugin walk path-matches
+    ///   CollectionFolders precisely because the server's GetCollectionFolders (which
+    ///   populated the AncestorIds rows) can resolve to the wrong folder. Conservative
+    ///   guard: if ANY value-carrying container is a CollectionFolder, the rule falls back
+    ///   to no-prefilter (null) instead of attempting path expansion.
+    ///
+    /// Per-field pushdown (negative operators never ride - SupportsNegativeOperators stays
+    /// false; MatchRegex never rides any of these fields, see ResolveMatchingNames):
+    /// - Tags: Equal only, raw value into Tags= (the server cleans both sides, so the
+    ///   cleaned exact match is a superset of the plugin's OrdinalIgnoreCase equality).
+    ///   Tags are not by-name BaseItems and no tag-name dump API exists in either ABI, so
+    ///   substring operators cannot be expanded to exact values.
+    /// - Genres: Equal via the same raw pushdown into Genres= (name-based filter exists in
+    ///   both ABIs and covers music genres - all genres share ItemValueType.Genre);
+    ///   Contains/IsIn ride via the ItemValues-backed name dump
+    ///   (IItemRepository.GetGenreNames + GetMusicGenreNames - GetGenreNames excludes the
+    ///   music item types, so both calls are required), matched on normalized values and
+    ///   pushed as exact names.
+    /// - Studios: neither ABI has a name-based Studios filter, only the StudioIds join
+    ///   through EXISTING Studio rows. Rule values are resolved against the by-name Studio
+    ///   item dump on normalized values (never GetStudio(name) - that is CreateItemByName
+    ///   and materializes phantom studios), cross-checked against GetStudioNames() so a
+    ///   studio string whose by-name item the post-scan validator has not materialized yet
+    ///   forces a fallback instead of a silent false negative.
+    /// </summary>
+    internal sealed class ParentValuesPrefilterResolver : IRulePrefilterResolver
+    {
+        /// <summary>
+        /// Above this many matched dump names the pushdown query stops being cheap (a rule
+        /// like Contains "a" can match most of the table) - the rule then stays per-item.
+        /// </summary>
+        internal const int MaxMatchedNames = 200;
+
+        /// <summary>
+        /// Genre name dump for this filter run (the resolver lives for one
+        /// CandidateSetBuilder.Build call); null when unavailable.
+        /// </summary>
+        private IReadOnlyList<string>? _genreNames;
+        private bool _genreNamesAttempted;
+
+        /// <summary>
+        /// ItemValues-backed studio name dump for this filter run; null when unavailable.
+        /// </summary>
+        private IReadOnlyList<string>? _studioNames;
+        private bool _studioNamesAttempted;
+
+        /// <summary>
+        /// Materialized by-name Studio items (id, name) for this filter run; null when
+        /// unavailable.
+        /// </summary>
+        private IReadOnlyList<(Guid Id, string Name)>? _studioItems;
+        private bool _studioItemsAttempted;
+
+        /// <inheritdoc />
+        public HashSet<Guid>? Resolve(Expression expression, PrefilterContext context)
+        {
+            if (context.LibraryManager == null || !SmartList.IsParentAwareListExpression(expression))
+            {
+                return null;
+            }
+
+            if (string.IsNullOrWhiteSpace(expression.TargetValue))
+            {
+                return null;
+            }
+
+            return expression.MemberName switch
+            {
+                "Tags" => ResolveTags(expression, context),
+                "Genres" => ResolveGenres(expression, context),
+                "Studios" => ResolveStudios(expression, context),
+                _ => null,
+            };
+        }
+
+        private static HashSet<Guid>? ResolveTags(Expression expression, PrefilterContext context)
+        {
+            var push = ResolveTagPushdownValues(expression.Operator, expression.TargetValue);
+            if (push == null)
+            {
+                return null;
+            }
+
+            return ExpandDirectAndDescendants(context, query => query.Tags = push, expression);
+        }
+
+        private HashSet<Guid>? ResolveGenres(Expression expression, PrefilterContext context)
+        {
+            string[] push;
+            if (string.Equals(expression.Operator, "Equal", StringComparison.Ordinal))
+            {
+                // Raw pushdown - the server cleans both sides of Genres=, so the cleaned
+                // exact match is a superset of the plugin's OrdinalIgnoreCase equality.
+                // No dump dependency for the most common operator.
+                push = [expression.TargetValue];
+            }
+            else
+            {
+                var names = GetGenreNames(context);
+                if (names == null)
+                {
+                    return null;
+                }
+
+                var matched = ResolveMatchingNames(names, expression.Operator, expression.TargetValue);
+                if (matched == null || matched.Count == 0)
+                {
+                    // Zero matches would be a hard "nothing matches" claim resting on the
+                    // completeness of the two-method dump union - stay per-item instead.
+                    return null;
+                }
+
+                push = [.. matched];
+            }
+
+            return ExpandDirectAndDescendants(context, query => query.Genres = push, expression);
+        }
+
+        private HashSet<Guid>? ResolveStudios(Expression expression, PrefilterContext context)
+        {
+            var itemValueNames = GetStudioNames(context);
+            if (itemValueNames == null)
+            {
+                return null;
+            }
+
+            var studioItems = GetStudioItems(context);
+            if (studioItems == null)
+            {
+                return null;
+            }
+
+            var ids = ResolveStudioIds(itemValueNames, studioItems, expression.Operator, expression.TargetValue);
+            if (ids == null || ids.Length == 0)
+            {
+                return null;
+            }
+
+            return ExpandDirectAndDescendants(context, query => query.StudioIds = ids, expression);
+        }
+
+        /// <summary>
+        /// Decides whether a Tags rule can ride and with which pushdown values.
+        /// </summary>
+        /// <param name="ruleOperator">The rule operator.</param>
+        /// <param name="targetValue">The rule target value.</param>
+        /// <returns>The values to push into Tags=, or null when the rule stays per-item.</returns>
+        internal static string[]? ResolveTagPushdownValues(string ruleOperator, string targetValue)
+        {
+            // Equal only: the DB Tags filter is a cleaned EXACT match and tags are not
+            // by-name BaseItems, so there is no dump to expand Contains/IsIn/regex
+            // against. IsIn in particular is per-term SUBSTRING matching plugin-side and
+            // must not be pushed as exact terms.
+            if (!string.Equals(ruleOperator, "Equal", StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            if (string.IsNullOrWhiteSpace(targetValue))
+            {
+                return null;
+            }
+
+            return [targetValue];
+        }
+
+        /// <summary>
+        /// Evaluates the rule operator against dumped names on the normalized form
+        /// (<see cref="PrefilterValueCleaner.MatchNormalize"/>). Deliberately BROADER than
+        /// the plugin's per-item semantics: the dump holds one representative raw variant
+        /// per server-cleaned group, so plugin-exact matching would miss groups whose other
+        /// variants match (false negatives). Broader matching only adds candidates.
+        /// </summary>
+        /// <param name="storedNames">Dumped names (one representative per cleaned group).</param>
+        /// <param name="ruleOperator">The rule operator.</param>
+        /// <param name="targetValue">The rule target value.</param>
+        /// <returns>
+        /// The matched names (empty when nothing matches), or null when the rule cannot
+        /// ride: unsupported operator (MatchRegex is case-sensitive plugin-side and a lone
+        /// representative variant cannot soundly stand in for its group; negatives never
+        /// ride), an empty normalized needle (would match everything), a matched
+        /// whitespace-only name (cannot be pushed as a query value), or more than
+        /// <see cref="MaxMatchedNames"/> matches.
+        /// </returns>
+        internal static List<string>? ResolveMatchingNames(IReadOnlyCollection<string> storedNames, string ruleOperator, string targetValue)
+        {
+            ArgumentNullException.ThrowIfNull(storedNames);
+
+            Func<string, bool> matches;
+            switch (ruleOperator)
+            {
+                case "Equal":
+                    var equalKey = PrefilterValueCleaner.MatchNormalize(targetValue);
+                    matches = normalized => string.Equals(normalized, equalKey, StringComparison.Ordinal);
+                    break;
+                case "Contains":
+                    var needle = PrefilterValueCleaner.MatchNormalize(targetValue);
+                    if (needle.Length == 0)
+                    {
+                        return null;
+                    }
+
+                    matches = normalized => normalized.Contains(needle, StringComparison.Ordinal);
+                    break;
+                case "IsIn":
+                    // Mirrors Engine.AnyItemIsInList term splitting (semicolons, trimmed,
+                    // empties dropped); each term is a substring match plugin-side.
+                    var terms = targetValue.Split(';', StringSplitOptions.RemoveEmptyEntries)
+                        .Select(term => term.Trim())
+                        .Where(term => term.Length > 0)
+                        .Select(PrefilterValueCleaner.MatchNormalize)
+                        .ToList();
+                    if (terms.Count == 0 || terms.Any(term => term.Length == 0))
+                    {
+                        // No terms, or a term that normalizes to empty (e.g. "!!") - the
+                        // plugin still substring-matches such a term against raw values,
+                        // so dropping it would under-match. Stay per-item.
+                        return null;
+                    }
+
+                    matches = normalized => terms.Any(term => normalized.Contains(term, StringComparison.Ordinal));
+                    break;
+                default:
+                    return null;
+            }
+
+            var matched = new List<string>();
+            foreach (var name in storedNames)
+            {
+                if (name == null)
+                {
+                    continue;
+                }
+
+                if (!matches(PrefilterValueCleaner.MatchNormalize(name)))
+                {
+                    continue;
+                }
+
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    // A whitespace-only value cannot be pushed (query translation for
+                    // blank values is undefined), and silently skipping a MATCHED name
+                    // could drop a true match. Stay per-item.
+                    return null;
+                }
+
+                matched.Add(name);
+                if (matched.Count > MaxMatchedNames)
+                {
+                    return null;
+                }
+            }
+
+            return matched;
+        }
+
+        /// <summary>
+        /// Resolves a Studios rule to by-name Studio item ids, with the materialization
+        /// coverage check: the StudioIds join only reaches items through an EXISTING Studio
+        /// row (CleanName == the item value's CleanValue), so every rule-matching
+        /// ItemValues name must have a Studio item under the same <see
+        /// cref="PrefilterValueCleaner.CleanValue"/> key - equality on that key implies
+        /// join reachability on both ABIs. A matching name without one (post-scan
+        /// validator lag) forces a fallback.
+        /// </summary>
+        /// <param name="itemValueNames">GetStudioNames() dump (complete per cleaned group).</param>
+        /// <param name="studioItems">Materialized by-name Studio items.</param>
+        /// <param name="ruleOperator">The rule operator.</param>
+        /// <param name="targetValue">The rule target value.</param>
+        /// <returns>Studio ids to push into StudioIds=, or null when the rule stays per-item.</returns>
+        internal static Guid[]? ResolveStudioIds(IReadOnlyCollection<string> itemValueNames, IReadOnlyList<(Guid Id, string Name)> studioItems, string ruleOperator, string targetValue)
+        {
+            ArgumentNullException.ThrowIfNull(studioItems);
+
+            var matched = ResolveMatchingNames(itemValueNames, ruleOperator, targetValue);
+            if (matched == null || matched.Count == 0)
+            {
+                // Zero matches would be a hard "nothing matches" claim - stay per-item.
+                return null;
+            }
+
+            var idsByCleanName = new Dictionary<string, List<Guid>>(StringComparer.Ordinal);
+            foreach (var (id, name) in studioItems)
+            {
+                if (string.IsNullOrEmpty(name))
+                {
+                    continue;
+                }
+
+                var key = PrefilterValueCleaner.CleanValue(name);
+                if (!idsByCleanName.TryGetValue(key, out var ids))
+                {
+                    ids = [];
+                    idsByCleanName[key] = ids;
+                }
+
+                ids.Add(id);
+            }
+
+            var result = new HashSet<Guid>();
+            foreach (var name in matched)
+            {
+                if (!idsByCleanName.TryGetValue(PrefilterValueCleaner.CleanValue(name), out var ids))
+                {
+                    // Studio string present in ItemValues but its by-name item is not
+                    // materialized yet - the per-item path (raw BaseItem.Studios strings)
+                    // would still match those items, and no StudioIds query can reach them.
+                    return null;
+                }
+
+                result.UnionWith(ids);
+            }
+
+            return [.. result];
+        }
+
+        /// <summary>
+        /// Runs the shared two-query expansion: value-filtered direct matches over all item
+        /// types, then descendants of every value-carrying container via AncestorIds, with
+        /// the conservative CollectionFolder guard. All queries run user-neutral with
+        /// GroupByPresentationUniqueKey pinned off (the constructor default collapses
+        /// alternate versions when a user is set); visibility is restored by the caller
+        /// intersecting with the already user-scoped pool.
+        /// </summary>
+        private static HashSet<Guid>? ExpandDirectAndDescendants(PrefilterContext context, Action<InternalItemsQuery> applyValueFilter, Expression expression)
+        {
+            var stopwatch = Stopwatch.StartNew();
+
+            var directQuery = new InternalItemsQuery { GroupByPresentationUniqueKey = false };
+            applyValueFilter(directQuery);
+            var direct = context.LibraryManager.GetItemIds(directQuery);
+
+            var containerQuery = new InternalItemsQuery { GroupByPresentationUniqueKey = false, IsFolder = true };
+            applyValueFilter(containerQuery);
+            var containers = context.LibraryManager.GetItemList(containerQuery);
+
+            var containerIds = new List<Guid>();
+            foreach (var container in containers)
+            {
+                if (container == null)
+                {
+                    continue;
+                }
+
+                if (container is CollectionFolder)
+                {
+                    // Conservative virtual-library guard: the plugin walk path-matches
+                    // CollectionFolders because the server's GetCollectionFolders (which
+                    // populates AncestorIds) can resolve symlinked/virtual libraries to the
+                    // wrong folder - AncestorIds expansion is not a superset then.
+                    context.Logger?.LogDebug(
+                        "Parent-values prefilter: {Field} {Operator} matched CollectionFolder '{Folder}' - falling back to no-prefilter for this rule",
+                        expression.MemberName, expression.Operator, container.Name);
+                    return null;
+                }
+
+                containerIds.Add(container.Id);
+            }
+
+            var result = new HashSet<Guid>(direct);
+            if (containerIds.Count > 0)
+            {
+                var descendantsQuery = new InternalItemsQuery
+                {
+                    GroupByPresentationUniqueKey = false,
+                    AncestorIds = [.. containerIds],
+                };
+                result.UnionWith(context.LibraryManager.GetItemIds(descendantsQuery));
+            }
+
+            context.Logger?.LogDebug(
+                "Parent-values prefilter: {Field} {Operator} -> {DirectCount} direct matches + {ContainerCount} containers -> {CandidateCount} candidates in {Ms}ms",
+                expression.MemberName, expression.Operator, direct.Count, containerIds.Count, result.Count, stopwatch.ElapsedMilliseconds);
+            return result;
+        }
+
+        /// <summary>
+        /// Gets the ItemValues-backed genre name dump (regular + music genres - all genres
+        /// share ItemValueType.Genre on the query side, but GetGenreNames excludes the
+        /// music item types, so both calls are required for completeness). Null when the
+        /// item repository is unavailable.
+        /// </summary>
+        private IReadOnlyList<string>? GetGenreNames(PrefilterContext context)
+        {
+            if (_genreNamesAttempted)
+            {
+                return _genreNames;
+            }
+
+            _genreNamesAttempted = true;
+            var repository = context.ItemRepository;
+            if (repository == null)
+            {
+                return null;
+            }
+
+            var names = new List<string>();
+            names.AddRange(repository.GetGenreNames());
+            names.AddRange(repository.GetMusicGenreNames());
+            _genreNames = names;
+            return _genreNames;
+        }
+
+        /// <summary>
+        /// Gets the ItemValues-backed studio name dump. Null when the item repository is
+        /// unavailable.
+        /// </summary>
+        private IReadOnlyList<string>? GetStudioNames(PrefilterContext context)
+        {
+            if (_studioNamesAttempted)
+            {
+                return _studioNames;
+            }
+
+            _studioNamesAttempted = true;
+            _studioNames = context.ItemRepository?.GetStudioNames();
+            return _studioNames;
+        }
+
+        /// <summary>
+        /// Gets the materialized by-name Studio items via a plain item query - never
+        /// GetStudio(name), which is CreateItemByName in both ABIs and would materialize
+        /// phantom Studio items for typo'd rule values.
+        /// </summary>
+        private IReadOnlyList<(Guid Id, string Name)>? GetStudioItems(PrefilterContext context)
+        {
+            if (_studioItemsAttempted)
+            {
+                return _studioItems;
+            }
+
+            _studioItemsAttempted = true;
+            var items = context.LibraryManager.GetItemList(new InternalItemsQuery
+            {
+                IncludeItemTypes = [BaseItemKind.Studio],
+                GroupByPresentationUniqueKey = false,
+            });
+
+            var studios = new List<(Guid Id, string Name)>(items.Count);
+            foreach (var item in items)
+            {
+                if (item?.Name is { Length: > 0 } name)
+                {
+                    studios.Add((item.Id, name));
+                }
+            }
+
+            _studioItems = studios;
+            return _studioItems;
+        }
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/PeoplePrefilterResolver.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/PeoplePrefilterResolver.cs
@@ -23,14 +23,18 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
     ///    also exists as a people-table row reachable through the same dump.
     ///
     /// Role handling differs per ABI:
-    /// - net10 (Jellyfin 12): the unrestricted people dump collapses to ONE arbitrary-typed
-    ///   row per name, so role-specific fields must push the role into the people query
-    ///   itself (InternalPeopleQuery.PersonTypes is translated BEFORE the collapse) and into
-    ///   the item query (Person + PersonTypes compose). Never role-filter the dump in memory.
-    /// - net9 (Jellyfin 10.11): the dump returns one row per (Name, Type), so the role
-    ///   filter runs in memory with the same Type.ToString() comparison CategorizePeople
-    ///   uses. PersonTypes is a silent no-op on 10.11 item queries, so the per-name item
-    ///   query is any-role there - a valid superset; role verification stays per-item.
+    /// - net10 (Jellyfin 12): names are dumped via GetPeopleNames, whose SQL is a plain
+    ///   ordinal Distinct over Name - unlike GetPeople, whose no-ItemId branch collapses to
+    ///   ONE arbitrary row per LOWERCASED name and would drop case-only duplicate spellings
+    ///   (each stored spelling needs its own byte-exact item query). Role-specific fields
+    ///   push the role into the people query itself (InternalPeopleQuery.PersonTypes is
+    ///   translated BEFORE the name projection) and into the item query (Person +
+    ///   PersonTypes compose). Never role-filter dump results in memory on 12.
+    /// - net9 (Jellyfin 10.11): the GetPeople dump has no collapse and returns one row per
+    ///   (Name, Type); it runs ONCE per filter run and each role's names are derived from
+    ///   it in memory with the same Type.ToString() comparison CategorizePeople uses.
+    ///   PersonTypes is a silent no-op on 10.11 item queries, so the per-name item query is
+    ///   any-role there - a valid superset; role verification stays per-item.
     ///
     /// ActorRoles never rides: role strings live on the people map row and are not
     /// filterable in either ABI. Negative operators are rejected centrally by
@@ -244,46 +248,68 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
             }
 
 #if NET10_0_OR_GREATER
-            // Jellyfin 12 collapses the unrestricted dump to one arbitrary-typed row per
-            // name, so role narrowing must happen inside the people query (PersonTypes is
-            // ctor-only there and translated before the collapse) - never in memory
-            // against the dump.
+            // Jellyfin 12: GetPeopleNames only - its SQL is an ordinal Distinct over Name,
+            // so every distinct stored spelling survives and gets its own byte-exact item
+            // query. GetPeople's no-ItemId branch instead collapses to one arbitrary row
+            // per LOWERCASED name, silently losing case-only duplicate spellings (a false
+            // negative for Equal/Contains/IsIn and a wrong hard "nothing matches" for
+            // case-sensitive MatchRegex). Role narrowing must happen inside the people
+            // query (PersonTypes is ctor-only there and translated before the name
+            // projection) - never in memory against the dump.
             var query = role == null
                 ? new InternalPeopleQuery()
                 : new InternalPeopleQuery([role], []);
 
-            var names = DumpNames(context, query, roleFilter: null);
+            IReadOnlyList<string>? names = context.LibraryManager.GetPeopleNames(query);
 #else
-            // Jellyfin 10.11 returns one row per (Name, Type): role-filter in memory with
-            // the same Type.ToString() comparison the per-item CategorizePeople switch uses.
-            // (PersonTypes narrowing in the people query is 12-only behavior.)
-            var names = DumpNames(context, new InternalPeopleQuery(), roleFilter: role);
+            // Jellyfin 10.11 returns one GetPeople row per (Name, Type) with no collapse:
+            // dump the table once per filter run and derive each role's names in memory
+            // with the same Type.ToString() comparison the per-item CategorizePeople
+            // switch uses. (PersonTypes narrowing in the people query is 12-only behavior,
+            // and 10.11's GetPeopleNames cannot be used - it drops the Type column.)
+            var names = FilterNamesByRole(GetDumpRows(context), role);
 #endif
             _namesByRole[cacheKey] = names;
             return names;
         }
 
+#if !NET10_0_OR_GREATER
         /// <summary>
-        /// Runs the people dump through the reflected ABI-shared
-        /// ILibraryManager.GetPeople(InternalPeopleQuery) and collects distinct names.
-        /// Ordinal distinctness is deliberate: names differing only by case are distinct
-        /// stored rows and each needs its own byte-exact item query on 10.11.
+        /// The unrestricted (Name, Type) dump rows for this filter run, materialized at most
+        /// once; null when the dump is unavailable. See <see cref="_dumpAttempted"/>.
         /// </summary>
-        private static IReadOnlyList<string>? DumpNames(PrefilterContext context, InternalPeopleQuery query, string? roleFilter)
+        private IReadOnlyList<(string Name, string? Type)>? _dumpRows;
+
+        /// <summary>
+        /// Whether the dump has been attempted, so a failed dump is not retried per role.
+        /// </summary>
+        private bool _dumpAttempted;
+
+        /// <summary>
+        /// Runs the unrestricted people dump through the reflected ABI-shared
+        /// ILibraryManager.GetPeople(InternalPeopleQuery), once per filter run.
+        /// </summary>
+        private IReadOnlyList<(string Name, string? Type)>? GetDumpRows(PrefilterContext context)
         {
+            if (_dumpAttempted)
+            {
+                return _dumpRows;
+            }
+
+            _dumpAttempted = true;
             var getPeopleMethod = OperandFactory.GetPeopleQueryMethod(context.LibraryManager);
             if (getPeopleMethod == null)
             {
                 return null;
             }
 
-            var result = getPeopleMethod.Invoke(context.LibraryManager, [query]);
+            var result = getPeopleMethod.Invoke(context.LibraryManager, [new InternalPeopleQuery()]);
             if (result is not IEnumerable<object> rows)
             {
                 return null;
             }
 
-            var names = new HashSet<string>(StringComparer.Ordinal);
+            var dump = new List<(string Name, string? Type)>();
             PropertyInfo? nameProperty = null;
             PropertyInfo? typeProperty = null;
             foreach (var row in rows)
@@ -294,18 +320,37 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
                 }
 
                 nameProperty ??= row.GetType().GetProperty("Name");
+                typeProperty ??= row.GetType().GetProperty("Type");
                 if (nameProperty?.GetValue(row) is not string name || name.Length == 0)
                 {
                     continue;
                 }
 
-                if (roleFilter != null)
+                dump.Add((name, typeProperty?.GetValue(row)?.ToString()));
+            }
+
+            _dumpRows = dump;
+            return _dumpRows;
+        }
+
+        /// <summary>
+        /// Derives the distinct names for a role (null = any role) from the dump rows.
+        /// Ordinal distinctness is deliberate: names differing only by case are distinct
+        /// stored rows and each needs its own byte-exact item query on 10.11.
+        /// </summary>
+        private static IReadOnlyList<string>? FilterNamesByRole(IReadOnlyList<(string Name, string? Type)>? rows, string? role)
+        {
+            if (rows == null)
+            {
+                return null;
+            }
+
+            var names = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var (name, type) in rows)
+            {
+                if (role != null && !string.Equals(type, role, StringComparison.Ordinal))
                 {
-                    typeProperty ??= row.GetType().GetProperty("Type");
-                    if (!string.Equals(typeProperty?.GetValue(row)?.ToString(), roleFilter, StringComparison.Ordinal))
-                    {
-                        continue;
-                    }
+                    continue;
                 }
 
                 names.Add(name);
@@ -313,5 +358,6 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
 
             return [.. names];
         }
+#endif
     }
 }

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/PeoplePrefilterResolver.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/PeoplePrefilterResolver.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Reflection;
-using System.Text.RegularExpressions;
 using MediaBrowser.Controller.Entities;
 using Microsoft.Extensions.Logging;
+#if !NET10_0_OR_GREATER
+using System.Reflection;
+#endif
 
 namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
 {
@@ -167,40 +168,10 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
         {
             ArgumentNullException.ThrowIfNull(storedNames);
 
-            Func<string, bool> matches;
-            switch (ruleOperator)
+            var matches = PrefilterStringMatcher.TryBuildMatcher(ruleOperator, targetValue);
+            if (matches == null)
             {
-                case "Equal":
-                    matches = name => Engine.AnyItemEquals([name], targetValue);
-                    break;
-                case "Contains":
-                    matches = name => Engine.AnyItemContains([name], targetValue);
-                    break;
-                case "IsIn":
-                    matches = name => Engine.AnyItemIsInList([name], targetValue);
-                    break;
-                case "MatchRegex":
-                    try
-                    {
-                        // An empty people list is evaluated against "", so a pattern that
-                        // matches the empty string matches items with no people at all -
-                        // which no name-derived candidate set can bound.
-                        if (Regex.IsMatch(string.Empty, targetValue))
-                        {
-                            return null;
-                        }
-                    }
-                    catch (ArgumentException)
-                    {
-                        // Invalid pattern - the per-item path surfaces the error.
-                        return null;
-                    }
-
-                    matches = name => Engine.AnyRegexMatch([name], targetValue);
-                    break;
-                default:
-                    // Negative operators and anything unexpected stay per-item.
-                    return null;
+                return null;
             }
 
             var matched = new List<string>();

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/PeoplePrefilterResolver.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/PeoplePrefilterResolver.cs
@@ -1,0 +1,317 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using MediaBrowser.Controller.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
+{
+    /// <summary>
+    /// Prefilter resolver for the people rule fields (People, Actors, Directors, ...).
+    ///
+    /// Two steps, preserving the per-item operator semantics exactly:
+    /// 1. Resolve which STORED person names the rule matches by evaluating the operator in
+    ///    memory (via the same <see cref="Engine"/> helpers the compiled rules bind) against
+    ///    a bulk name dump from the people table. This step is mandatory, not an
+    ///    optimization: the item query's Person clause is byte-exact case-sensitive on
+    ///    Jellyfin 10.11, so passing the user's raw rule value would silently under-match.
+    /// 2. One user-neutral GetItemIds(Person = exact stored name) query per matched name.
+    ///    The union over matched names is a guaranteed superset of the items whose people
+    ///    list satisfies the rule, because every name in an item's extracted people list
+    ///    also exists as a people-table row reachable through the same dump.
+    ///
+    /// Role handling differs per ABI:
+    /// - net10 (Jellyfin 12): the unrestricted people dump collapses to ONE arbitrary-typed
+    ///   row per name, so role-specific fields must push the role into the people query
+    ///   itself (InternalPeopleQuery.PersonTypes is translated BEFORE the collapse) and into
+    ///   the item query (Person + PersonTypes compose). Never role-filter the dump in memory.
+    /// - net9 (Jellyfin 10.11): the dump returns one row per (Name, Type), so the role
+    ///   filter runs in memory with the same Type.ToString() comparison CategorizePeople
+    ///   uses. PersonTypes is a silent no-op on 10.11 item queries, so the per-name item
+    ///   query is any-role there - a valid superset; role verification stays per-item.
+    ///
+    /// ActorRoles never rides: role strings live on the people map row and are not
+    /// filterable in either ABI. Negative operators are rejected centrally by
+    /// <see cref="CandidateSetBuilder"/> (SupportsNegativeOperators stays false).
+    /// </summary>
+    internal sealed class PeoplePrefilterResolver : IRulePrefilterResolver
+    {
+        /// <summary>
+        /// Above this many matched names the per-name queries stop being cheap (a rule like
+        /// Contains "a" can match most of the people table) - the rule then stays per-item.
+        /// </summary>
+        internal const int MaxMatchedNames = 200;
+
+        /// <summary>
+        /// Field name to people-map role, mirroring CategorizePeople's switch labels
+        /// verbatim - including "SoundEngineer" and "Penciler", which match no PersonKind
+        /// name ("Engineer"/"Penciller"): per-item extraction therefore always yields empty
+        /// lists for those two fields, and the prefilter must agree with that, not fix it.
+        /// "People" is role-agnostic (null). ActorRoles is deliberately absent.
+        /// </summary>
+        private static readonly Dictionary<string, string?> RoleByField = new(StringComparer.Ordinal)
+        {
+            ["People"] = null,
+            ["Actors"] = "Actor",
+            ["Directors"] = "Director",
+            ["Composers"] = "Composer",
+            ["Writers"] = "Writer",
+            ["GuestStars"] = "GuestStar",
+            ["Producers"] = "Producer",
+            ["Conductors"] = "Conductor",
+            ["Lyricists"] = "Lyricist",
+            ["Arrangers"] = "Arranger",
+            ["SoundEngineers"] = "SoundEngineer",
+            ["Mixers"] = "Mixer",
+            ["Remixers"] = "Remixer",
+            ["Creators"] = "Creator",
+            ["PersonArtists"] = "Artist",
+            ["PersonAlbumArtists"] = "AlbumArtist",
+            ["Authors"] = "Author",
+            ["Illustrators"] = "Illustrator",
+            ["Pencilers"] = "Penciler",
+            ["Inkers"] = "Inker",
+            ["Colorists"] = "Colorist",
+            ["Letterers"] = "Letterer",
+            ["CoverArtists"] = "CoverArtist",
+            ["Editors"] = "Editor",
+            ["Translators"] = "Translator",
+        };
+
+        /// <summary>
+        /// Per-role name dumps for this filter run (the resolver lives for one
+        /// CandidateSetBuilder.Build call). Key is the role, "" for role-agnostic.
+        /// </summary>
+        private readonly Dictionary<string, IReadOnlyList<string>?> _namesByRole = new(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Returns whether this resolver handles the given rule field.
+        /// </summary>
+        /// <param name="fieldName">The rule field name.</param>
+        /// <returns>True when the field is a people field this resolver can bound.</returns>
+        internal static bool HandlesField(string fieldName) => RoleByField.ContainsKey(fieldName);
+
+        /// <inheritdoc />
+        public HashSet<Guid>? Resolve(Expression expression, PrefilterContext context)
+        {
+            if (context.LibraryManager == null || !RoleByField.TryGetValue(expression.MemberName, out var role))
+            {
+                return null;
+            }
+
+            var storedNames = GetStoredNames(context, role);
+            if (storedNames == null)
+            {
+                return null;
+            }
+
+            var matched = ResolveMatchingNames(storedNames, expression.Operator, expression.TargetValue);
+            if (matched == null)
+            {
+                context.Logger?.LogDebug("People prefilter: rule {Field} {Operator} not pushdownable ({NameCount} stored names)",
+                    expression.MemberName, expression.Operator, storedNames.Count);
+                return null;
+            }
+
+            var stopwatch = Stopwatch.StartNew();
+            var result = new HashSet<Guid>();
+            foreach (var name in matched)
+            {
+                // User-neutral with grouping pinned off: the constructor default
+                // (GroupByPresentationUniqueKey = true) collapses alternate versions when a
+                // user is set and would drop pool items. Visibility is restored later by
+                // intersecting with the already user-scoped pool.
+                var query = new InternalItemsQuery
+                {
+                    Person = name,
+                    GroupByPresentationUniqueKey = false,
+                };
+#if NET10_0_OR_GREATER
+                // Jellyfin 12 composes Person + PersonTypes into an indexed role-specific
+                // lookup. On 10.11 PersonTypes is declared but never read by TranslateQuery,
+                // so the query stays any-role there (still a superset).
+                if (role != null)
+                {
+                    query.PersonTypes = [role];
+                }
+#endif
+                result.UnionWith(context.LibraryManager.GetItemIds(query));
+            }
+
+            context.Logger?.LogDebug("People prefilter: {Field} {Operator} matched {NameCount} names -> {ItemCount} candidate items in {Ms}ms",
+                expression.MemberName, expression.Operator, matched.Count, result.Count, stopwatch.ElapsedMilliseconds);
+            return result;
+        }
+
+        /// <summary>
+        /// Evaluates the rule operator against the stored names with the plugin's exact
+        /// per-item semantics (each name is tested as a single-element people list through
+        /// the same Engine helpers the compiled rules use).
+        /// </summary>
+        /// <param name="storedNames">Stored person names from the people-table dump.</param>
+        /// <param name="ruleOperator">The rule operator.</param>
+        /// <param name="targetValue">The rule target value.</param>
+        /// <returns>
+        /// The matched names, empty when no stored name satisfies the rule (a hard "nothing
+        /// matches" claim), or null when the rule cannot ride the prefilter (unsupported
+        /// operator, empty-matching or invalid regex, a matched whitespace-only name that
+        /// cannot be queried, or more than <see cref="MaxMatchedNames"/> matches).
+        /// </returns>
+        internal static List<string>? ResolveMatchingNames(IReadOnlyCollection<string> storedNames, string ruleOperator, string targetValue)
+        {
+            ArgumentNullException.ThrowIfNull(storedNames);
+
+            Func<string, bool> matches;
+            switch (ruleOperator)
+            {
+                case "Equal":
+                    matches = name => Engine.AnyItemEquals([name], targetValue);
+                    break;
+                case "Contains":
+                    matches = name => Engine.AnyItemContains([name], targetValue);
+                    break;
+                case "IsIn":
+                    matches = name => Engine.AnyItemIsInList([name], targetValue);
+                    break;
+                case "MatchRegex":
+                    try
+                    {
+                        // An empty people list is evaluated against "", so a pattern that
+                        // matches the empty string matches items with no people at all -
+                        // which no name-derived candidate set can bound.
+                        if (Regex.IsMatch(string.Empty, targetValue))
+                        {
+                            return null;
+                        }
+                    }
+                    catch (ArgumentException)
+                    {
+                        // Invalid pattern - the per-item path surfaces the error.
+                        return null;
+                    }
+
+                    matches = name => Engine.AnyRegexMatch([name], targetValue);
+                    break;
+                default:
+                    // Negative operators and anything unexpected stay per-item.
+                    return null;
+            }
+
+            var matched = new List<string>();
+            foreach (var name in storedNames)
+            {
+                if (string.IsNullOrEmpty(name))
+                {
+                    // Per-item extraction drops null/empty names, so they can never satisfy a rule.
+                    continue;
+                }
+
+                if (!matches(name))
+                {
+                    continue;
+                }
+
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    // TranslateQuery silently drops a whitespace Person clause (returning ALL
+                    // items), so a matched whitespace-only name cannot be queried - and
+                    // skipping just this name could drop a true match. Stay per-item.
+                    return null;
+                }
+
+                matched.Add(name);
+                if (matched.Count > MaxMatchedNames)
+                {
+                    return null;
+                }
+            }
+
+            return matched;
+        }
+
+        /// <summary>
+        /// Gets the stored person names for the given role (null = any role), cached for the
+        /// duration of this filter run. Returns null when the dump is unavailable.
+        /// </summary>
+        private IReadOnlyList<string>? GetStoredNames(PrefilterContext context, string? role)
+        {
+            var cacheKey = role ?? string.Empty;
+            if (_namesByRole.TryGetValue(cacheKey, out var cached))
+            {
+                return cached;
+            }
+
+#if NET10_0_OR_GREATER
+            // Jellyfin 12 collapses the unrestricted dump to one arbitrary-typed row per
+            // name, so role narrowing must happen inside the people query (PersonTypes is
+            // ctor-only there and translated before the collapse) - never in memory
+            // against the dump.
+            var query = role == null
+                ? new InternalPeopleQuery()
+                : new InternalPeopleQuery([role], []);
+
+            var names = DumpNames(context, query, roleFilter: null);
+#else
+            // Jellyfin 10.11 returns one row per (Name, Type): role-filter in memory with
+            // the same Type.ToString() comparison the per-item CategorizePeople switch uses.
+            // (PersonTypes narrowing in the people query is 12-only behavior.)
+            var names = DumpNames(context, new InternalPeopleQuery(), roleFilter: role);
+#endif
+            _namesByRole[cacheKey] = names;
+            return names;
+        }
+
+        /// <summary>
+        /// Runs the people dump through the reflected ABI-shared
+        /// ILibraryManager.GetPeople(InternalPeopleQuery) and collects distinct names.
+        /// Ordinal distinctness is deliberate: names differing only by case are distinct
+        /// stored rows and each needs its own byte-exact item query on 10.11.
+        /// </summary>
+        private static IReadOnlyList<string>? DumpNames(PrefilterContext context, InternalPeopleQuery query, string? roleFilter)
+        {
+            var getPeopleMethod = OperandFactory.GetPeopleQueryMethod(context.LibraryManager);
+            if (getPeopleMethod == null)
+            {
+                return null;
+            }
+
+            var result = getPeopleMethod.Invoke(context.LibraryManager, [query]);
+            if (result is not IEnumerable<object> rows)
+            {
+                return null;
+            }
+
+            var names = new HashSet<string>(StringComparer.Ordinal);
+            PropertyInfo? nameProperty = null;
+            PropertyInfo? typeProperty = null;
+            foreach (var row in rows)
+            {
+                if (row == null)
+                {
+                    continue;
+                }
+
+                nameProperty ??= row.GetType().GetProperty("Name");
+                if (nameProperty?.GetValue(row) is not string name || name.Length == 0)
+                {
+                    continue;
+                }
+
+                if (roleFilter != null)
+                {
+                    typeProperty ??= row.GetType().GetProperty("Type");
+                    if (!string.Equals(typeProperty?.GetValue(row)?.ToString(), roleFilter, StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+                }
+
+                names.Add(name);
+            }
+
+            return [.. names];
+        }
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/PrefilterContext.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/PrefilterContext.cs
@@ -63,7 +63,9 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
 
         /// <summary>
         /// Gets the already-fetched, user-scoped item pool for this filter run, or null when
-        /// pool-derived narrowing is unavailable. Only pool-scan resolvers (SeriesName) read it.
+        /// pool-derived narrowing is unavailable. Only pool-scan resolvers read it: SeriesName
+        /// (additionally gated on <see cref="SeriesNamesById"/>) and the LastEpisodeAirDate
+        /// Before/OlderThan complement.
         /// </summary>
         public IReadOnlyList<BaseItem>? PoolItems { get; init; }
 

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/PrefilterContext.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/PrefilterContext.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Jellyfin.Database.Implementations.Entities;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Persistence;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
@@ -81,5 +82,12 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
         /// null when unavailable (the SeriesName resolver then keeps every extra).
         /// </summary>
         public IReadOnlyDictionary<Guid, Guid>? ExtraOwnerSeriesIds { get; init; }
+
+        /// <summary>
+        /// Gets the item repository for ItemValues-backed name dumps (GetGenreNames,
+        /// GetStudioNames, ...), or null when unavailable - dump-dependent pushdowns
+        /// (Genres Contains/IsIn, all Studios operators) then stay per-item.
+        /// </summary>
+        public IItemRepository? ItemRepository { get; init; }
     }
 }

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/PrefilterContext.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/PrefilterContext.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using Jellyfin.Database.Implementations.Entities;
+using MediaBrowser.Controller.Library;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
+{
+    /// <summary>
+    /// Everything a rule prefilter resolver may need to run a candidate query.
+    /// Candidate queries are always separate <see cref="ILibraryManager"/> calls - resolvers
+    /// must never mutate the shared per-(user, mediaTypes) pool fetch or any drain-scoped
+    /// membership cache.
+    /// </summary>
+    internal sealed class PrefilterContext
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PrefilterContext"/> class.
+        /// </summary>
+        /// <param name="libraryManager">Library manager used for candidate queries.</param>
+        /// <param name="user">The list's user (see <see cref="User"/> for scoping rules).</param>
+        /// <param name="mediaTypes">The list's media types, or null when unrestricted.</param>
+        /// <param name="logger">Logger for diagnostics.</param>
+        public PrefilterContext(ILibraryManager libraryManager, User user, IReadOnlyList<string>? mediaTypes, ILogger? logger)
+        {
+            LibraryManager = libraryManager;
+            User = user;
+            MediaTypes = mediaTypes;
+            Logger = logger;
+        }
+
+        /// <summary>
+        /// Gets the library manager used for candidate queries.
+        /// </summary>
+        public ILibraryManager LibraryManager { get; }
+
+        /// <summary>
+        /// Gets the list's user. Candidate queries themselves must run USER-NEUTRAL with
+        /// GroupByPresentationUniqueKey = false (a user-scoped query collapses alternate
+        /// versions and would drop items); visibility is restored by intersecting with the
+        /// already user-scoped pool. The user is provided for resolvers that need the user id
+        /// to resolve user-specific rules (e.g. IsFavorite).
+        /// </summary>
+        public User User { get; }
+
+        /// <summary>
+        /// Gets the list's media types, or null when unrestricted.
+        /// </summary>
+        public IReadOnlyList<string>? MediaTypes { get; }
+
+        /// <summary>
+        /// Gets the logger for diagnostics.
+        /// </summary>
+        public ILogger? Logger { get; }
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/PrefilterContext.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/PrefilterContext.cs
@@ -55,6 +55,13 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
         public ILogger? Logger { get; }
 
         /// <summary>
+        /// Gets the user manager for resolving rule-referenced additional users, or null when
+        /// unavailable - user-specific resolvers (NextUnwatched) then only bound rules that
+        /// target the list's own user.
+        /// </summary>
+        public IUserManager? UserManager { get; init; }
+
+        /// <summary>
         /// Gets the already-fetched, user-scoped item pool for this filter run, or null when
         /// pool-derived narrowing is unavailable. Only pool-scan resolvers (SeriesName) read it.
         /// </summary>

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/PrefilterContext.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/PrefilterContext.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using Jellyfin.Database.Implementations.Entities;
+using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using Microsoft.Extensions.Logging;
 
@@ -51,5 +53,24 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
         /// Gets the logger for diagnostics.
         /// </summary>
         public ILogger? Logger { get; }
+
+        /// <summary>
+        /// Gets the already-fetched, user-scoped item pool for this filter run, or null when
+        /// pool-derived narrowing is unavailable. Only pool-scan resolvers (SeriesName) read it.
+        /// </summary>
+        public IReadOnlyList<BaseItem>? PoolItems { get; init; }
+
+        /// <summary>
+        /// Gets the bulk-warmed series-name dump (series id → name), or null when the warmup
+        /// did not run or failed - SeriesName narrowing is then disabled. Per-item evaluation
+        /// reads the SAME dictionary, which is what makes dump-based narrowing exact.
+        /// </summary>
+        public IReadOnlyDictionary<Guid, string>? SeriesNamesById { get; init; }
+
+        /// <summary>
+        /// Gets the extra id → owning-series id reverse map (built during media fetch), or
+        /// null when unavailable (the SeriesName resolver then keeps every extra).
+        /// </summary>
+        public IReadOnlyDictionary<Guid, Guid>? ExtraOwnerSeriesIds { get; init; }
     }
 }

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/PrefilterContext.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/PrefilterContext.cs
@@ -40,8 +40,9 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
         /// Gets the list's user. Candidate queries themselves must run USER-NEUTRAL with
         /// GroupByPresentationUniqueKey = false (a user-scoped query collapses alternate
         /// versions and would drop items); visibility is restored by intersecting with the
-        /// already user-scoped pool. The user is provided for resolvers that need the user id
-        /// to resolve user-specific rules (e.g. IsFavorite).
+        /// already user-scoped pool. The user is provided for resolvers that need it to
+        /// resolve user-specific rules (e.g. NextUnwatched, whose IsPlayed query is the one
+        /// mandated exception to user-neutrality).
         /// </summary>
         public User User { get; }
 

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/PrefilterStringMatcher.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/PrefilterStringMatcher.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
+{
+    /// <summary>
+    /// Shared operator-to-predicate mapping for resolvers that evaluate a rule in memory
+    /// against server-side string dumps (people names, stream language codes). Each dump
+    /// value is tested as a single-element list through the same <see cref="Engine"/>
+    /// helpers the compiled rules bind, so the per-item operator semantics are preserved
+    /// exactly.
+    /// </summary>
+    internal static class PrefilterStringMatcher
+    {
+        /// <summary>
+        /// The central MatchRegex pushdown gate: a pattern matching the empty string
+        /// matches items with an empty extracted list (empty-list semantics test against
+        /// ""), which no dump-derived candidate set can bound, and an invalid pattern is
+        /// left to the per-item path to surface.
+        /// </summary>
+        /// <param name="pattern">The rule's regex pattern.</param>
+        /// <returns>True when the pattern matches "" or does not compile.</returns>
+        internal static bool RegexMatchesEmptyOrIsInvalid(string pattern)
+        {
+            try
+            {
+                return Regex.IsMatch(string.Empty, pattern);
+            }
+            catch (ArgumentException)
+            {
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Builds the predicate a rule operator applies to a single dump value, or null
+        /// when the rule cannot ride a dump-based prefilter: negative operators and
+        /// anything unexpected stay per-item, as does MatchRegex when
+        /// <see cref="RegexMatchesEmptyOrIsInvalid"/> rejects the pattern.
+        /// </summary>
+        /// <param name="ruleOperator">The rule operator.</param>
+        /// <param name="targetValue">The rule target value.</param>
+        /// <returns>The per-value predicate, or null when the rule stays per-item.</returns>
+        internal static Func<string, bool>? TryBuildMatcher(string ruleOperator, string targetValue)
+        {
+            switch (ruleOperator)
+            {
+                case "Equal":
+                    return value => Engine.AnyItemEquals([value], targetValue);
+                case "Contains":
+                    return value => Engine.AnyItemContains([value], targetValue);
+                case "IsIn":
+                    return value => Engine.AnyItemIsInList([value], targetValue);
+                case "MatchRegex":
+                    if (RegexMatchesEmptyOrIsInvalid(targetValue))
+                    {
+                        return null;
+                    }
+
+                    return value => Engine.AnyRegexMatch([value], targetValue);
+                default:
+                    return null;
+            }
+        }
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/PrefilterValueCleaner.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/PrefilterValueCleaner.cs
@@ -1,0 +1,62 @@
+using System.Text;
+using Jellyfin.Extensions;
+
+namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
+{
+    /// <summary>
+    /// Normalization helpers for matching rule values against server-side name dumps.
+    ///
+    /// Background: the ItemValues-backed name dumps (GetGenreNames/GetStudioNames/...) hold
+    /// ONE representative raw variant per server-cleaned group (GetItemValueNames groups by
+    /// CleanValue and returns the first Value). Matching a rule against a representative
+    /// with the plugin's per-item semantics (OrdinalIgnoreCase on raw strings) would miss
+    /// groups whose OTHER variants match - a false negative. These helpers instead compare
+    /// on normalized forms whose granularity is chosen per use case relative to the two
+    /// server cleans (10.11: RemoveDiacritics + lowercase; Jellyfin 12: the same plus
+    /// punctuation stripping and whitespace collapsing).
+    /// </summary>
+    internal static class PrefilterValueCleaner
+    {
+        /// <summary>
+        /// The 10.11 server's GetCleanValue: RemoveDiacritics (the server's own
+        /// implementation, so character folding matches exactly) + ToLowerInvariant.
+        /// This is the FINEST clean either ABI applies to ItemValues - Jellyfin 12's
+        /// clean only removes more - so equality on this key implies equality of the
+        /// stored CleanValue on BOTH ABIs. That implication is what the studio
+        /// materialization coverage check relies on.
+        /// </summary>
+        /// <param name="value">The raw value.</param>
+        /// <returns>The cleaned value.</returns>
+        internal static string CleanValue(string value)
+        {
+            return value.RemoveDiacritics().ToLowerInvariant();
+        }
+
+        /// <summary>
+        /// <see cref="CleanValue"/> with every non-alphanumeric character removed. This is
+        /// COARSER than both ABIs' server cleans: any two raw variants the server stores
+        /// under one cleaned group normalize to the same string here (the extra steps of
+        /// either server clean only delete/collapse non-alphanumerics, never touch letters
+        /// or digits). Matching a rule against one dumped representative on this form can
+        /// therefore never miss a group whose other variant the per-item path would match.
+        /// The per-character mapping also preserves substring containment, so Contains/IsIn
+        /// matching stays a superset too. Extra matches only add candidates (harmless).
+        /// </summary>
+        /// <param name="value">The raw value.</param>
+        /// <returns>The normalized comparison form.</returns>
+        internal static string MatchNormalize(string value)
+        {
+            var cleaned = CleanValue(value);
+            var builder = new StringBuilder(cleaned.Length);
+            foreach (var c in cleaned)
+            {
+                if (char.IsLetterOrDigit(c))
+                {
+                    builder.Append(c);
+                }
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/ResolutionPrefilterResolver.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/ResolutionPrefilterResolver.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.SmartLists.Core.Constants;
+using MediaBrowser.Controller.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
+{
+    /// <summary>
+    /// Prefilter resolver for the Resolution rule field.
+    ///
+    /// The per-item path buckets EXCLUSIVELY on the max video-stream HEIGHT with
+    /// upper-inclusive boundaries (OperandFactory.ExtractResolution: &lt;=480 -> 480p,
+    /// &lt;=720 -> 720p, &lt;=1080 -> 1080p, &lt;=1440 -> 1440p, &lt;=2160 -> 4K, else 8K),
+    /// and the compiled rule compares bucket heights only after a validity gate that
+    /// requires a positive extracted height (Engine.BuildResolutionExpression). On the
+    /// height axis those buckets translate to exact MinHeight/MaxHeight windows against
+    /// the denormalized item-row Height - both ABIs translate Min/MaxHeight to indexed
+    /// SQL comparisons - so one GetItemIds range query replaces per-item stream
+    /// extraction over the whole pool. Width windows are deliberately NOT used: non-16:9
+    /// content (4:3, portrait) breaks any width window while the height axis stays exact.
+    ///
+    /// Operator mapping (bucket boundaries, upper-inclusive):
+    /// - Equal "X": (previous bucket height + 1) .. X's height (e.g. 1080p -> 721..1080).
+    /// - GreaterThan "X": X's height + 1, no upper bound.
+    /// - GreaterThanOrEqual "X": previous bucket height + 1, no upper bound.
+    /// - LessThan "X": no lower bound, up to the previous bucket height.
+    /// - LessThanOrEqual "X": no lower bound, up to X's height.
+    /// - Equal/GreaterThanOrEqual "8K" get NO MaxHeight: the bucketer maps every height
+    ///   above 2160 (including &gt; 4320) to "8K", so the top bucket is open-ended.
+    /// - LessThanOrEqual "8K" stays per-item for the same reason: it matches EVERY item
+    ///   with a valid resolution (all buckets compare &lt;= the top bucket), so no height
+    ///   window can bound it without dropping &gt;4320-height items that match per-item.
+    /// - NotEqual stays per-item (central negative-operator gate; the complement is not a
+    ///   single range and a pool-minus-window complement would inherit the divergence edge
+    ///   below in the unsafe direction).
+    ///
+    /// ACCEPTED DIVERGENCE EDGE (row-vs-streams, both operator directions): the SQL window
+    /// filters the denormalized row Width/Height while per-item extraction reads the media
+    /// streams, so an item whose row Height is NULL (unfilled dimensions) but whose streams
+    /// are readable - or a multi-video-stream file whose non-default stream is taller than
+    /// the default the row dims come from - can be dropped here yet classified per-item.
+    /// Rare in practice (both require the row dims to disagree with the streams table) and
+    /// accepted as a documented divergence per the spec.
+    ///
+    /// GATE: only applied when the list's media types are exclusively leaf video types
+    /// (Movie/Episode/Video/MusicVideo). Folder kinds (Series/Season/BoxSet) carry no row
+    /// Width/Height and the Min/Max filters do no descendant walk in either ABI, so a
+    /// folder pool would be shrunk to nothing - those pools skip the prefilter entirely.
+    /// Series items pulled into leaf pools by the Collections expansion, and extras, are
+    /// kept by the central prefilter exemptions regardless of this resolver's output.
+    ///
+    /// Query notes: user-neutral with GroupByPresentationUniqueKey pinned off (a user
+    /// collapses alternate versions and would drop pool items); visibility is restored by
+    /// intersecting with the already user-scoped pool. IncludeItemTypes narrows to the
+    /// pool's own leaf kinds - safe because every non-exempt pool item is of those kinds.
+    /// </summary>
+    internal sealed class ResolutionPrefilterResolver : IRulePrefilterResolver
+    {
+        /// <inheritdoc />
+        public HashSet<Guid>? Resolve(Expression expression, PrefilterContext context)
+        {
+            if (!string.Equals(expression.MemberName, "Resolution", StringComparison.Ordinal)
+                || context.LibraryManager == null
+                || !AppliesToMediaTypes(context.MediaTypes))
+            {
+                return null;
+            }
+
+            var window = TryBuildHeightWindow(expression.Operator, expression.TargetValue);
+            if (window == null)
+            {
+                return null;
+            }
+
+            var stopwatch = Stopwatch.StartNew();
+            var query = new InternalItemsQuery
+            {
+                IncludeItemTypes = MapToLeafVideoKinds(context.MediaTypes!),
+                MinHeight = window.MinHeight,
+                MaxHeight = window.MaxHeight,
+                Recursive = true,
+                GroupByPresentationUniqueKey = false,
+            };
+
+            var ids = context.LibraryManager.GetItemIds(query);
+
+            context.Logger?.LogDebug(
+                "Resolution prefilter: {Operator} '{Value}' -> height window [{Min}..{Max}] -> {Count} candidate items in {Ms}ms",
+                expression.Operator, expression.TargetValue, window.MinHeight, window.MaxHeight, ids.Count, stopwatch.ElapsedMilliseconds);
+
+            // Fresh set per call - the caller owns and mutates the result.
+            return [.. ids];
+        }
+
+        /// <summary>
+        /// Immutable height window an operator/value combination maps to. A null bound is
+        /// left unset on the query (no constraint in that direction).
+        /// </summary>
+        /// <param name="MinHeight">Inclusive lower bound, or null for none.</param>
+        /// <param name="MaxHeight">Inclusive upper bound, or null for none.</param>
+        internal sealed record HeightWindow(int? MinHeight, int? MaxHeight);
+
+        /// <summary>
+        /// Maps an operator/value combination to its exact bucket-boundary height window,
+        /// or null when the rule stays per-item (NotEqual, LessThanOrEqual on the top
+        /// bucket, an operator the whitelist rejects, or a value the compiled rule would
+        /// reject). Value lookup mirrors the Engine exactly: ordinal match against
+        /// <see cref="ResolutionTypes.AllResolutions"/>.
+        /// </summary>
+        /// <param name="ruleOperator">The rule operator.</param>
+        /// <param name="targetValue">The rule target value (e.g. "1080p").</param>
+        /// <returns>The height window, or null when the rule stays per-item.</returns>
+        internal static HeightWindow? TryBuildHeightWindow(string? ruleOperator, string? targetValue)
+        {
+            var target = ResolutionTypes.GetByValue(targetValue ?? string.Empty);
+            if (target == null)
+            {
+                return null;
+            }
+
+            var previousBucketHeight = PreviousBucketHeight(target.Height);
+            var isTopBucket = target.Height == TopBucketHeight();
+
+            switch (ruleOperator)
+            {
+                case "Equal":
+                    return new HeightWindow(previousBucketHeight + 1, isTopBucket ? null : target.Height);
+
+                case "GreaterThan":
+                    return new HeightWindow(target.Height + 1, null);
+
+                case "GreaterThanOrEqual":
+                    return new HeightWindow(previousBucketHeight + 1, null);
+
+                case "LessThan":
+                    return new HeightWindow(null, previousBucketHeight);
+
+                case "LessThanOrEqual":
+                    // The top bucket is open-ended above; see the class doc.
+                    return isTopBucket ? null : new HeightWindow(null, target.Height);
+
+                default:
+                    // NotEqual and anything else is not a riding resolution operator.
+                    // Operator comparison is Ordinal, mirroring the engine switch.
+                    return null;
+            }
+        }
+
+        /// <summary>
+        /// Gates the prefilter on pools whose media types are exclusively leaf video types
+        /// (Movie/Episode/Video/MusicVideo). Null or empty means unrestricted - skip.
+        /// </summary>
+        /// <param name="mediaTypes">The list's media types.</param>
+        /// <returns>True when every media type is a leaf video type.</returns>
+        internal static bool AppliesToMediaTypes(IReadOnlyList<string>? mediaTypes)
+        {
+            if (mediaTypes == null || mediaTypes.Count == 0)
+            {
+                return false;
+            }
+
+            foreach (var mediaType in mediaTypes)
+            {
+                if (mediaType == null || !MediaTypes.VideoStreamCapableSet.Contains(mediaType))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Maps the (already gate-checked) leaf video media types to their query kinds.
+        /// </summary>
+        private static BaseItemKind[] MapToLeafVideoKinds(IReadOnlyList<string> mediaTypes)
+        {
+            var kinds = new HashSet<BaseItemKind>();
+            foreach (var mediaType in mediaTypes)
+            {
+                if (MediaTypes.MediaTypeToBaseItemKind.TryGetValue(mediaType, out var kind))
+                {
+                    kinds.Add(kind);
+                }
+            }
+
+            return [.. kinds];
+        }
+
+        /// <summary>
+        /// The largest bucket height strictly below the target, or 0 for the lowest bucket
+        /// (480p windows then start at height 1, matching the compiled rule's positive-
+        /// height validity gate).
+        /// </summary>
+        private static int PreviousBucketHeight(int targetHeight)
+        {
+            var previous = 0;
+            foreach (var info in ResolutionTypes.AllResolutions)
+            {
+                if (info.Height < targetHeight && info.Height > previous)
+                {
+                    previous = info.Height;
+                }
+            }
+
+            return previous;
+        }
+
+        /// <summary>
+        /// The top bucket's height (the bucketer maps everything above the second-highest
+        /// boundary into this bucket, so it is open-ended above).
+        /// </summary>
+        private static int TopBucketHeight()
+        {
+            var top = 0;
+            foreach (var info in ResolutionTypes.AllResolutions)
+            {
+                if (info.Height > top)
+                {
+                    top = info.Height;
+                }
+            }
+
+            return top;
+        }
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/ResolutionPrefilterResolver.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/ResolutionPrefilterResolver.cs
@@ -75,10 +75,16 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
                 return null;
             }
 
+            var kinds = MapToLeafVideoKinds(context.MediaTypes!);
+            if (kinds == null)
+            {
+                return null;
+            }
+
             var stopwatch = Stopwatch.StartNew();
             var query = new InternalItemsQuery
             {
-                IncludeItemTypes = MapToLeafVideoKinds(context.MediaTypes!),
+                IncludeItemTypes = kinds,
                 MinHeight = window.MinHeight,
                 MaxHeight = window.MaxHeight,
                 Recursive = true,
@@ -175,19 +181,24 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
 
         /// <summary>
         /// Maps the (already gate-checked) leaf video media types to their query kinds.
+        /// Null when any media type has no kind mapping: a partially mapped list would
+        /// narrow the query below the pool (false negatives), and an empty kinds array
+        /// would apply no type filter at all.
         /// </summary>
-        private static BaseItemKind[] MapToLeafVideoKinds(IReadOnlyList<string> mediaTypes)
+        private static BaseItemKind[]? MapToLeafVideoKinds(IReadOnlyList<string> mediaTypes)
         {
             var kinds = new HashSet<BaseItemKind>();
             foreach (var mediaType in mediaTypes)
             {
-                if (MediaTypes.MediaTypeToBaseItemKind.TryGetValue(mediaType, out var kind))
+                if (!MediaTypes.MediaTypeToBaseItemKind.TryGetValue(mediaType, out var kind))
                 {
-                    kinds.Add(kind);
+                    return null;
                 }
+
+                kinds.Add(kind);
             }
 
-            return [.. kinds];
+            return kinds.Count == 0 ? null : [.. kinds];
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/SeriesNamePrefilterResolver.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/SeriesNamePrefilterResolver.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
+{
+    /// <summary>
+    /// Prefilter resolver for the SeriesName rule field.
+    ///
+    /// Unlike the DB-query resolvers, this one runs entirely in memory against the bulk-warmed
+    /// series-name dump (OperandFactory.WarmSeriesNameCache) and the already-fetched item pool -
+    /// zero extra queries:
+    /// 1. The rule is compiled through Engine.CompileRule - the exact single-rule compilation
+    ///    the per-item path uses - and evaluated against every dumped series name, yielding the
+    ///    matching series ids plus whether the rule matches "".
+    /// 2. Pool items are then classified through the SAME resolution order ExtractSeriesName
+    ///    uses: Episode.SeriesId first, then the extras owner map (gated on being an extra),
+    ///    else SeriesName "".
+    ///
+    /// Negative operators ride (<see cref="SupportsNegativeOperators"/> is true): per-item
+    /// evaluation reads the very same cache entries the dump populated, so the complement is
+    /// exact rather than approximated. Items whose series is NOT in the dump are always kept -
+    /// the per-miss GetItemById fallback then decides per item. MatchRegex patterns matching ""
+    /// are rejected centrally by CandidateSetBuilder before this resolver is consulted; the
+    /// matchesEmpty inclusion below covers the remaining empty-matching operators (NotEqual,
+    /// NotContains, IsNotIn) for seriesless pool items (movies, Series themselves, episodes
+    /// without a usable SeriesId).
+    ///
+    /// Narrowing only happens when the context carries PoolItems + SeriesNamesById (SmartList
+    /// sets them only after a successful warmup); otherwise the rule stays per-item.
+    /// </summary>
+    internal sealed class SeriesNamePrefilterResolver : IRulePrefilterResolver
+    {
+        /// <inheritdoc />
+        public bool SupportsNegativeOperators => true;
+
+        /// <inheritdoc />
+        public HashSet<Guid>? Resolve(Expression expression, PrefilterContext context)
+        {
+            if (!string.Equals(expression.MemberName, "SeriesName", StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            var pool = context.PoolItems;
+            var seriesNames = context.SeriesNamesById;
+            if (pool == null || seriesNames == null)
+            {
+                return null;
+            }
+
+            var stopwatch = Stopwatch.StartNew();
+
+            // Exact by construction: the same single-rule compilation the compiled rule sets
+            // go through, evaluated against an operand carrying only SeriesName.
+            var rule = Engine.CompileRule<Operand>(expression, context.User?.Id.ToString("N") ?? string.Empty, context.Logger);
+            var probe = new Operand(string.Empty);
+            bool Matches(string seriesName)
+            {
+                probe.SeriesName = seriesName;
+                return rule(probe);
+            }
+
+            var matchingSeriesIds = new HashSet<Guid>();
+            foreach (var entry in seriesNames)
+            {
+                if (Matches(entry.Value))
+                {
+                    matchingSeriesIds.Add(entry.Key);
+                }
+            }
+
+            var matchesEmpty = Matches(string.Empty);
+
+            var extraOwners = context.ExtraOwnerSeriesIds;
+            var result = new HashSet<Guid>();
+            foreach (var item in pool)
+            {
+                if (item == null)
+                {
+                    continue;
+                }
+
+                if (OperandFactory.TryGetEpisodeSeriesGuid(item, out var seriesId))
+                {
+                    // A dumped series resolves per item to exactly the cached name; a series
+                    // missing from the dump is unknown and must be kept for the GetItemById
+                    // fallback to decide.
+                    if (matchingSeriesIds.Contains(seriesId) || !seriesNames.ContainsKey(seriesId))
+                    {
+                        result.Add(item.Id);
+                    }
+                }
+                else if (OperandFactory.IsExtra(item))
+                {
+                    // Same gate as extraction (ExtraType non-empty): the owner map decides;
+                    // an unmapped extra keeps SeriesName "". Without a map, keep every extra
+                    // (the consumption-side exemption keeps them regardless).
+                    if (extraOwners == null)
+                    {
+                        result.Add(item.Id);
+                    }
+                    else if (extraOwners.TryGetValue(item.Id, out var ownerSeriesId))
+                    {
+                        if (matchingSeriesIds.Contains(ownerSeriesId) || !seriesNames.ContainsKey(ownerSeriesId))
+                        {
+                            result.Add(item.Id);
+                        }
+                    }
+                    else if (matchesEmpty)
+                    {
+                        result.Add(item.Id);
+                    }
+                }
+                else if (matchesEmpty)
+                {
+                    // Seriesless pool items evaluate SeriesName "".
+                    result.Add(item.Id);
+                }
+            }
+
+            context.Logger?.LogDebug(
+                "SeriesName prefilter: {Operator} '{Value}' matched {SeriesCount}/{DumpCount} series (empty match: {MatchesEmpty}) -> {ItemCount}/{PoolCount} candidate items in {Ms}ms",
+                expression.Operator, expression.TargetValue, matchingSeriesIds.Count, seriesNames.Count, matchesEmpty, result.Count, pool.Count, stopwatch.ElapsedMilliseconds);
+
+            return result;
+        }
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/SeriesNamePrefilterResolver.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/SeriesNamePrefilterResolver.cs
@@ -28,7 +28,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
     /// without a usable SeriesId).
     ///
     /// Narrowing only happens when the context carries PoolItems + SeriesNamesById (SmartList
-    /// sets them only after a successful warmup); otherwise the rule stays per-item.
+    /// sets the dump only after a successful warmup); otherwise the rule stays per-item.
     /// </summary>
     internal sealed class SeriesNamePrefilterResolver : IRulePrefilterResolver
     {

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/StreamLanguagePrefilterResolver.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/StreamLanguagePrefilterResolver.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+#if NET10_0_OR_GREATER
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Model.Entities;
+#endif
+
+namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
+{
+    /// <summary>
+    /// Prefilter resolver for the AudioLanguages and SubtitleLanguages rule fields,
+    /// Jellyfin 12 only.
+    ///
+    /// Two steps, preserving the per-item operator semantics exactly:
+    /// 1. Dump the distinct STORED language codes for the stream kind via
+    ///    ILibraryManager.GetMediaStreamLanguages (one query), then decide which of them the
+    ///    rule matches by evaluating the operator in memory - against each code's
+    ///    ISO 639-2 B-to-T NORMALIZED form, because that is what per-item extraction sees:
+    ///    the server's stream read path (MediaStreamRepository.Map) rewrites stored B codes
+    ///    to T codes through ILocalizationManager.TryGetISO6392TFromB, so a track stored as
+    ///    'ger' (the Matroska norm) reaches the plugin as 'deu'. Matching the raw dump
+    ///    instead would systematically drop B-code libraries (rule "Equal deu" would find no
+    ///    raw code and claim nothing matches - a false negative on common real-world data).
+    /// 2. One user-neutral GetItemIds query with the matched RAW codes in
+    ///    InternalItemsQuery.AudioLanguages/SubtitleLanguages - RAW because the query's
+    ///    EXISTS over MediaStreamInfos compares the stored Language column byte-exact, and
+    ///    the raw dump codes come verbatim from that column. Total: 2 queries per rule.
+    ///
+    /// Superset proof: every language code per-item extraction can produce for any item is
+    /// the normalized form of some stored code, and every stored code is in the dump. An
+    /// item satisfying the rule therefore carries a stream whose raw code is in the matched
+    /// set, and the EXISTS query returns it. The reverse direction over-matches only
+    /// (harmless false positives): the server treats 'und' in the positive filter as also
+    /// matching null/empty stored languages, which per-item extraction skips, and the
+    /// filter is folder-aware (a Series/BoxSet with matching descendants can enter the
+    /// candidate set) while per-item extraction of folders yields empty lists. Rules with
+    /// OnlyDefaultAudioLanguage ride safely for the same reason: default-stream languages
+    /// are a subset of all audio-stream languages, so the any-stream candidate set is a
+    /// superset and default-ness stays verified per-item.
+    ///
+    /// Jellyfin 10.11 (net9.0) contributes no candidates: there is no positive language
+    /// filter there, and the double-negation route over HasNo*TrackWithLanguage has
+    /// verified false-negative traps (the server silently DROPS the filter when it cannot
+    /// resolve the code - collapsing pool-minus-result to an empty candidate set - and its
+    /// SQL IN over stored codes is case-sensitive where the plugin compare is not). Those
+    /// rules simply stay per-item on 10.11.
+    ///
+    /// Negative operators are rejected centrally by <see cref="CandidateSetBuilder"/>
+    /// (SupportsNegativeOperators stays false); MatchRegex patterns matching the empty
+    /// string are rejected both centrally and here (empty stream lists test against "").
+    /// </summary>
+    internal sealed class StreamLanguagePrefilterResolver : IRulePrefilterResolver
+    {
+        /// <summary>
+        /// Mirror of ILocalizationManager.TryGetISO6392TFromB, injectable so the pure
+        /// matching step is testable against a fake B-to-T mapping.
+        /// </summary>
+        /// <param name="rawCode">The raw stored language code.</param>
+        /// <param name="normalized">The ISO 639-2/T form when the code is a known B code.</param>
+        /// <returns>True when the code was a B code with a T mapping.</returns>
+        internal delegate bool TryNormalizeLanguage(string rawCode, out string? normalized);
+
+        /// <inheritdoc />
+        public HashSet<Guid>? Resolve(Expression expression, PrefilterContext context)
+        {
+#if NET10_0_OR_GREATER
+            var isAudio = string.Equals(expression.MemberName, "AudioLanguages", StringComparison.Ordinal);
+            if ((!isAudio && !string.Equals(expression.MemberName, "SubtitleLanguages", StringComparison.Ordinal))
+                || context.LibraryManager == null)
+            {
+                return null;
+            }
+
+            // The server-populated BaseItem static is the same instance MediaStreamRepository
+            // normalizes with on the read path. Without it the B-to-T step cannot run, and
+            // matching raw codes instead would under-match - so the rule stays per-item.
+            var localization = BaseItem.LocalizationManager;
+            if (localization == null)
+            {
+                return null;
+            }
+
+            var streamType = isAudio ? MediaStreamType.Audio : MediaStreamType.Subtitle;
+            var rawCodes = GetDump(context, streamType);
+            if (rawCodes == null)
+            {
+                return null;
+            }
+
+            var matched = ResolveMatchingRawCodes(rawCodes, expression.Operator, expression.TargetValue,
+                localization.TryGetISO6392TFromB);
+            if (matched == null)
+            {
+                context.Logger?.LogDebug("Stream language prefilter: rule {Field} {Operator} not pushdownable ({CodeCount} stored codes)",
+                    expression.MemberName, expression.Operator, rawCodes.Count);
+                return null;
+            }
+
+            if (matched.Count == 0)
+            {
+                // No stored code's normalized form satisfies the rule, so no item can - and an
+                // empty ItemIds-style list must never reach the query (it would fail OPEN).
+                context.Logger?.LogDebug("Stream language prefilter: {Field} {Operator} '{Value}' matches no stored language code",
+                    expression.MemberName, expression.Operator, expression.TargetValue);
+                return [];
+            }
+
+            var stopwatch = Stopwatch.StartNew();
+
+            // User-neutral with grouping pinned off: the constructor default
+            // (GroupByPresentationUniqueKey = true) collapses alternate versions when a user
+            // is set and would drop pool items. Visibility is restored later by intersecting
+            // with the already user-scoped pool.
+            var query = new InternalItemsQuery
+            {
+                GroupByPresentationUniqueKey = false,
+            };
+            if (isAudio)
+            {
+                query.AudioLanguages = matched;
+            }
+            else
+            {
+                query.SubtitleLanguages = matched;
+            }
+
+            var ids = context.LibraryManager.GetItemIds(query);
+
+            context.Logger?.LogDebug("Stream language prefilter: {Field} {Operator} matched {CodeCount} raw codes -> {ItemCount} candidate items in {Ms}ms",
+                expression.MemberName, expression.Operator, matched.Count, ids.Count, stopwatch.ElapsedMilliseconds);
+
+            // Fresh set per call - the caller owns and mutates the result.
+            return [.. ids];
+#else
+            // Jellyfin 10.11: no positive language filter; the double-negation route has
+            // verified false-negative traps (see the class doc). Always per-item.
+            return null;
+#endif
+        }
+
+        /// <summary>
+        /// Evaluates the rule operator against each raw dump code's B-to-T normalized form
+        /// with the plugin's exact per-item semantics (each code is tested as a
+        /// single-element list through the same Engine helpers the compiled rules bind),
+        /// returning the RAW codes whose normalized form matches.
+        /// </summary>
+        /// <param name="rawCodes">Distinct raw stored codes from the stream-language dump.</param>
+        /// <param name="ruleOperator">The rule operator.</param>
+        /// <param name="targetValue">The rule target value.</param>
+        /// <param name="tryNormalize">The B-to-T normalization the read path applies.</param>
+        /// <returns>
+        /// The matched raw codes, empty when no stored code satisfies the rule (a hard
+        /// "nothing matches" claim), or null when the rule cannot ride the prefilter
+        /// (unsupported operator, or an empty-matching or invalid regex).
+        /// </returns>
+        internal static List<string>? ResolveMatchingRawCodes(IReadOnlyCollection<string> rawCodes, string ruleOperator, string targetValue, TryNormalizeLanguage tryNormalize)
+        {
+            ArgumentNullException.ThrowIfNull(rawCodes);
+            ArgumentNullException.ThrowIfNull(tryNormalize);
+
+            Func<string, bool> matches;
+            switch (ruleOperator)
+            {
+                case "Equal":
+                    matches = code => Engine.AnyItemEquals([code], targetValue);
+                    break;
+                case "Contains":
+                    matches = code => Engine.AnyItemContains([code], targetValue);
+                    break;
+                case "IsIn":
+                    matches = code => Engine.AnyItemIsInList([code], targetValue);
+                    break;
+                case "MatchRegex":
+                    try
+                    {
+                        // An empty stream-language list is evaluated against "", so a pattern
+                        // that matches the empty string matches items with no such streams at
+                        // all - which no code-derived candidate set can bound.
+                        if (Regex.IsMatch(string.Empty, targetValue))
+                        {
+                            return null;
+                        }
+                    }
+                    catch (ArgumentException)
+                    {
+                        // Invalid pattern - the per-item path surfaces the error.
+                        return null;
+                    }
+
+                    matches = code => Engine.AnyRegexMatch([code], targetValue);
+                    break;
+                default:
+                    // Negative operators and anything unexpected stay per-item.
+                    return null;
+            }
+
+            var matched = new List<string>();
+            foreach (var rawCode in rawCodes)
+            {
+                if (string.IsNullOrEmpty(rawCode))
+                {
+                    // The dump maps null/empty stored languages to 'und', and per-item
+                    // extraction drops them - an empty code can never satisfy a rule.
+                    continue;
+                }
+
+                // Per-item extraction sees the T form of stored B codes (read-path Map);
+                // unmapped codes pass through raw there and here alike.
+                var normalized = tryNormalize(rawCode, out var isoT) && !string.IsNullOrEmpty(isoT) ? isoT : rawCode;
+                if (matches(normalized))
+                {
+                    matched.Add(rawCode);
+                }
+            }
+
+            return matched;
+        }
+
+#if NET10_0_OR_GREATER
+        /// <summary>
+        /// Per-stream-kind raw code dumps for this filter run (the resolver lives for one
+        /// CandidateSetBuilder.Build call); null when the dump failed, so a failure is not
+        /// retried per rule.
+        /// </summary>
+        private readonly Dictionary<MediaStreamType, IReadOnlyList<string>?> _dumpByType = new();
+
+        /// <summary>
+        /// Gets the distinct raw stored language codes for the stream kind, cached for the
+        /// duration of this filter run. Returns null when the dump is unavailable.
+        /// </summary>
+        private IReadOnlyList<string>? GetDump(PrefilterContext context, MediaStreamType streamType)
+        {
+            if (_dumpByType.TryGetValue(streamType, out var cached))
+            {
+                return cached;
+            }
+
+            IReadOnlyList<string>? codes;
+            try
+            {
+                codes = context.LibraryManager.GetMediaStreamLanguages(streamType);
+            }
+            catch (Exception ex)
+            {
+                context.Logger?.LogDebug(ex, "Stream language prefilter: {StreamType} language dump failed; rules stay per-item", streamType);
+                codes = null;
+            }
+
+            _dumpByType[streamType] = codes;
+            return codes;
+        }
+#endif
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/StreamLanguagePrefilterResolver.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/StreamLanguagePrefilterResolver.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 #if NET10_0_OR_GREATER
 using MediaBrowser.Controller.Entities;
@@ -161,40 +160,10 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
             ArgumentNullException.ThrowIfNull(rawCodes);
             ArgumentNullException.ThrowIfNull(tryNormalize);
 
-            Func<string, bool> matches;
-            switch (ruleOperator)
+            var matches = PrefilterStringMatcher.TryBuildMatcher(ruleOperator, targetValue);
+            if (matches == null)
             {
-                case "Equal":
-                    matches = code => Engine.AnyItemEquals([code], targetValue);
-                    break;
-                case "Contains":
-                    matches = code => Engine.AnyItemContains([code], targetValue);
-                    break;
-                case "IsIn":
-                    matches = code => Engine.AnyItemIsInList([code], targetValue);
-                    break;
-                case "MatchRegex":
-                    try
-                    {
-                        // An empty stream-language list is evaluated against "", so a pattern
-                        // that matches the empty string matches items with no such streams at
-                        // all - which no code-derived candidate set can bound.
-                        if (Regex.IsMatch(string.Empty, targetValue))
-                        {
-                            return null;
-                        }
-                    }
-                    catch (ArgumentException)
-                    {
-                        // Invalid pattern - the per-item path surfaces the error.
-                        return null;
-                    }
-
-                    matches = code => Engine.AnyRegexMatch([code], targetValue);
-                    break;
-                default:
-                    // Negative operators and anything unexpected stay per-item.
-                    return null;
+                return null;
             }
 
             var matched = new List<string>();

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -2983,7 +2983,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
         /// Series must survive whenever Collections rules are present so the
         /// DoesSeriesMatchCollectionsRules bypass can still see them.
         /// </summary>
-        private List<BaseItem> FilterByCandidateSet(IEnumerable<BaseItem> items, HashSet<Guid> candidateSet, ILogger? logger, string phase)
+        internal List<BaseItem> FilterByCandidateSet(IEnumerable<BaseItem> items, HashSet<Guid> candidateSet, ILogger? logger, string phase)
         {
             var input = items as ICollection<BaseItem> ?? items.ToList();
             var kept = new List<BaseItem>(Math.Min(input.Count, candidateSet.Count + 8));

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -1071,6 +1071,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                         candidateSet = CandidateSetBuilder.CreateDefault()
                             .Build(ExpressionSets, new PrefilterContext(libraryManager, user, MediaTypes, logger)
                             {
+                                UserManager = UserManager,
                                 PoolItems = seriesDumpComplete ? itemsArray : null,
                                 SeriesNamesById = seriesDumpComplete ? refreshCache.SeriesNameById : null,
                                 ExtraOwnerSeriesIds = seriesDumpComplete ? refreshCache.ExtraOwnerSeriesId : null,

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -1072,7 +1072,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                             .Build(ExpressionSets, new PrefilterContext(libraryManager, user, MediaTypes, logger)
                             {
                                 UserManager = UserManager,
-                                PoolItems = seriesDumpComplete ? itemsArray : null,
+                                PoolItems = itemsArray,
                                 SeriesNamesById = seriesDumpComplete ? refreshCache.SeriesNameById : null,
                                 ExtraOwnerSeriesIds = seriesDumpComplete ? refreshCache.ExtraOwnerSeriesId : null,
                             });

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -42,6 +42,10 @@ namespace Jellyfin.Plugin.SmartLists.Core
         // UserManager for resolving user-specific queries (Jellyfin 10.11+)
         public IUserManager UserManager { get; set; } = null!;
 
+        // Item repository for the DB prefilter's ItemValues-backed name dumps; optional -
+        // dump-dependent pushdowns degrade conservatively (stay per-item) when absent.
+        public MediaBrowser.Controller.Persistence.IItemRepository? ItemRepository { get; set; }
+
         // Similarity scores for sorting (populated during filtering when SimilarTo rules are active)
         private readonly ConcurrentDictionary<Guid, float> _similarityScores = new();
 
@@ -65,7 +69,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 && !IsParentAwareListExpression(expr);
         }
 
-        private static bool IsParentAwareListExpression(Expression expr)
+        internal static bool IsParentAwareListExpression(Expression expr)
         {
             return (expr.MemberName == "Tags" && (expr.IncludeParentTagsEffective || expr.OnlyParentTags == true)) ||
                    (expr.MemberName == "Studios" && (expr.IncludeParentStudiosEffective || expr.OnlyParentStudios == true)) ||
@@ -1072,6 +1076,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                             .Build(ExpressionSets, new PrefilterContext(libraryManager, user, MediaTypes, logger)
                             {
                                 UserManager = UserManager,
+                                ItemRepository = ItemRepository,
                                 PoolItems = itemsArray,
                                 SeriesNamesById = seriesDumpComplete ? refreshCache.SeriesNameById : null,
                                 ExtraOwnerSeriesIds = seriesDumpComplete ? refreshCache.ExtraOwnerSeriesId : null,

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -2987,6 +2987,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
         {
             var input = items as ICollection<BaseItem> ?? items.ToList();
             var kept = new List<BaseItem>(Math.Min(input.Count, candidateSet.Count + 8));
+            var hasCollectionsRules = HasCollectionsRules();
 
             foreach (var item in input)
             {
@@ -2995,7 +2996,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                     continue;
                 }
 
-                if (candidateSet.Contains(item.Id) || IsPrefilterExempt(item))
+                if (candidateSet.Contains(item.Id) || IsPrefilterExempt(item, hasCollectionsRules))
                 {
                     kept.Add(item);
                 }
@@ -3008,7 +3009,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
         /// <summary>
         /// Items a prefilter must never shrink away, per the safety contract.
         /// </summary>
-        private bool IsPrefilterExempt(BaseItem item)
+        private static bool IsPrefilterExempt(BaseItem item, bool hasCollectionsRules)
         {
             // Extras are pulled via GetExtras() on their owners (LibraryManagerHelper.FetchExtras);
             // a candidate query over the main library never returns them.
@@ -3019,7 +3020,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
 
             // Series-under-Collections bypass: deliberately broader than
             // ShouldExpandEpisodesForCollections - keeping too much is always safe.
-            if (item is Series && HasCollectionsRules())
+            if (item is Series && hasCollectionsRules)
             {
                 return true;
             }

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -10,6 +10,7 @@ using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.SmartLists.Core.Models;
 using Jellyfin.Plugin.SmartLists.Core.Orders;
 using Jellyfin.Plugin.SmartLists.Core.QueryEngine;
+using Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters;
 using Jellyfin.Plugin.SmartLists.Services.ExternalList;
 using Jellyfin.Plugin.SmartLists.Services.Shared;
 using Jellyfin.Plugin.SmartLists.Utilities;
@@ -1051,6 +1052,25 @@ namespace Jellyfin.Plugin.SmartLists.Core
                     hasNonExpensiveRules = true; // Conservative assumption,
                 }
 
+                // Build the DB-backed candidate set ONCE per filter run (never per chunk).
+                // Null = no shrink possible; both expensive-field paths then behave exactly as
+                // before. Only those paths consume it - ProcessItemsSimple stays untouched -
+                // so building is skipped entirely when no expensive fields are required.
+                HashSet<Guid>? candidateSet = null;
+                if ((fieldReqs.RequiredGroups & ~FieldRegistry.CheapExtractionGroups) != ExtractionGroup.None)
+                {
+                    try
+                    {
+                        candidateSet = CandidateSetBuilder.CreateDefault()
+                            .Build(ExpressionSets, new PrefilterContext(libraryManager, user, MediaTypes, logger));
+                    }
+                    catch (Exception ex)
+                    {
+                        logger?.LogWarning(ex, "Prefilter candidate set build failed for playlist '{PlaylistName}'. Continuing without prefilter.", Name);
+                        candidateSet = null;
+                    }
+                }
+
                 // Build reference metadata once for SimilarTo queries (before chunking to avoid rebuilding per chunk)
                 OperandFactory.ReferenceMetadata? referenceMetadata = null;
                 if (fieldReqs.NeedsSimilarTo)
@@ -1101,7 +1121,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
 
                         // Process chunk
                         var chunkResults = ProcessItemChunk(chunk, libraryManager, user, userDataManager, logger,
-                            fieldReqs, referenceMetadata, similarityComparisonFields, compiledRules, hasAnyRules, hasNonExpensiveRules, refreshCache);
+                            fieldReqs, referenceMetadata, similarityComparisonFields, compiledRules, hasAnyRules, hasNonExpensiveRules, candidateSet, refreshCache);
                         results.AddRange(chunkResults);
                         
                         // Report progress after chunk is complete
@@ -2938,9 +2958,65 @@ namespace Jellyfin.Plugin.SmartLists.Core
             return limitedItems;
         }
 
+        /// <summary>
+        /// Intersects a phase's input pool with the DB-backed candidate set. Exempt items are
+        /// always kept regardless of the candidate set: extras never appear in candidate
+        /// queries (they enter pools via the owner chain, not the main library query), and
+        /// Series must survive whenever Collections rules are present so the
+        /// DoesSeriesMatchCollectionsRules bypass can still see them.
+        /// </summary>
+        private List<BaseItem> FilterByCandidateSet(IEnumerable<BaseItem> items, HashSet<Guid> candidateSet, ILogger? logger, string phase)
+        {
+            var input = items as ICollection<BaseItem> ?? items.ToList();
+            var kept = new List<BaseItem>(Math.Min(input.Count, candidateSet.Count + 8));
+
+            foreach (var item in input)
+            {
+                if (item == null)
+                {
+                    continue;
+                }
+
+                if (candidateSet.Contains(item.Id) || IsPrefilterExempt(item))
+                {
+                    kept.Add(item);
+                }
+            }
+
+            logger?.LogDebug("Prefilter shrank {Phase} pool {From} -> {To} items", phase, input.Count, kept.Count);
+            return kept;
+        }
+
+        /// <summary>
+        /// Items a prefilter must never shrink away, per the safety contract.
+        /// </summary>
+        private bool IsPrefilterExempt(BaseItem item)
+        {
+            // Extras are pulled via GetExtras() on their owners (LibraryManagerHelper.FetchExtras);
+            // a candidate query over the main library never returns them.
+            if (OperandFactory.IsExtra(item))
+            {
+                return true;
+            }
+
+            // Series-under-Collections bypass: deliberately broader than
+            // ShouldExpandEpisodesForCollections - keeping too much is always safe.
+            if (item is Series && HasCollectionsRules())
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool HasCollectionsRules()
+        {
+            return ExpressionSets?.Any(set => set?.Expressions?.Any(expr => expr?.MemberName == "Collections") == true) == true;
+        }
+
         private List<BaseItem> ProcessItemChunk(IEnumerable<BaseItem> items, ILibraryManager libraryManager,
             User user, IUserDataManager? userDataManager, ILogger? logger, FieldRequirements fieldReqs,
-            OperandFactory.ReferenceMetadata? referenceMetadata, List<string> similarityComparisonFields, List<List<Func<Operand, bool>>> compiledRules, bool hasAnyRules, bool hasNonExpensiveRules, RefreshQueueService.RefreshCache refreshCache)
+            OperandFactory.ReferenceMetadata? referenceMetadata, List<string> similarityComparisonFields, List<List<Func<Operand, bool>>> compiledRules, bool hasAnyRules, bool hasNonExpensiveRules, HashSet<Guid>? candidateSet, RefreshQueueService.RefreshCache refreshCache)
         {
             var results = new List<BaseItem>();
 
@@ -3056,6 +3132,13 @@ namespace Jellyfin.Plugin.SmartLists.Core
 
                         // Materialize items to prevent multiple enumerations
                         var itemList = items as IList<BaseItem> ?? items.ToList();
+
+                        // DB-prefilter: shrink the pool before per-item expensive extraction.
+                        // Null candidate set = no shrink possible; behavior is unchanged.
+                        if (candidateSet != null)
+                        {
+                            itemList = FilterByCandidateSet(itemList, candidateSet, logger, "expensive-only");
+                        }
 
                         // Preload People cache in parallel if needed for performance
                         if (fieldReqs.NeedsPeople)
@@ -3266,6 +3349,14 @@ namespace Jellyfin.Plugin.SmartLists.Core
 
                         logger?.LogDebug("Phase 1 complete: {Survivors}/{Total} items passed cheap filtering ({SeriesMatches} series matches bypass Phase 2)",
                             phase1Survivors.Count, itemList.Count, phase1SeriesMatches.Count);
+
+                        // DB-prefilter: shrink the Phase 1 survivors before per-item expensive
+                        // extraction in Phase 2. Null candidate set = no shrink possible.
+                        // phase1SeriesMatches already bypassed Phase 2 above and are never filtered.
+                        if (candidateSet != null)
+                        {
+                            phase1Survivors = FilterByCandidateSet(phase1Survivors, candidateSet, logger, "Phase 2");
+                        }
 
                         // Preload People cache for Phase 1 survivors if needed
                         if (fieldReqs.NeedsPeople && phase1Survivors.Count > 0)

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -1061,8 +1061,20 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 {
                     try
                     {
+                        // Mandatory SeriesName bulk warmup: one query replaces the
+                        // per-distinct-series GetItemById round-trips, and a complete dump is
+                        // the precondition for SeriesName candidate narrowing (the resolver
+                        // only narrows when the context carries the pool and the dump).
+                        var seriesDumpComplete = fieldReqs.NeedsSeriesName
+                            && OperandFactory.WarmSeriesNameCache(libraryManager, refreshCache, logger);
+
                         candidateSet = CandidateSetBuilder.CreateDefault()
-                            .Build(ExpressionSets, new PrefilterContext(libraryManager, user, MediaTypes, logger));
+                            .Build(ExpressionSets, new PrefilterContext(libraryManager, user, MediaTypes, logger)
+                            {
+                                PoolItems = seriesDumpComplete ? itemsArray : null,
+                                SeriesNamesById = seriesDumpComplete ? refreshCache.SeriesNameById : null,
+                                ExtraOwnerSeriesIds = seriesDumpComplete ? refreshCache.ExtraOwnerSeriesId : null,
+                            });
                     }
                     catch (Exception ex)
                     {

--- a/Jellyfin.Plugin.SmartLists/ServiceRegistrator.cs
+++ b/Jellyfin.Plugin.SmartLists/ServiceRegistrator.cs
@@ -77,6 +77,8 @@ namespace Jellyfin.Plugin.SmartLists
                 var loggerFactory = sp.GetRequiredService<Microsoft.Extensions.Logging.ILoggerFactory>();
                 var imageService = sp.GetRequiredService<SmartListImageService>();
                 var externalListService = sp.GetRequiredService<ExternalListService>();
+                // Optional: DB prefilters degrade conservatively without it.
+                var itemRepository = sp.GetService<MediaBrowser.Controller.Persistence.IItemRepository>();
 
                 var queueService = new RefreshQueueService(
                     logger,
@@ -90,7 +92,8 @@ namespace Jellyfin.Plugin.SmartLists
                     refreshStatusService,
                     loggerFactory,
                     imageService,
-                    externalListService);
+                    externalListService,
+                    itemRepository);
 
                 // Set the reference in RefreshStatusService
                 refreshStatusService.SetRefreshQueueService(queueService);

--- a/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
@@ -45,6 +45,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
         private readonly IProviderManager _providerManager;
         private readonly SmartListImageService? _imageService;
         private readonly ExternalListService? _externalListService;
+        private readonly MediaBrowser.Controller.Persistence.IItemRepository? _itemRepository;
 
         public CollectionService(
             ILibraryManager libraryManager,
@@ -54,7 +55,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
             ILogger<CollectionService> logger,
             IProviderManager providerManager,
             SmartListImageService? imageService = null,
-            ExternalListService? externalListService = null)
+            ExternalListService? externalListService = null,
+            MediaBrowser.Controller.Persistence.IItemRepository? itemRepository = null)
         {
             _libraryManager = libraryManager;
             _collectionManager = collectionManager;
@@ -64,6 +66,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
             _providerManager = providerManager;
             _imageService = imageService;
             _externalListService = externalListService;
+            _itemRepository = itemRepository;
         }
 
         /// <summary>
@@ -214,7 +217,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
         {
                 var smartCollection = new Core.SmartList(dto)
                 {
-                    UserManager = _userManager // Set UserManager for Jellyfin 10.11+ user resolution
+                    UserManager = _userManager, // Set UserManager for Jellyfin 10.11+ user resolution
+                    ItemRepository = _itemRepository, // ItemValues-backed name dumps for DB prefilters
                 };
 
                 // Query for collections if IncludeCollectionOnly is enabled

--- a/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
@@ -41,6 +41,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
         private readonly ILogger<PlaylistService> _logger;
         private readonly SmartListImageService? _imageService;
         private readonly ExternalListService? _externalListService;
+        private readonly MediaBrowser.Controller.Persistence.IItemRepository? _itemRepository;
 
         public PlaylistService(
             IUserManager userManager,
@@ -49,7 +50,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
             IUserDataManager userDataManager,
             ILogger<PlaylistService> logger,
             SmartListImageService? imageService = null,
-            ExternalListService? externalListService = null)
+            ExternalListService? externalListService = null,
+            MediaBrowser.Controller.Persistence.IItemRepository? itemRepository = null)
         {
             _userManager = userManager;
             _libraryManager = libraryManager;
@@ -58,6 +60,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
             _logger = logger;
             _imageService = imageService;
             _externalListService = externalListService;
+            _itemRepository = itemRepository;
         }
 
 
@@ -141,7 +144,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
 
                 var smartPlaylist = new Core.SmartList(dto)
                 {
-                    UserManager = _userManager // Set UserManager for Jellyfin 10.11+ user resolution,
+                    UserManager = _userManager, // Set UserManager for Jellyfin 10.11+ user resolution
+                    ItemRepository = _itemRepository, // ItemValues-backed name dumps for DB prefilters
                 };
 
                 // Log the playlist rules
@@ -1363,7 +1367,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
 
                 var bumperList = new Core.SmartList(bumperDto)
                 {
-                    UserManager = _userManager // Set UserManager for Jellyfin 10.11+ user resolution,
+                    UserManager = _userManager, // Set UserManager for Jellyfin 10.11+ user resolution
+                    ItemRepository = _itemRepository, // ItemValues-backed name dumps for DB prefilters
                 };
                 var bumperMedia = GetAllUserMedia(user, bumperDto.MediaTypes, bumperDto).ToArray();
                 var bumperIds = bumperList.FilterPlaylistItems(bumperMedia, _libraryManager, user, refreshCache, _userDataManager, logger, null);

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/AutoRefreshHostedService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/AutoRefreshHostedService.cs
@@ -51,14 +51,16 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                 var playlistServiceLogger = loggerFactory.CreateLogger<PlaylistService>();
 
                 var externalListService = _serviceProvider.GetRequiredService<ExternalListService>();
+                // Optional: DB prefilters degrade conservatively without it.
+                var itemRepository = _serviceProvider.GetService<MediaBrowser.Controller.Persistence.IItemRepository>();
 
                 var fileSystem = new SmartListFileSystem(serverApplicationPaths);
                 var playlistStore = new PlaylistStore(fileSystem);
-                var playlistService = new PlaylistService(userManager, libraryManager, playlistManager, userDataManager, playlistServiceLogger, externalListService: externalListService);
+                var playlistService = new PlaylistService(userManager, libraryManager, playlistManager, userDataManager, playlistServiceLogger, externalListService: externalListService, itemRepository: itemRepository);
 
                 var collectionServiceLogger = loggerFactory.CreateLogger<CollectionService>();
                 var collectionStore = new CollectionStore(fileSystem);
-                var collectionService = new CollectionService(libraryManager, collectionManager, userManager, userDataManager, collectionServiceLogger, providerManager, externalListService: externalListService);
+                var collectionService = new CollectionService(libraryManager, collectionManager, userManager, userDataManager, collectionServiceLogger, providerManager, externalListService: externalListService, itemRepository: itemRepository);
 
                 // Get RefreshStatusService from DI - it should be registered as singleton
                 // Use GetRequiredService to prevent creating duplicate instances that cause split-brain state

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/ManualRefreshService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/ManualRefreshService.cs
@@ -110,7 +110,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
         ILogger<ManualRefreshService> logger,
         Microsoft.Extensions.Logging.ILoggerFactory loggerFactory,
         RefreshQueueService refreshQueueService,
-        ExternalListService externalListService) : IManualRefreshService
+        ExternalListService externalListService,
+        MediaBrowser.Controller.Persistence.IItemRepository? itemRepository = null) : IManualRefreshService
     {
         private readonly IUserManager _userManager = userManager;
         private readonly ILibraryManager _libraryManager = libraryManager;
@@ -123,6 +124,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
         private readonly Microsoft.Extensions.Logging.ILoggerFactory _loggerFactory = loggerFactory;
         private readonly RefreshQueueService _refreshQueueService = refreshQueueService;
         private readonly ExternalListService _externalListService = externalListService;
+        private readonly MediaBrowser.Controller.Persistence.IItemRepository? _itemRepository = itemRepository;
 
         /// <summary>
         /// Gets the user for a playlist, handling migration from old User field to new UserId field.
@@ -208,7 +210,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                 _playlistManager,
                 _userDataManager,
                 playlistServiceLogger,
-                externalListService: _externalListService);
+                externalListService: _externalListService,
+                itemRepository: _itemRepository);
         }
 
         /// <summary>
@@ -226,7 +229,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                 _userDataManager,
                 collectionServiceLogger,
                 _providerManager,
-                externalListService: _externalListService);
+                externalListService: _externalListService,
+                itemRepository: _itemRepository);
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
@@ -756,6 +756,14 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
             public ConcurrentDictionary<Guid, string> SeriesSortNameById { get; } = new();
 
             /// <summary>
+            /// SeriesName bulk-warmup state: null = not attempted, true = SeriesNameById and
+            /// SeriesSortNameById cover every in-scope series (dump completed), false = the dump
+            /// failed and only per-miss lazy entries exist. Written only on the sequential refresh
+            /// path (see OperandFactory.WarmSeriesNameCache).
+            /// </summary>
+            public bool? SeriesNameWarmupSucceeded { get; set; }
+
+            /// <summary>
             /// Ancestor-inherited Tags/Studios/Genres, keyed by the ANCESTOR NODE id (season id,
             /// album id, folder id) — never the item id — so every episode of a season is a single
             /// lookup and the walk itself runs once per container. Each entry is the COMPLETE union

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
@@ -66,6 +66,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
         private readonly Microsoft.Extensions.Logging.ILoggerFactory _loggerFactory;
         private readonly SmartListImageService? _imageService;
         private readonly ExternalListService? _externalListService;
+        private readonly MediaBrowser.Controller.Persistence.IItemRepository? _itemRepository;
 
         // Queue data structures
         private readonly ConcurrentQueue<RefreshQueueItem> _queue = new();
@@ -96,7 +97,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
             RefreshStatusService refreshStatusService,
             Microsoft.Extensions.Logging.ILoggerFactory loggerFactory,
             SmartListImageService? imageService = null,
-            ExternalListService? externalListService = null)
+            ExternalListService? externalListService = null,
+            MediaBrowser.Controller.Persistence.IItemRepository? itemRepository = null)
         {
             _logger = logger;
             _userManager = userManager;
@@ -110,6 +112,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
             _loggerFactory = loggerFactory;
             _imageService = imageService;
             _externalListService = externalListService;
+            _itemRepository = itemRepository;
 
             // Start background processing task
             _processingTask = Task.Run(ProcessQueueAsync, _cancellationTokenSource.Token);
@@ -685,7 +688,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                 _userDataManager,
                 playlistServiceLogger,
                 _imageService,
-                _externalListService);
+                _externalListService,
+                _itemRepository);
         }
 
         /// <summary>
@@ -702,7 +706,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                 collectionServiceLogger,
                 _providerManager,
                 _imageService,
-                _externalListService);
+                _externalListService,
+                _itemRepository);
         }
 
         public void Dispose()


### PR DESCRIPTION
## What
Replaces per-item DB extraction with indexed candidate-set queries for the expensive rule fields, turning multi-minute refreshes (a Director rule on a large library took 20+ minutes, #501) into seconds.

## Why
Expensive fields (People, SeriesName, media-stream fields, parent-aware Tags/Genres/Studios, …) were evaluated by issuing one DB round-trip per library item — e.g. a reflected `GetPeople(ItemId)` for every item in the pool. The AutoCollections plugin demonstrated the fast alternative: push the filter into one indexed `InternalItemsQuery`. This PR generalizes that idea behind the rule engine while preserving exact operator semantics.

## How it works
A `CandidateSetBuilder` runs once per filter pass and asks per-field resolvers for a DB-backed candidate ID set (per rule set: intersection over pushdownable rules; across OR'd sets: union). The set only ever *shrinks* the pool — final per-item evaluation still runs on every surviving candidate, so a prefilter can produce false positives but never false negatives. Anything unprovable degrades to "all items" (no shrink, identical behavior to today).

## Changes
- **Foundation**: `Core/QueryEngine/Prefilters/` — `CandidateSetBuilder`, resolver seam, candidate-set intersection at both consumption points (Phase-1→2 handoff and the expensive-only path), with exemptions for extras and Series-under-Collections expansion
- **People (26 role fields)**: resolve stored person names from a people dump with plugin operator semantics, then one `Person=` item query per matched name; on Jellyfin 12 the role narrows via `InternalPeopleQuery.PersonTypes` and Phase-2 extraction goes bulk through `GetPeopleByItems` (10.11: `PersonTypes` is a silent no-op on item queries, so the prefilter is any-role — a valid superset)
- **SeriesName**: one all-Series warmup query replaces per-distinct-series `GetItemById`; pool-derived candidate narrowing with extras/unknown-series/seriesless handling
- **NextUnwatched**: `IsPlayed=false` episode query per rule target user
- **LastEpisodeAirDate**: max/exists equivalence — one `MinPremiereDate` episode range query (After/NewerThan), exact complement for Before/OlderThan, day-window superset for Equal
- **Resolution**: `MinHeight`/`MaxHeight` windows mapped to the plugin's height bucketer (8K open-topped)
- **AudioLanguages/SubtitleLanguages** (Jellyfin 12 only): language dump normalized ISO-639-2 B→T, matched in memory, pushed as raw codes; 10.11 stays per-item
- **Parent-aware Tags/Genres/Studios**: value-filtered query → `AncestorIds` expansion of matched containers, with a conservative CollectionFolder guard for virtual/symlinked libraries
- **Bugfix**: `ExtractFramerate` bypassed the shared `MediaStreamsCache`, re-fetching streams per item whenever a Framerate rule co-occurred with other stream rules
- ~230 new unit tests (full suite: 1498 passing); both TFMs build warning-free

## Verification
End-to-end against local dev containers on **both ABIs** (Jellyfin 12.0-rc3 / net10.0 and Jellyfin 10.11.6 / net9.0): Director, SeriesName, Resolution, AudioLanguages, parent-tag, NextUnwatched and LastEpisodeAirDate rules all produced results identical to SQL-derived ground truths, with prefilter log lines confirming pool shrinks (e.g. `People prefilter: Directors Equal matched 1 names -> 4 candidate items`, `Prefilter shrank expensive-only pool 40 -> 3 items`) and correct conservative fallbacks (invalid rule values, 12-only resolvers on 10.11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9Qe3VFG7DQsuWdbfW6qra

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smart Lists now prefilter matching media before expensive processing, improving refresh efficiency.
  * Faster filtering is available for series names, people, genres, studios, tags, resolutions, stream languages, air dates, and unwatched episodes.
  * Filtering preserves safe fallback behavior when metadata or indexing support is unavailable.

* **Bug Fixes**
  * Improved handling of negative operators, regular expressions, missing metadata, normalization, and unmatched values.

* **Tests**
  * Added comprehensive automated coverage for filtering behavior, edge cases, fallback logic, and resolver failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->