### PR TITLE
feat: Collection/Playlist media types with member matching

### DIFF
--- a/Jellyfin.Plugin.SmartLists.Tests/Core/ContainerMatchingTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/ContainerMatchingTests.cs
@@ -1,0 +1,474 @@
+using Jellyfin.Plugin.SmartLists.Core;
+using Jellyfin.Plugin.SmartLists.Core.Models;
+using Jellyfin.Plugin.SmartLists.Core.QueryEngine;
+using Jellyfin.Plugin.SmartLists.Services.Shared;
+using Jellyfin.Plugin.SmartLists.Tests.Support;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Playlists;
+using Expression = Jellyfin.Plugin.SmartLists.Core.QueryEngine.Expression;
+using MediaTypeConstants = Jellyfin.Plugin.SmartLists.Core.Constants.MediaTypes;
+using Movie = MediaBrowser.Controller.Entities.Movies.Movie;
+
+namespace Jellyfin.Plugin.SmartLists.Tests.Core;
+
+/// <summary>
+/// Covers the container media types (Collection/Playlist) in the single-path engine that replaced
+/// the legacy per-rule "include collections/playlists only" checkboxes:
+///
+/// - MatchByMembers OFF: container candidates flow through the normal item pipeline and are
+///   matched against their OWN metadata (Name, Genres, ...), members are never consulted.
+/// - MatchByMembers ON: a container is included iff at least one member item passes the full rule
+///   pipeline; member matches project onto the parent container.
+/// - Self-reference (#499, engine surface): a list must never include its own container, in
+///   EITHER mode - the pool-level Origin guard, distinct from the extraction-level guard covered
+///   by ListOriginTests.
+///
+/// HARNESS NOTE: members are enumerated from RefreshCache.CollectionDirectChildren /
+/// PlaylistChildItems, so the library manager (TestLibraryManager, which throws on unstubbed
+/// members) is never queried for children; rules are either cheap (ItemLists/TextContent/Dates)
+/// or People-backed with RefreshCache.ItemPeople seeded, so no prefilter or library query runs.
+/// </summary>
+public class ContainerMatchingTests
+{
+    // ---------------------------------------------------------------------------------------
+    // Fixture builders
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>A BoxSet - what Jellyfin calls a collection. Name before SortName, as ever.</summary>
+    private static BoxSet CollectionNamed(string name, params string[] genres)
+    {
+        var boxSet = new BoxSet { Id = Guid.NewGuid(), Name = name, Genres = genres };
+        boxSet.SortName = name;
+        return boxSet;
+    }
+
+    private static Movie MovieNamed(string name, params string[] genres)
+    {
+        var movie = new Movie { Id = Guid.NewGuid(), Name = name, Genres = genres };
+        movie.SortName = name;
+        return movie;
+    }
+
+    /// <summary>
+    /// A smart collection targeting the given media types with a single Genres-contains rule.
+    /// Genres is a cheap (ItemLists) field, keeping the whole run on the simple pipeline.
+    /// </summary>
+    private static SmartList MakeList(
+        List<string> mediaTypes,
+        bool matchByMembers,
+        string genre = "Action",
+        string? jellyfinCollectionId = null)
+    {
+        var dto = new SmartCollectionDto
+        {
+            Id = Guid.NewGuid().ToString(),
+            Name = "Container Test List",
+            MediaTypes = mediaTypes,
+            MatchByMembers = matchByMembers,
+            JellyfinCollectionId = jellyfinCollectionId,
+            ExpressionSets =
+            [
+                new ExpressionSet { Expressions = [new Expression("Genres", "Contains", genre)] },
+            ],
+        };
+
+        return new SmartList(dto);
+    }
+
+    /// <summary>Seeds a collection's direct members so no library query is needed.</summary>
+    private static void SeedMembers(RefreshQueueService.RefreshCache cache, BoxSet boxSet, params BaseItem[] members)
+    {
+        cache.CollectionDirectChildren[boxSet.Id] = members;
+    }
+
+    private static Guid[] Filter(SmartList list, RefreshQueueService.RefreshCache cache, params BaseItem[] pool)
+        => [.. list.FilterPlaylistItems(pool, BaseItem.LibraryManager, TestItems.User, cache)];
+
+    // ---------------------------------------------------------------------------------------
+    // MatchByMembers ON - member matches project onto their container
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void MatchByMembers_IncludesAContainerWhenAtLeastOneMemberPasses()
+    {
+        var actionBox = CollectionNamed("Arnold Movies");     // no genres of its own
+        var dramaBox = CollectionNamed("Sad Movies");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedMembers(cache, actionBox, MovieNamed("Predator", "Action"), MovieNamed("Twins", "Comedy"));
+        SeedMembers(cache, dramaBox, MovieNamed("The Notebook", "Drama"));
+
+        var list = MakeList([Jellyfin.Plugin.SmartLists.Core.Constants.MediaTypes.Collection], matchByMembers: true);
+
+        var result = Filter(list, cache, actionBox, dramaBox);
+
+        Assert.Equal([actionBox.Id], result);
+    }
+
+    [Fact]
+    public void MatchByMembers_NeverIncludesTheListsOwnContainer()
+    {
+        // Both containers hold a passing member; the first one IS the list being built.
+        var self = CollectionNamed("Action Collection [Smart]");
+        var other = CollectionNamed("Manually Curated Action");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedMembers(cache, self, MovieNamed("Commando", "Action"));
+        SeedMembers(cache, other, MovieNamed("Predator", "Action"));
+
+        var list = MakeList(
+            [Jellyfin.Plugin.SmartLists.Core.Constants.MediaTypes.Collection],
+            matchByMembers: true,
+            jellyfinCollectionId: self.Id.ToString());
+
+        var result = Filter(list, cache, self, other);
+
+        Assert.Equal([other.Id], result);
+    }
+
+    [Fact]
+    public void MatchByMembers_MixedList_ReturnsMatchedItemsAndTheirContainersWithoutDuplicates()
+    {
+        var actionMovie = MovieNamed("Predator", "Action");
+        var dramaMovie = MovieNamed("The Notebook", "Drama");
+        var box = CollectionNamed("Arnold Movies");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedMembers(cache, box, actionMovie);
+
+        var list = MakeList(
+            [Jellyfin.Plugin.SmartLists.Core.Constants.MediaTypes.Movie, Jellyfin.Plugin.SmartLists.Core.Constants.MediaTypes.Collection],
+            matchByMembers: true);
+
+        var result = Filter(list, cache, actionMovie, dramaMovie, box);
+
+        // The action movie matches as itself AND rescues its container; the drama movie is out.
+        Assert.Equal(2, result.Length);
+        Assert.Contains(actionMovie.Id, result);
+        Assert.Contains(box.Id, result);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // MatchByMembers OFF - containers are matched on their own metadata only
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void MatchByMembersOff_MatchesContainersOnTheirOwnMetadataAndIgnoresMembers()
+    {
+        // The Action-tagged box holds only a drama; the Drama-tagged box holds an action movie.
+        // Own-metadata matching must pick the first and must NOT let the member rescue the second.
+        var taggedAction = CollectionNamed("Box A", "Action");
+        var taggedDrama = CollectionNamed("Box B", "Drama");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedMembers(cache, taggedAction, MovieNamed("The Notebook", "Drama"));
+        SeedMembers(cache, taggedDrama, MovieNamed("Predator", "Action"));
+
+        var list = MakeList([Jellyfin.Plugin.SmartLists.Core.Constants.MediaTypes.Collection], matchByMembers: false);
+
+        var result = Filter(list, cache, taggedAction, taggedDrama);
+
+        Assert.Equal([taggedAction.Id], result);
+    }
+
+    [Fact]
+    public void MatchByMembersOff_NeverIncludesTheListsOwnContainer()
+    {
+        var self = CollectionNamed("Action Collection [Smart]", "Action");
+        var other = CollectionNamed("Manually Curated Action", "Action");
+
+        var list = MakeList(
+            [Jellyfin.Plugin.SmartLists.Core.Constants.MediaTypes.Collection],
+            matchByMembers: false,
+            jellyfinCollectionId: self.Id.ToString());
+
+        var result = Filter(list, new RefreshQueueService.RefreshCache(), self, other);
+
+        Assert.Equal([other.Id], result);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Name + Equal container fallback (migration parity: users target smart lists by base name)
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// PRECONDITION: Plugin.Instance is null in a test process, so StripPrefixAndSuffix
+    /// deterministically strips the default "[Smart]" suffix (same as ListOriginTests).
+    /// </summary>
+    [Theory]
+    [InlineData("Arnold [Smart]", "Collection", "Arnold", true)]   // container: base name matches
+    [InlineData("Arnold [Smart]", "Playlist", "Arnold", true)]     // container: base name matches
+    [InlineData("Arnold [Smart]", "Movie", "Arnold", false)]       // non-container: no fallback
+    [InlineData("Arnold", "Movie", "Arnold", true)]                // plain equality still works
+    [InlineData("Arnold", "Collection", "Terminator", false)]      // no match at all
+    public void NameEqualsWithContainerBaseName_StripsThePrefixSuffixForContainersOnly(
+        string name, string itemType, string target, bool expected)
+    {
+        Assert.Equal(expected, Engine.NameEqualsWithContainerBaseName(name, itemType, target));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // MatchByMembers ON - AND within a group is evaluated per single member
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>A Movie with a production year, for the per-member AND coverage.</summary>
+    private static Movie MovieFromYear(string name, int year, params string[] genres)
+    {
+        var movie = MovieNamed(name, genres);
+        movie.ProductionYear = year;
+        return movie;
+    }
+
+    /// <summary>
+    /// Seeds an item's people into the refresh cache so People extraction is a cache hit and the
+    /// throwing TestLibraryManager is never queried. Seeding an EMPTY set models Jellyfin's
+    /// reality for containers: people are never rolled up onto a BoxSet.
+    /// </summary>
+    private static void SeedActors(RefreshQueueService.RefreshCache cache, BaseItem item, params string[] actors)
+    {
+        cache.ItemPeople[item.Id] = new RefreshQueueService.CategorizedPeople
+        {
+            AllPeople = [.. actors],
+            Actors = [.. actors],
+        };
+    }
+
+    /// <summary>Overload taking fully-shaped expression sets (and optionally a named sort).</summary>
+    private static SmartList MakeList(
+        List<string> mediaTypes,
+        bool matchByMembers,
+        List<ExpressionSet> expressionSets,
+        string? orderName = null)
+    {
+        var dto = new SmartCollectionDto
+        {
+            Id = Guid.NewGuid().ToString(),
+            Name = "Container Test List",
+            MediaTypes = mediaTypes,
+            MatchByMembers = matchByMembers,
+            ExpressionSets = expressionSets,
+            Order = orderName == null ? null : new OrderDto { Name = orderName },
+        };
+
+        return new SmartList(dto);
+    }
+
+    [Fact]
+    public void MatchByMembers_AllRulesOfAGroupMustPassOnTheSameMember()
+    {
+        // The spec's Arnold/Stallone case: "Actors contains Arnold AND year < 1990" means
+        // "collections containing a pre-1990 Arnold movie" - ONE member must satisfy the whole
+        // group. A collection holding a 2013 Arnold movie and a 1976 Stallone movie satisfies
+        // each rule on SOME member but neither on a single one, and must stay out.
+        //
+        // Actors is an expensive (People) field while ProductionYear is cheap, so this also runs
+        // the members through the two-phase pipeline: the year rule gates phase 1, and phase 2
+        // resolves Actors from the seeded people cache.
+        var terminator = MovieFromYear("The Terminator", 1984);
+        var escapePlan = MovieFromYear("Escape Plan", 2013);
+        var rocky = MovieFromYear("Rocky", 1976);
+
+        var arnoldClassics = CollectionNamed("Arnold Classics");
+        var mixedBag = CollectionNamed("Mixed Bag");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedMembers(cache, arnoldClassics, terminator);
+        SeedMembers(cache, mixedBag, escapePlan, rocky);
+        SeedActors(cache, terminator, "Arnold Schwarzenegger");
+        SeedActors(cache, escapePlan, "Arnold Schwarzenegger", "Sylvester Stallone");
+        SeedActors(cache, rocky, "Sylvester Stallone");
+
+        var list = MakeList(
+            [MediaTypeConstants.Collection],
+            matchByMembers: true,
+            [
+                new ExpressionSet
+                {
+                    Expressions =
+                    [
+                        new Expression("Actors", "Contains", "Arnold Schwarzenegger"),
+                        new Expression("ProductionYear", "LessThan", "1990"),
+                    ],
+                },
+            ]);
+
+        var result = Filter(list, cache, arnoldClassics, mixedBag);
+
+        Assert.Equal([arnoldClassics.Id], result);
+    }
+
+    [Fact]
+    public void MatchByMembers_NegativeOperatorKeepsItsItemMeaning_SomeMemberLacksTheValue()
+    {
+        // "Genres NotContains Horror" with MatchByMembers ON means "at least one member is not
+        // Horror" - the operator keeps its per-item meaning, deliberately NOT "no member has
+        // Horror". A collection whose members are all Horror stays out; a single non-Horror
+        // member lets a collection in even when its siblings are Horror.
+        var allHorror = CollectionNamed("Wall To Wall Horror");
+        var mostlyHorror = CollectionNamed("Mostly Horror");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedMembers(cache, allHorror, MovieNamed("It", "Horror"), MovieNamed("Saw", "Horror"));
+        SeedMembers(cache, mostlyHorror, MovieNamed("Scream", "Horror"), MovieNamed("Clue", "Comedy"));
+
+        var list = MakeList(
+            [MediaTypeConstants.Collection],
+            matchByMembers: true,
+            [new ExpressionSet { Expressions = [new Expression("Genres", "NotContains", "Horror")] }]);
+
+        var result = Filter(list, cache, allHorror, mostlyHorror);
+
+        Assert.Equal([mostlyHorror.Id], result);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // MatchByMembers OFF - own metadata only, and item-only fields honestly match nothing
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void MatchByMembersOff_MatchesContainersByTheirOwnName()
+    {
+        var arnoldBox = CollectionNamed("Arnold Movies");
+        var stalloneBox = CollectionNamed("Stallone Movies");
+
+        var list = MakeList(
+            [MediaTypeConstants.Collection],
+            matchByMembers: false,
+            [new ExpressionSet { Expressions = [new Expression("Name", "Contains", "Arnold")] }]);
+
+        var result = Filter(list, new RefreshQueueService.RefreshCache(), arnoldBox, stalloneBox);
+
+        Assert.Equal([arnoldBox.Id], result);
+    }
+
+    [Fact]
+    public void MatchByMembersOff_PeopleRuleMatchesNothingAgainstABareBoxSet()
+    {
+        // Jellyfin never rolls People up onto a BoxSet, so with the toggle off a People rule
+        // evaluates against the container's own (empty) people and returns nothing - even when a
+        // member DOES have the actor. The engine must not secretly consult members in this mode;
+        // the field picker hides People for container-only + toggle-off lists for the same reason.
+        var box = CollectionNamed("Arnold Movies");
+        var member = MovieNamed("Predator", "Action");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedMembers(cache, box, member);
+        SeedActors(cache, member, "Arnold Schwarzenegger");
+        SeedActors(cache, box); // empty - a BoxSet has no people rows of its own
+
+        var list = MakeList(
+            [MediaTypeConstants.Collection],
+            matchByMembers: false,
+            [new ExpressionSet { Expressions = [new Expression("Actors", "Contains", "Arnold Schwarzenegger")] }]);
+
+        Assert.Empty(Filter(list, cache, box));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Group tracking - containers inherit their passing members' rule-group mappings
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void MatchByMembers_RuleBlockOrder_PlacesContainersInTheirMembersBlock()
+    {
+        // Rule Block Order sorts by matched group index and puts UNMAPPED items last. The
+        // container's group is deliberately FIRST (set 0 = Drama, matched via its member) to make
+        // the assertion discriminating: a container that never inherited its member's mapping
+        // would sort after the Action movie instead of before it.
+        var actionMovie = MovieNamed("Predator", "Action");
+        var box = CollectionNamed("Drama Box");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedMembers(cache, box, MovieNamed("The Notebook", "Drama"));
+
+        var list = MakeList(
+            [MediaTypeConstants.Movie, MediaTypeConstants.Collection],
+            matchByMembers: true,
+            [
+                new ExpressionSet { Expressions = [new Expression("Genres", "Contains", "Drama")] },
+                new ExpressionSet { Expressions = [new Expression("Genres", "Contains", "Action")] },
+            ],
+            orderName: "Rule Block Order Ascending");
+
+        var result = Filter(list, cache, actionMovie, box);
+
+        Assert.Equal([box.Id, actionMovie.Id], result);
+    }
+
+    [Fact]
+    public void MatchByMembers_PerGroupLimits_ContainersSurviveInTheirMappedGroup()
+    {
+        // ApplyPerGroupLimits rebuilds the result from per-group buckets, silently DROPPING any
+        // item without a group mapping. The container must land in its member's bucket (set 1):
+        // mapped to set 0 it would lose the MaxItems=1 slot to "Alpha Action" (Name sort) and
+        // vanish; unmapped it would vanish outright.
+        var alpha = MovieNamed("Alpha Action", "Action");
+        var beta = MovieNamed("Beta Action", "Action");
+        var dramaMovie = MovieNamed("Drama Movie", "Drama");
+        var box = CollectionNamed("Zebra Box");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedMembers(cache, box, MovieNamed("The Notebook", "Drama"));
+
+        var list = MakeList(
+            [MediaTypeConstants.Movie, MediaTypeConstants.Collection],
+            matchByMembers: true,
+            [
+                new ExpressionSet { Expressions = [new Expression("Genres", "Contains", "Action")], MaxItems = 1 },
+                new ExpressionSet { Expressions = [new Expression("Genres", "Contains", "Drama")] },
+            ]);
+
+        var result = Filter(list, cache, alpha, beta, dramaMovie, box);
+
+        Assert.Equal(3, result.Length);
+        Assert.Contains(alpha.Id, result);      // set 0's single slot goes to the first Action name
+        Assert.Contains(dramaMovie.Id, result);
+        Assert.Contains(box.Id, result);        // the container kept its set-1 slot
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Playlist containers - same semantics, PlaylistChildItems-backed
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>A Jellyfin Playlist container candidate.</summary>
+    private static Playlist PlaylistContainer(string name)
+    {
+        var playlist = new Playlist { Id = Guid.NewGuid(), Name = name };
+        playlist.SortName = name;
+        return playlist;
+    }
+
+    [Fact]
+    public void MatchByMembers_PlaylistContainersMatchByTheirMembers()
+    {
+        var actionMix = PlaylistContainer("Action Mix");
+        var chillMix = PlaylistContainer("Chill Mix");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        cache.PlaylistChildItems[actionMix.Id] = [MovieNamed("Predator", "Action")];
+        cache.PlaylistChildItems[chillMix.Id] = [MovieNamed("The Notebook", "Drama")];
+
+        var list = MakeList([MediaTypeConstants.Playlist], matchByMembers: true);
+
+        var result = Filter(list, cache, actionMix, chillMix);
+
+        Assert.Equal([actionMix.Id], result);
+    }
+
+    [Fact]
+    public void MatchByMembersOff_PlaylistContainersMatchByTheirOwnName()
+    {
+        var actionMix = PlaylistContainer("Action Mix");
+        var chillMix = PlaylistContainer("Chill Mix");
+
+        var list = MakeList(
+            [MediaTypeConstants.Playlist],
+            matchByMembers: false,
+            [new ExpressionSet { Expressions = [new Expression("Name", "Contains", "Action")] }]);
+
+        var result = Filter(list, new RefreshQueueService.RefreshCache(), actionMix, chillMix);
+
+        Assert.Equal([actionMix.Id], result);
+    }
+}

--- a/Jellyfin.Plugin.SmartLists.Tests/Core/ContainerMatchingTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/ContainerMatchingTests.cs
@@ -107,6 +107,40 @@ public class ContainerMatchingTests
     }
 
     [Fact]
+    public void MatchByMembers_SimilarToReferenceInsideACandidateContainerIsFound()
+    {
+        // A container-only pool holds no items, so the SimilarTo reference lookup must extend
+        // to the candidates' members - otherwise reference metadata comes back empty and every
+        // container silently fails (PR #508 review finding).
+        var arnoldBox = CollectionNamed("Arnold Movies");
+        var dramaBox = CollectionNamed("Sad Movies");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        // Predator is the reference; Commando shares its full genre profile, so the box passes
+        // on Commando's similarity even if the reference item itself is not counted.
+        SeedMembers(cache, arnoldBox,
+            MovieNamed("Predator", "Action", "Sci-Fi"),
+            MovieNamed("Commando", "Action", "Sci-Fi"));
+        SeedMembers(cache, dramaBox, MovieNamed("The Notebook", "Drama"));
+
+        var dto = new SmartCollectionDto
+        {
+            Id = Guid.NewGuid().ToString(),
+            Name = "Similar To Container List",
+            MediaTypes = [Jellyfin.Plugin.SmartLists.Core.Constants.MediaTypes.Collection],
+            MatchByMembers = true,
+            ExpressionSets =
+            [
+                new ExpressionSet { Expressions = [new Expression("SimilarTo", "Equal", "Predator")] },
+            ],
+        };
+
+        var result = Filter(new SmartList(dto), cache, arnoldBox, dramaBox);
+
+        Assert.Equal([arnoldBox.Id], result);
+    }
+
+    [Fact]
     public void MatchByMembers_NeverIncludesTheListsOwnContainer()
     {
         // Both containers hold a passing member; the first one IS the list being built.

--- a/Jellyfin.Plugin.SmartLists.Tests/Services/Collections/CollectionAggregateMetadataTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Services/Collections/CollectionAggregateMetadataTests.cs
@@ -1,0 +1,189 @@
+using System.Reflection;
+using Jellyfin.Plugin.SmartLists.Services.Collections;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Model.Globalization;
+using Movie = MediaBrowser.Controller.Entities.Movies.Movie;
+
+namespace Jellyfin.Plugin.SmartLists.Tests.Services.Collections;
+
+/// <summary>
+/// Covers <see cref="CollectionService.UpdateAggregateMetadata"/> - the roll-up of member
+/// genres, studios, official rating and cumulative runtime onto a smart collection's BoxSet.
+///
+/// Smart collections are metadata-locked by design (#433), which also suppresses Jellyfin's own
+/// child aggregation - so unlike the PlaylistService counterpart this roll-up must run DESPITE
+/// the lock, and it must report whether anything actually changed so no-op refreshes skip the
+/// repository write.
+///
+/// HARNESS NOTE: <c>BaseItem.UpdateRatingToItems</c> resolves rating scores through the static
+/// <c>BaseItem.LocalizationManager</c>, which is null offline - the static ctor installs a stub
+/// that scores nothing, so rating aggregation falls back to first-distinct order. Fixtures use a
+/// single distinct rating per pass, keeping the outcome independent of score ordering.
+/// </summary>
+public class CollectionAggregateMetadataTests
+{
+    static CollectionAggregateMetadataTests()
+    {
+        BaseItem.LocalizationManager = DispatchProxy.Create<ILocalizationManager, NeutralLocalizationManager>();
+    }
+
+    /// <summary>
+    /// Answers <c>GetRatingScore</c> with null (no rating system loaded), which is exactly what
+    /// the real manager returns for a rating it does not know. Everything else throws so a new
+    /// dependency on localization fails loudly instead of returning a default silently.
+    /// </summary>
+    public class NeutralLocalizationManager : DispatchProxy
+    {
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod?.Name == "GetRatingScore")
+            {
+                return null;
+            }
+
+            throw new NotSupportedException(
+                $"NeutralLocalizationManager: {targetMethod?.Name} is not stubbed. Add it deliberately.");
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Fixture builders
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// A collection under test. <c>PreferredMetadataCountryCode</c> is set because
+    /// <c>UpdateRatingToItems</c> resolves it per rating via <c>GetPreferredMetadataCountryCode()</c>,
+    /// whose fallback chain dereferences the unstubbed library manager and config statics offline.
+    /// </summary>
+    private static BoxSet Collection() => new() { Id = Guid.NewGuid(), Name = "Aggregate Test Collection", PreferredMetadataCountryCode = "US" };
+
+    private static Movie MovieWith(
+        string name,
+        string[]? genres = null,
+        string[]? studios = null,
+        long? runtimeTicks = null,
+        string? rating = null)
+        => new()
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            Genres = genres ?? [],
+            Studios = studios ?? [],
+            RunTimeTicks = runtimeTicks,
+            OfficialRating = rating,
+        };
+
+    // ---------------------------------------------------------------------------------------
+    // Tests
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void RollsUpGenresStudiosRuntimeAndRatingFromMembers()
+    {
+        var boxSet = Collection();
+        var members = new BaseItem[]
+        {
+            MovieWith("Terminator", genres: ["Action", "Sci-Fi"], studios: ["Carolco"], runtimeTicks: 100, rating: "R"),
+            // "action" duplicates "Action" case-insensitively - first casing must win
+            MovieWith("Predator", genres: ["action", "Thriller"], studios: ["20th Century Fox"], runtimeTicks: 50, rating: "R"),
+        };
+
+        var changed = CollectionService.UpdateAggregateMetadata(boxSet, members);
+
+        Assert.True(changed);
+        Assert.Equal(["Action", "Sci-Fi", "Thriller"], boxSet.Genres);
+        Assert.Equal(["20th Century Fox", "Carolco"], boxSet.Studios); // sorted for order-independent change detection
+        Assert.Equal(150, boxSet.RunTimeTicks);
+        Assert.Equal("R", boxSet.OfficialRating);
+    }
+
+    [Fact]
+    public void SecondPassWithSameMembersIsNoOp()
+    {
+        var boxSet = Collection();
+        var members = new BaseItem[]
+        {
+            MovieWith("Conan", genres: ["Adventure"], studios: ["Universal"], runtimeTicks: 75, rating: "PG-13"),
+        };
+
+        Assert.True(CollectionService.UpdateAggregateMetadata(boxSet, members));
+
+        // Same members again: nothing changed, so the caller must be told to skip the write
+        Assert.False(CollectionService.UpdateAggregateMetadata(boxSet, members));
+        Assert.Equal(["Adventure"], boxSet.Genres);
+        Assert.Equal(75, boxSet.RunTimeTicks);
+        Assert.Equal("PG-13", boxSet.OfficialRating);
+    }
+
+    [Fact]
+    public void FolderMembersAreExcludedFromRuntimeButNotFromGenres()
+    {
+        var boxSet = Collection();
+        var nested = Collection();
+        nested.Genres = ["Documentary"];
+        nested.RunTimeTicks = 999;
+
+        var members = new BaseItem[]
+        {
+            MovieWith("Rocky", genres: ["Drama"], runtimeTicks: 60),
+            nested, // BoxSet is a folder: contributes genres, never runtime
+        };
+
+        CollectionService.UpdateAggregateMetadata(boxSet, members);
+
+        Assert.Equal(60, boxSet.RunTimeTicks);
+        Assert.Equal(["Documentary", "Drama"], boxSet.Genres); // sorted for order-independent change detection
+    }
+
+    [Fact]
+    public void RunsDespiteMetadataLock()
+    {
+        // The point of difference vs PlaylistService.UpdateAggregateMetadata: smart collections
+        // are ALWAYS IsLocked (#433), and the roll-up must run anyway.
+        var boxSet = Collection();
+        boxSet.IsLocked = true;
+
+        var changed = CollectionService.UpdateAggregateMetadata(
+            boxSet,
+            [MovieWith("Rambo", genres: ["War"], runtimeTicks: 40, rating: "R")]);
+
+        Assert.True(changed);
+        Assert.Equal(["War"], boxSet.Genres);
+        Assert.Equal(40, boxSet.RunTimeTicks);
+        Assert.Equal("R", boxSet.OfficialRating);
+    }
+
+    [Fact]
+    public void EmptyMembersClearAggregatesButKeepRating()
+    {
+        var boxSet = Collection();
+        boxSet.Genres = ["Stale"];
+        boxSet.Studios = ["Stale Studio"];
+        boxSet.RunTimeTicks = 10;
+        boxSet.OfficialRating = "PG";
+
+        var changed = CollectionService.UpdateAggregateMetadata(boxSet, []);
+
+        Assert.True(changed);
+        Assert.Empty(boxSet.Genres);
+        Assert.Empty(boxSet.Studios);
+        Assert.Equal(0, boxSet.RunTimeTicks);
+        // UpdateRatingToItems keeps the current rating when no member carries one
+        Assert.Equal("PG", boxSet.OfficialRating);
+    }
+
+    [Fact]
+    public void RatingChangeAloneIsReportedAsChanged()
+    {
+        var boxSet = Collection();
+        var movie = MovieWith("Die Hard", genres: ["Action"], runtimeTicks: 80, rating: "R");
+        Assert.True(CollectionService.UpdateAggregateMetadata(boxSet, [movie]));
+
+        // Only the member's rating changes: genres/studios/runtime compare equal, rating must
+        // still flip the changed flag on its own
+        movie.OfficialRating = "PG-13";
+        Assert.True(CollectionService.UpdateAggregateMetadata(boxSet, [movie]));
+        Assert.Equal("PG-13", boxSet.OfficialRating);
+    }
+}

--- a/Jellyfin.Plugin.SmartLists.Tests/Services/Shared/SmartListFileSystemMigrationTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Services/Shared/SmartListFileSystemMigrationTests.cs
@@ -1,0 +1,321 @@
+using System.Text.Json;
+using Jellyfin.Plugin.SmartLists.Core;
+using Jellyfin.Plugin.SmartLists.Core.Models;
+using Jellyfin.Plugin.SmartLists.Core.QueryEngine;
+using Jellyfin.Plugin.SmartLists.Services.Shared;
+using MediaTypeConstants = Jellyfin.Plugin.SmartLists.Core.Constants.MediaTypes;
+
+namespace Jellyfin.Plugin.SmartLists.Tests.Services.Shared;
+
+/// <summary>
+/// Pins the one-time load migration in <see cref="SmartListFileSystem.ApplyPostProcessing(SmartCollectionDto)"/>
+/// (and the playlist overload) that replaces the legacy per-rule IncludeCollectionOnly/
+/// IncludePlaylistOnly checkboxes with the Collection/Playlist media types.
+///
+/// Collections: each include-only Collections/Playlists rule becomes a Name rule against the
+/// container itself (operator and value preserved) and the list gains the matching container
+/// media type. Pure include-only lists (every rule group carries an include-only rule) only ever
+/// produced containers, so their item media types are replaced outright; mixed lists keep their
+/// item types. MatchByMembers stays false, preserving the legacy match-against-container-metadata
+/// behavior.
+///
+/// Playlists: the flags are stripped silently - the feature never worked there because Jellyfin
+/// playlists can only contain media items (container results were silently dropped).
+/// </summary>
+public class SmartListFileSystemMigrationTests
+{
+    // ---------------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------------
+
+    private static ExpressionSet Group(params Expression[] rules)
+        => new() { Expressions = [.. rules] };
+
+    private static Expression IncludeOnlyCollectionsRule(string op = "Contains", string value = "Marvel")
+        => new("Collections", op, value) { IncludeCollectionOnly = true };
+
+    private static Expression IncludeOnlyPlaylistsRule(string op = "Equal", string value = "Morning Mix")
+        => new("Playlists", op, value) { IncludePlaylistOnly = true };
+
+    // ---------------------------------------------------------------------------------
+    // Collections - pure include-only lists
+    // ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void PureIncludeOnlyCollection_MigratesToCollectionMediaTypeAndNameRule()
+    {
+        // Legacy pure include-only lists carried an item media type (the UI default) even though
+        // their results were only ever containers - the migration replaces it outright.
+        var dto = new SmartCollectionDto
+        {
+            Name = "Legacy",
+            MediaTypes = [MediaTypeConstants.Movie],
+            ExpressionSets =
+            [
+                Group(
+                    IncludeOnlyCollectionsRule(op: "Contains", value: "Marvel"),
+                    new Expression("Studios", "Contains", "Disney")),
+            ],
+        };
+
+        SmartListFileSystem.ApplyPostProcessing(dto);
+
+        Assert.Equal([MediaTypeConstants.Collection], dto.MediaTypes);
+
+        var rules = Assert.Single(dto.ExpressionSets).Expressions!;
+        Assert.Equal(2, rules.Count);
+
+        // The include-only rule becomes a Name rule against the container, operator/value intact
+        Assert.Equal("Name", rules[0].MemberName);
+        Assert.Equal("Contains", rules[0].Operator);
+        Assert.Equal("Marvel", rules[0].TargetValue);
+        Assert.Null(rules[0].IncludeCollectionOnly);
+        Assert.Null(rules[0].IncludePlaylistOnly);
+
+        // Sibling rules already evaluated against the container and carry over unchanged
+        Assert.Equal("Studios", rules[1].MemberName);
+        Assert.Equal("Contains", rules[1].Operator);
+        Assert.Equal("Disney", rules[1].TargetValue);
+
+        // Toggle stays off: migrated lists keep matching containers by their own metadata
+        Assert.False(dto.MatchByMembers);
+    }
+
+    [Fact]
+    public void PureIncludeOnlyPlaylistsRule_MigratesToPlaylistMediaType()
+    {
+        var dto = new SmartCollectionDto
+        {
+            Name = "Legacy",
+            MediaTypes = [MediaTypeConstants.Audio],
+            ExpressionSets = [Group(IncludeOnlyPlaylistsRule(op: "Equal", value: "Morning Mix"))],
+        };
+
+        SmartListFileSystem.ApplyPostProcessing(dto);
+
+        Assert.Equal([MediaTypeConstants.Playlist], dto.MediaTypes);
+
+        var rule = Assert.Single(Assert.Single(dto.ExpressionSets).Expressions!);
+        Assert.Equal("Name", rule.MemberName);
+        Assert.Equal("Equal", rule.Operator);
+        Assert.Equal("Morning Mix", rule.TargetValue);
+        Assert.Null(rule.IncludePlaylistOnly);
+    }
+
+    [Fact]
+    public void PureIncludeOnlyCollection_KeepsCollectionSearchDepthReachable()
+    {
+        // The nested-collection walk depth lived on the include-only rule. The rewrite must not
+        // strand it: the depth stays on the Name rule and SmartList's depth extraction reads it
+        // from there, so migrated lists keep their configured depth instead of falling back to 0
+        // (which would kill the nested walk and child-aggregation sorting).
+        var dto = new SmartCollectionDto
+        {
+            Id = "legacy-depth",
+            Name = "Legacy depth",
+            MediaTypes = [MediaTypeConstants.Movie],
+            ExpressionSets =
+            [
+                Group(new Expression("Collections", "Contains", "Marvel")
+                {
+                    IncludeCollectionOnly = true,
+                    CollectionSearchDepth = 3,
+                }),
+            ],
+        };
+
+        SmartListFileSystem.ApplyPostProcessing(dto);
+
+        var rule = Assert.Single(Assert.Single(dto.ExpressionSets).Expressions!);
+        Assert.Equal("Name", rule.MemberName);
+        Assert.Equal(3, rule.CollectionSearchDepth);
+        Assert.Equal(3, new SmartList(dto).CollectionSearchDepth);
+    }
+
+    // ---------------------------------------------------------------------------------
+    // Collections - mixed legacy lists
+    // ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void MixedLegacyCollection_KeepsItemMediaTypesAndAppendsContainerType()
+    {
+        var dto = new SmartCollectionDto
+        {
+            Name = "Mixed",
+            MediaTypes = [MediaTypeConstants.Movie, MediaTypeConstants.Series],
+            ExpressionSets =
+            [
+                Group(IncludeOnlyCollectionsRule()),
+                Group(new Expression("Genres", "Contains", "Action")),
+            ],
+        };
+
+        SmartListFileSystem.ApplyPostProcessing(dto);
+
+        Assert.Equal(
+            [MediaTypeConstants.Movie, MediaTypeConstants.Series, MediaTypeConstants.Collection],
+            dto.MediaTypes);
+
+        // The include-only rule is rewritten, the normal item group is untouched
+        var migratedRule = Assert.Single(dto.ExpressionSets[0].Expressions!);
+        Assert.Equal("Name", migratedRule.MemberName);
+        Assert.Null(migratedRule.IncludeCollectionOnly);
+
+        var itemRule = Assert.Single(dto.ExpressionSets[1].Expressions!);
+        Assert.Equal("Genres", itemRule.MemberName);
+        Assert.Equal("Contains", itemRule.Operator);
+        Assert.Equal("Action", itemRule.TargetValue);
+    }
+
+    [Fact]
+    public void GroupWithBothIncludeOnlyFlavors_GainsBothContainerTypes()
+    {
+        // One group carrying BOTH flavors: the list is pure include-only (its only group has an
+        // include-only rule), so the item type is dropped and BOTH container types are added.
+        var dto = new SmartCollectionDto
+        {
+            Name = "Both Flavors",
+            MediaTypes = [MediaTypeConstants.Movie],
+            ExpressionSets = [Group(IncludeOnlyCollectionsRule(), IncludeOnlyPlaylistsRule())],
+        };
+
+        SmartListFileSystem.ApplyPostProcessing(dto);
+
+        Assert.Equal([MediaTypeConstants.Collection, MediaTypeConstants.Playlist], dto.MediaTypes);
+
+        var rules = Assert.Single(dto.ExpressionSets).Expressions!;
+        Assert.Equal(2, rules.Count);
+        Assert.All(rules, r => Assert.Equal("Name", r.MemberName));
+    }
+
+    [Fact]
+    public void NormalCollectionsMembershipRule_IsNotRewritten()
+    {
+        // Collections rules WITHOUT the include-only flag are membership rules
+        // ("items belonging to collection X") and must survive migration as-is.
+        var dto = new SmartCollectionDto
+        {
+            Name = "Membership",
+            MediaTypes = [MediaTypeConstants.Movie],
+            ExpressionSets = [Group(new Expression("Collections", "Contains", "Marvel"))],
+        };
+
+        SmartListFileSystem.ApplyPostProcessing(dto);
+
+        Assert.Equal([MediaTypeConstants.Movie], dto.MediaTypes);
+        var rule = Assert.Single(Assert.Single(dto.ExpressionSets).Expressions!);
+        Assert.Equal("Collections", rule.MemberName);
+    }
+
+    // ---------------------------------------------------------------------------------
+    // Playlists - flags are stripped, never migrated
+    // ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void PlaylistWithIncludeOnlyFlags_HasFlagsStrippedWithoutMigration()
+    {
+        var dto = new SmartPlaylistDto
+        {
+            Name = "Legacy Playlist",
+            MediaTypes = [MediaTypeConstants.Movie],
+            ExpressionSets = [Group(IncludeOnlyCollectionsRule(), IncludeOnlyPlaylistsRule())],
+        };
+
+        SmartListFileSystem.ApplyPostProcessing(dto);
+
+        // No media-type migration and no rule rewrite - the flags just disappear
+        Assert.Equal([MediaTypeConstants.Movie], dto.MediaTypes);
+
+        var rules = Assert.Single(dto.ExpressionSets).Expressions!;
+        Assert.Equal("Collections", rules[0].MemberName);
+        Assert.Equal("Playlists", rules[1].MemberName);
+        Assert.All(rules, r =>
+        {
+            Assert.Null(r.IncludeCollectionOnly);
+            Assert.Null(r.IncludePlaylistOnly);
+        });
+    }
+
+    [Fact]
+    public void PlaylistIncludeOnlyGroup_IsRemovedWhenOtherGroupsRemain()
+    {
+        // The legacy engine skipped include-only groups on playlists entirely (container results
+        // were dropped at write), so the behavior-preserving migration removes the dead group
+        // rather than letting its rules start filtering items.
+        var normalGroup = Group(new Expression("Genres", "Contains", "Action"));
+        var dto = new SmartPlaylistDto
+        {
+            Name = "Legacy Mixed Playlist",
+            MediaTypes = [MediaTypeConstants.Movie],
+            ExpressionSets = [Group(IncludeOnlyCollectionsRule()), normalGroup],
+        };
+
+        SmartListFileSystem.ApplyPostProcessing(dto);
+
+        var survivor = Assert.Single(dto.ExpressionSets);
+        Assert.Same(normalGroup, survivor);
+        Assert.Equal("Genres", Assert.Single(survivor.Expressions!).MemberName);
+    }
+
+    [Fact]
+    public void PlaylistWithContainerMediaTypes_HasThemDropped()
+    {
+        // The DTO setter accepts container types (they are valid for collections), so stored
+        // playlist JSON carrying them is sanitized at load instead.
+        var dto = new SmartPlaylistDto
+        {
+            Name = "Hand-edited",
+            MediaTypes = [MediaTypeConstants.Movie, MediaTypeConstants.Collection, MediaTypeConstants.Playlist],
+            ExpressionSets = [Group(new Expression("Genres", "Contains", "Action"))],
+        };
+
+        SmartListFileSystem.ApplyPostProcessing(dto);
+
+        Assert.Equal([MediaTypeConstants.Movie], dto.MediaTypes);
+    }
+
+    // ---------------------------------------------------------------------------------
+    // Idempotency and already-migrated lists
+    // ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void CollectionMigration_IsIdempotent()
+    {
+        var dto = new SmartCollectionDto
+        {
+            Name = "Mixed",
+            MediaTypes = [MediaTypeConstants.Movie],
+            ExpressionSets =
+            [
+                Group(IncludeOnlyCollectionsRule()),
+                Group(IncludeOnlyPlaylistsRule()),
+                Group(new Expression("Genres", "Contains", "Action")),
+            ],
+        };
+
+        SmartListFileSystem.ApplyPostProcessing(dto);
+        var afterFirstRun = JsonSerializer.Serialize(dto);
+
+        SmartListFileSystem.ApplyPostProcessing(dto);
+        var afterSecondRun = JsonSerializer.Serialize(dto);
+
+        Assert.Equal(afterFirstRun, afterSecondRun);
+    }
+
+    [Fact]
+    public void AlreadyMigratedCollection_IsLeftUntouched()
+    {
+        var dto = new SmartCollectionDto
+        {
+            Name = "New Format",
+            MediaTypes = [MediaTypeConstants.Movie, MediaTypeConstants.Collection],
+            MatchByMembers = true,
+            ExpressionSets = [Group(new Expression("Name", "Contains", "Marvel"))],
+        };
+        var before = JsonSerializer.Serialize(dto);
+
+        SmartListFileSystem.ApplyPostProcessing(dto);
+
+        Assert.Equal(before, JsonSerializer.Serialize(dto));
+    }
+}

--- a/Jellyfin.Plugin.SmartLists.Tests/Utilities/InputValidatorTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Utilities/InputValidatorTests.cs
@@ -701,10 +701,42 @@ public class InputValidatorTests
     [Fact]
     public void ValidateSmartList_EveryKnownMediaType_SurvivesTheDtoFilterAndValidates()
     {
-        var dto = ValidPlaylist();
-        dto.MediaTypes = [.. MediaTypeConstants.All];
+        // Collections accept every known media type, including the container types
+        // (Collection/Playlist) that playlists reject.
+        var dto = new SmartCollectionDto
+        {
+            Name = "Valid List",
+            MediaTypes = [.. MediaTypeConstants.All],
+            ExpressionSets = [Group(Rule())],
+        };
 
         Assert.Equal(MediaTypeConstants.All.Length, dto.MediaTypes.Count);
+        AssertValid(InputValidator.ValidateSmartList(dto));
+    }
+
+    [Theory]
+    [InlineData(MediaTypeConstants.Collection)]
+    [InlineData(MediaTypeConstants.Playlist)]
+    public void ValidateSmartList_ContainerMediaTypeOnPlaylist_IsRejected(string mediaType)
+    {
+        var dto = ValidPlaylist();
+        dto.MediaTypes = [MediaTypeConstants.Movie, mediaType];
+
+        AssertInvalid(InputValidator.ValidateSmartList(dto), mediaType + " media type is not supported for playlists");
+    }
+
+    [Theory]
+    [InlineData(MediaTypeConstants.Collection)]
+    [InlineData(MediaTypeConstants.Playlist)]
+    public void ValidateSmartList_ContainerMediaTypeOnCollection_IsAccepted(string mediaType)
+    {
+        var dto = new SmartCollectionDto
+        {
+            Name = "Valid List",
+            MediaTypes = [mediaType],
+            ExpressionSets = [Group(Rule())],
+        };
+
         AssertValid(InputValidator.ValidateSmartList(dto));
     }
 
@@ -876,6 +908,8 @@ public class InputValidatorTests
     [InlineData(MediaTypeConstants.Series)]
     [InlineData(MediaTypeConstants.Season)]
     [InlineData(MediaTypeConstants.MusicAlbum)]
+    [InlineData(MediaTypeConstants.Collection)]
+    [InlineData(MediaTypeConstants.Playlist)]
     public void ValidateSmartList_ContainerBumperMediaTypes_AreRejectedBecausePlaylistsCannotHoldThem(string mediaType)
     {
         var dto = PlaylistWithBumpers(b => b.MediaTypes = [mediaType]);

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-core.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-core.js
@@ -57,6 +57,15 @@
     SmartLists.AUDIO_CAPABLE_TYPES = ['Movie', 'Episode', 'Audio', 'AudioBook', 'MusicVideo', 'Video'];
     SmartLists.VIDEO_CAPABLE_TYPES = ['Movie', 'Episode', 'MusicVideo', 'Video'];
 
+    // Container media types - the collections/playlists themselves rather than the media
+    // items inside them. Only offered for smart collections (mirrors MediaTypes.ContainerTypes)
+    SmartLists.CONTAINER_MEDIA_TYPES = ['Collection', 'Playlist'];
+
+    // Fields a container (collection/playlist) actually has metadata for. When ONLY container
+    // types are selected and "Match by members" is off, rules evaluate the container itself,
+    // so the rule-field dropdown is restricted to these fields.
+    SmartLists.CONTAINER_METADATA_FIELDS = ['Name', 'Genres', 'Studios', 'ProductionYear', 'OfficialRating', 'DateCreated', 'DateLastRefreshed', 'DateLastSaved', 'ReleaseDate', 'Collections'];
+
     // Audio and video field lists for visibility gating
     SmartLists.AUDIO_FIELD_NAMES = ['AudioBitrate', 'AudioSampleRate', 'AudioBitDepth', 'AudioCodec', 'AudioProfile', 'AudioChannels', 'AudioLanguages', 'SubtitleLanguages'];
     SmartLists.VIDEO_FIELD_NAMES = ['Resolution', 'Framerate', 'VideoCodec', 'VideoProfile', 'VideoRange', 'VideoRangeType'];
@@ -155,7 +164,9 @@
         { Value: "Video", Label: "Video" },
         { Value: "Photo", Label: "Photo (Home Photo)" },
         { Value: "Book", Label: "Book" },
-        { Value: "AudioBook", Label: "Audiobook" }
+        { Value: "AudioBook", Label: "Audiobook" },
+        { Value: "Collection", Label: "Collection", CollectionOnly: true }, // Containers can only be added to Collections, not Playlists
+        { Value: "Playlist", Label: "Playlist", CollectionOnly: true } // Containers can only be added to Collections, not Playlists
     ];
 
     // Resolve the rules container for a scope: 'main' (default) or 'bumper'
@@ -170,6 +181,42 @@
             return (bumperSelect && bumperSelect.value) ? [bumperSelect.value] : [];
         }
         return SmartLists.getSelectedItems(page, 'mediaTypesMultiSelect', 'media-type-multi-select-checkbox');
+    };
+
+    // True when at least one container media type (Collection/Playlist) is selected
+    SmartLists.hasContainerMediaType = function (selectedMediaTypes) {
+        if (!selectedMediaTypes) return false;
+        return selectedMediaTypes.some(function (type) {
+            return SmartLists.CONTAINER_MEDIA_TYPES.indexOf(type) !== -1;
+        });
+    };
+
+    // True when the rule-field dropdown should be restricted to container metadata fields:
+    // every selected media type is a container AND "Match by members" is off (rules then
+    // evaluate the container's own metadata, not its member items). Bumper rules never
+    // apply - container types can't be selected as a bumper media type.
+    SmartLists.isContainerMetadataOnlyMode = function (page, scope) {
+        if (!page || scope === 'bumper') return false;
+        var selectedMediaTypes = SmartLists.getSelectedMediaTypes(page, 'main');
+        if (!selectedMediaTypes || selectedMediaTypes.length === 0) return false;
+        for (var i = 0; i < selectedMediaTypes.length; i++) {
+            if (SmartLists.CONTAINER_MEDIA_TYPES.indexOf(selectedMediaTypes[i]) === -1) return false;
+        }
+        var matchByMembersCheckbox = page.querySelector('#matchByMembers');
+        return !(matchByMembersCheckbox && matchByMembersCheckbox.checked);
+    };
+
+    // True when a container media type is selected AND "Match by members" is on:
+    // rules then evaluate member items, which can be of any supported kind, so the
+    // rule-field dropdown must offer the full item field set regardless of the
+    // selected media types. Bumper rules never apply - container types can't be
+    // selected as a bumper media type.
+    SmartLists.isMatchByMembersMode = function (page, scope) {
+        if (!page || scope === 'bumper') return false;
+        var selectedMediaTypes = SmartLists.getSelectedMediaTypes(page, 'main');
+        if (!SmartLists.hasContainerMediaType(selectedMediaTypes)) return false;
+        var matchByMembersCheckbox = page.querySelector('#matchByMembers');
+        return !!(matchByMembersCheckbox && matchByMembersCheckbox.checked);
     };
 
     // Resolve a rule row's editor scope ('main' or 'bumper') from its logic group's data-rule-scope attribute

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
@@ -318,6 +318,12 @@
     // Batch update function for all media type changes
     // Order matters: repopulate fields first (may invalidate), then sync dependent UI
     SmartLists.applyMediaTypeDependentUpdates = function (page) {
+        // 0) Sync the "Match by members" toggle first - hiding it unchecks the
+        // checkbox, which feeds the container-metadata field gating below
+        if (SmartLists.updateMatchByMembersVisibility) {
+            SmartLists.updateMatchByMembersVisibility(page);
+        }
+
         // 1) Re-populate fields (may invalidate current selections)
         if (SmartLists.updateAllFieldSelects) {
             SmartLists.updateAllFieldSelects(page);
@@ -465,6 +471,7 @@
         // Set default public/enabled/extras checkboxes
         SmartLists.setElementChecked(page, '#playlistIsPublic', config.DefaultMakePublic || false);
         SmartLists.setElementChecked(page, '#playlistIncludeExtras', false);
+        SmartLists.setElementChecked(page, '#matchByMembers', false);
         // Cache the resolved default so template application can read it even
         // after the checkbox has been toggled (e.g. by a previous template)
         page._defaultHideWhenEmpty = SmartLists.getDefaultHideWhenEmpty(config);
@@ -523,6 +530,7 @@
         SmartLists.setElementValue(page, '#autoRefreshMode', 'OnLibraryChanges');
         SmartLists.setElementChecked(page, '#playlistIsPublic', false);
         SmartLists.setElementChecked(page, '#playlistIncludeExtras', false);
+        SmartLists.setElementChecked(page, '#matchByMembers', false);
         page._defaultHideWhenEmpty = SmartLists.getDefaultHideWhenEmpty(null);
         SmartLists.setElementChecked(page, '#playlistHideWhenEmpty', page._defaultHideWhenEmpty);
         SmartLists.setElementChecked(page, '#playlistIsEnabled', true);
@@ -988,6 +996,14 @@
         if (listTypeSelect) {
             listTypeSelect.addEventListener('change', function () {
                 SmartLists.handleListTypeChange(page);
+            }, SmartLists.getEventListenerOptions(pageSignal));
+        }
+
+        // Match-by-members toggle changes which rule fields are offered for container-only lists
+        const matchByMembersCheckbox = page.querySelector('#matchByMembers');
+        if (matchByMembersCheckbox) {
+            matchByMembersCheckbox.addEventListener('change', function () {
+                SmartLists.applyMediaTypeDependentUpdates(page);
             }, SmartLists.getEventListenerOptions(pageSignal));
         }
 
@@ -2964,6 +2980,12 @@
         // Update Include Extras checkbox visibility based on media types
         if (SmartLists.updateIncludeExtrasVisibility) {
             SmartLists.updateIncludeExtrasVisibility(page);
+        }
+
+        // Update Match by members toggle visibility (container types are collection-only,
+        // so switching to Playlist strips them and this hides + resets the toggle)
+        if (SmartLists.updateMatchByMembersVisibility) {
+            SmartLists.updateMatchByMembersVisibility(page);
         }
 
         // Hide the bumper section for collections (playlists only feature)

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -345,6 +345,9 @@
 
             const isPublic = SmartLists.getElementChecked(page, '#playlistIsPublic', false);
             const includeExtras = SmartLists.getElementChecked(page, '#playlistIncludeExtras', false);
+            // Only meaningful when a container media type is selected; the checkbox is
+            // reset whenever the toggle is hidden, so reading it directly is safe
+            const matchByMembers = SmartLists.getElementChecked(page, '#matchByMembers', false);
             const hideWhenEmpty = SmartLists.getElementChecked(page, '#playlistHideWhenEmpty', false);
             const isEnabled = SmartLists.getElementChecked(page, '#playlistIsEnabled', true); // Default to true
             const autoRefreshMode = SmartLists.getElementValue(page, '#autoRefreshMode', 'Never');
@@ -441,6 +444,7 @@
                 Bumpers: bumperConfig,
                 Enabled: isEnabled,
                 IncludeExtras: includeExtras,
+                MatchByMembers: matchByMembers,
                 HideWhenEmpty: hideWhenEmpty,
                 MediaTypes: selectedMediaTypes,
                 MaxItems: maxItems,
@@ -977,6 +981,7 @@
 
         SmartLists.setElementChecked(page, '#playlistIsEnabled', playlist.Enabled !== false); // Default to true for backward compatibility
         SmartLists.setElementChecked(page, '#playlistIncludeExtras', playlist.IncludeExtras || false);
+        SmartLists.setElementChecked(page, '#matchByMembers', playlist.MatchByMembers || false);
         SmartLists.setElementChecked(page, '#playlistHideWhenEmpty', playlist.HideWhenEmpty || false);
 
         // Handle AutoRefresh with backward compatibility
@@ -1023,6 +1028,11 @@
         // Update Include Extras visibility based on loaded media types
         if (SmartLists.updateIncludeExtrasVisibility) {
             SmartLists.updateIncludeExtrasVisibility(page);
+        }
+
+        // Update Match by members toggle visibility based on loaded media types
+        if (SmartLists.updateMatchByMembersVisibility) {
+            SmartLists.updateMatchByMembersVisibility(page);
         }
         SmartLists.loadRandomGroupSelectionIntoUI(page, playlist);
 
@@ -1630,9 +1640,7 @@
                         let collectionsInfo = '';
                         if (rule.MemberName === 'Collections') {
                             var collectionParts = [];
-                            if (rule.IncludeCollectionOnly === true) {
-                                collectionParts.push('collection only');
-                            } else if (rule.IncludeEpisodesWithinSeries === true) {
+                            if (rule.IncludeEpisodesWithinSeries === true) {
                                 collectionParts.push('including episodes within series');
                             }
                             // Add depth info if set
@@ -1642,12 +1650,6 @@
                             if (collectionParts.length > 0) {
                                 collectionsInfo = ' (' + collectionParts.join(', ') + ')';
                             }
-                        }
-
-                        // Add Playlists configuration info
-                        let playlistsInfo = '';
-                        if (rule.MemberName === 'Playlists' && rule.IncludePlaylistOnly === true) {
-                            playlistsInfo = ' (playlist only)';
                         }
 
                         // Add Tags configuration info. The legacy IncludeParentSeries*/IncludeParentAlbum*
@@ -1699,7 +1701,7 @@
                         }
 
                         rulesHtml += '<span style="font-family: monospace; background: var(--jf-palette-background-paper); border: 1px solid var(--jf-palette-divider); padding: 4px 4px; border-radius: 3px;">';
-                        rulesHtml += SmartLists.escapeHtml(fieldName) + ' ' + SmartLists.escapeHtml(operator) + ' "' + SmartLists.escapeHtml(value) + '"' + SmartLists.escapeHtml(userInfo) + SmartLists.escapeHtml(nextUnwatchedInfo) + SmartLists.escapeHtml(unknownDateInfo) + SmartLists.escapeHtml(collectionsInfo) + SmartLists.escapeHtml(playlistsInfo) + SmartLists.escapeHtml(tagsInfo) + SmartLists.escapeHtml(studiosInfo) + SmartLists.escapeHtml(genresInfo) + SmartLists.escapeHtml(audioLanguagesInfo) + SmartLists.escapeHtml(similarityInfo);
+                        rulesHtml += SmartLists.escapeHtml(fieldName) + ' ' + SmartLists.escapeHtml(operator) + ' "' + SmartLists.escapeHtml(value) + '"' + SmartLists.escapeHtml(userInfo) + SmartLists.escapeHtml(nextUnwatchedInfo) + SmartLists.escapeHtml(unknownDateInfo) + SmartLists.escapeHtml(collectionsInfo) + SmartLists.escapeHtml(tagsInfo) + SmartLists.escapeHtml(studiosInfo) + SmartLists.escapeHtml(genresInfo) + SmartLists.escapeHtml(audioLanguagesInfo) + SmartLists.escapeHtml(similarityInfo);
                         rulesHtml += '</span>';
                     }
 

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-rules.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-rules.js
@@ -1150,18 +1150,6 @@
             '</select>' +
             '</div>' +
             '<div class="rule-collections-options" style="display: none; margin-bottom: 0.75em; padding: 0.5em; background: var(--jf-palette-background-paper); border: 1px solid var(--jf-palette-divider); border-radius: 4px;">' +
-            '<div class="rule-collections-collection-only" style="margin-bottom: 0.75em;">' +
-            '<label style="display: flex; align-items: center; margin-bottom: 0.25em; font-size: 0.85em; opacity: 0.8; font-weight: 500;">' +
-            'Include collections only:' +
-            '<a href="https://jellyfin-smartlists-plugin.dinsten.se/user-guide/fields-and-operators/#collection-name-options" target="_blank" rel="noopener noreferrer" title="Documentation" style="margin-left: 0.5em; text-decoration: none; color: inherit; display: inline-flex; align-items: center;">' +
-            '<span class="material-icons" aria-hidden="true" style="font-size: 1.1em; line-height: 0;">info_outline</span>' +
-            '</a>' +
-            '</label>' +
-            '<select is="emby-select" class="emby-select rule-collections-collection-only-select" style="width: 100%;">' +
-            '<option value="false">No - Include media items from the collections</option>' +
-            '<option value="true">Yes - Only include the actual collections</option>' +
-            '</select>' +
-            '</div>' +
             '<div class="rule-collections-episodes" style="margin-bottom: 0.75em;">' +
             '<label style="display: block; margin-bottom: 0.25em; font-size: 0.85em; opacity: 0.8; font-weight: 500;">' +
             'Include episodes within series:' +
@@ -1180,17 +1168,6 @@
             '</label>' +
             '<input type="number" class="emby-input rule-collections-depth-input" min="0" max="10" step="1" value="0" style="width: 100%;">' +
             '<div style="font-size: 0.75em; opacity: 0.7; margin-top: 0.25em;">How deep to traverse nested collections (0 = direct members only)</div>' +
-            '</div>' +
-            '</div>' +
-            '<div class="rule-playlists-options" style="display: none; margin-bottom: 0.75em; padding: 0.5em; background: var(--jf-palette-background-paper); border: 1px solid var(--jf-palette-divider); border-radius: 4px;">' +
-            '<div class="rule-playlists-playlist-only" style="margin-bottom: 0.75em;">' +
-            '<label style="display: block; margin-bottom: 0.25em; font-size: 0.85em; opacity: 0.8; font-weight: 500;">' +
-            'Include playlist only:' +
-            '</label>' +
-            '<select is="emby-select" class="emby-select rule-playlists-playlist-only-select" style="width: 100%;">' +
-            '<option value="false">No - Include media items from the playlist</option>' +
-            '<option value="true">Yes - Only include the playlist itself</option>' +
-            '</select>' +
             '</div>' +
             '</div>' +
             '<div class="rule-externallist-options" style="display: none; margin-bottom: 0.75em; padding: 0.5em; background: var(--jf-palette-background-paper); border: 1px solid var(--jf-palette-divider); border-radius: 4px;">' +
@@ -1303,9 +1280,6 @@
         // Initialize Collections options visibility
         SmartLists.updateCollectionsOptionsVisibility(newRuleRow, fieldSelect.value, page);
 
-        // Initialize Playlists options visibility
-        SmartLists.updatePlaylistsOptionsVisibility(newRuleRow, fieldSelect.value, page);
-
         // Initialize ExternalList options visibility
         SmartLists.updateExternalListOptionsVisibility(newRuleRow, fieldSelect.value);
 
@@ -1347,7 +1321,6 @@
             SmartLists.updateNextUnwatchedOptionsVisibility(newRuleRow, fieldSelect.value, page);
             SmartLists.updateUnknownDateOptionsVisibility(newRuleRow, fieldSelect.value);
             SmartLists.updateCollectionsOptionsVisibility(newRuleRow, fieldSelect.value, page);
-            SmartLists.updatePlaylistsOptionsVisibility(newRuleRow, fieldSelect.value, page);
             SmartLists.updateExternalListOptionsVisibility(newRuleRow, fieldSelect.value);
             SmartLists.updateTagsOptionsVisibility(newRuleRow, fieldSelect.value, page);
             SmartLists.updateStudiosOptionsVisibility(newRuleRow, fieldSelect.value, page);
@@ -1373,36 +1346,6 @@
             const fieldValue = fieldSelect.value;
             SmartLists.setValueInput(fieldValue, valueContainer, this.value);
         }, listenerOptions);
-
-        // Add event listener for collection-only select to hide/show episodes field
-        const collectionOnlySelect = newRuleRow.querySelector('.rule-collections-collection-only-select');
-        if (collectionOnlySelect) {
-            collectionOnlySelect.addEventListener('change', function () {
-                // Use the centralized visibility function to ensure consistency
-                const fieldSelect = newRuleRow.querySelector('.rule-field-select');
-                const fieldValue = fieldSelect ? fieldSelect.value : '';
-                SmartLists.updateCollectionsOptionsVisibility(newRuleRow, fieldValue, page);
-                // Update sort "Use Child Values" checkbox visibility when collection-only option changes
-                if (SmartLists.updateUseChildValuesVisibility) {
-                    SmartLists.updateUseChildValuesVisibility(page);
-                }
-            }, listenerOptions);
-        }
-
-        // Add change listener for Playlists playlist-only option
-        const playlistOnlySelect = newRuleRow.querySelector('.rule-playlists-playlist-only-select');
-        if (playlistOnlySelect) {
-            playlistOnlySelect.addEventListener('change', function () {
-                // Use the centralized visibility function to ensure consistency
-                const fieldSelect = newRuleRow.querySelector('.rule-field-select');
-                const fieldValue = fieldSelect ? fieldSelect.value : '';
-                SmartLists.updatePlaylistsOptionsVisibility(newRuleRow, fieldValue, page);
-                // Update sort "Use Child Values" checkbox visibility when playlist-only option changes
-                if (SmartLists.updateUseChildValuesVisibility) {
-                    SmartLists.updateUseChildValuesVisibility(page);
-                }
-            }, listenerOptions);
-        }
 
         // Style the action buttons
         const actionButtons = newRuleRow.querySelectorAll('.rule-action-btn');
@@ -1534,14 +1477,8 @@
         const unknownDateValue = unknownDateSelect ? unknownDateSelect.value : '';
 
         // Extract Collections options
-        const collectionOnlySelect = ruleRow.querySelector('.rule-collections-collection-only-select');
-        const collectionOnlyValue = collectionOnlySelect ? collectionOnlySelect.value : '';
         const collectionsSelect = ruleRow.querySelector('.rule-collections-select');
         const collectionsValue = collectionsSelect ? collectionsSelect.value : '';
-
-        // Extract Playlists options
-        const playlistOnlySelect = ruleRow.querySelector('.rule-playlists-playlist-only-select');
-        const playlistOnlyValue = playlistOnlySelect ? playlistOnlySelect.value : '';
 
         // Extract Tags, Studios, Genres, AudioLanguages options
         const tagsSelect = ruleRow.querySelector('.rule-tags-select');
@@ -1602,9 +1539,6 @@
             expression.IncludeUnknownDates = true;
         }
         if (fieldValue === 'Collections') {
-            if (collectionOnlyValue === 'true') {
-                expression.IncludeCollectionOnly = true;
-            }
             if (collectionsValue === 'true') {
                 expression.IncludeEpisodesWithinSeries = true;
             }
@@ -1616,10 +1550,19 @@
                     expression.CollectionSearchDepth = Math.min(depthValue, 10);
                 }
             }
-        }
-        if (fieldValue === 'Playlists') {
-            if (playlistOnlyValue === 'true') {
-                expression.IncludePlaylistOnly = true;
+        } else if (fieldValue === 'Name') {
+            // Name rules carry the Collection search depth on container lists; the depth
+            // input is only visible when the Collection media type is selected, so gate
+            // on visibility to emit exactly what collectRulesFromForm emits
+            var collectionsOptionsDiv = ruleRow.querySelector('.rule-collections-options');
+            if (collectionsOptionsDiv && collectionsOptionsDiv.style.display !== 'none') {
+                var nameDepthInput = ruleRow.querySelector('.rule-collections-depth-input');
+                if (nameDepthInput) {
+                    var nameDepthValue = parseInt(nameDepthInput.value, 10);
+                    if (!isNaN(nameDepthValue) && nameDepthValue > 0) {
+                        expression.CollectionSearchDepth = Math.min(nameDepthValue, 10);
+                    }
+                }
             }
         }
         // Must emit exactly what collectRulesFromForm emits, or a cloned rule round-trips
@@ -1945,7 +1888,6 @@
                     SmartLists.updateNextUnwatchedOptionsVisibility(ruleRow, currentFieldValue, page);
                     SmartLists.updateUnknownDateOptionsVisibility(ruleRow, currentFieldValue);
                     SmartLists.updateCollectionsOptionsVisibility(ruleRow, currentFieldValue, page);
-                    SmartLists.updatePlaylistsOptionsVisibility(ruleRow, currentFieldValue, page);
                     SmartLists.updateTagsOptionsVisibility(ruleRow, currentFieldValue, page);
                     SmartLists.updateStudiosOptionsVisibility(ruleRow, currentFieldValue, page);
                     SmartLists.updateGenresOptionsVisibility(ruleRow, currentFieldValue, page);
@@ -1976,7 +1918,6 @@
                     SmartLists.updateNextUnwatchedOptionsVisibility(ruleRow, fieldSelect.value, page);
                     SmartLists.updateUnknownDateOptionsVisibility(ruleRow, fieldSelect.value);
                     SmartLists.updateCollectionsOptionsVisibility(ruleRow, fieldSelect.value, page);
-                    SmartLists.updatePlaylistsOptionsVisibility(ruleRow, fieldSelect.value, page);
                     SmartLists.updateTagsOptionsVisibility(ruleRow, fieldSelect.value, page);
                     SmartLists.updateStudiosOptionsVisibility(ruleRow, fieldSelect.value, page);
                     SmartLists.updateGenresOptionsVisibility(ruleRow, fieldSelect.value, page);
@@ -2001,36 +1942,6 @@
                     const fieldValue = fieldSelect.value;
                     SmartLists.setValueInput(fieldValue, valueContainer, this.value);
                 }, listenerOptions);
-
-                // Add event listener for collection-only select to hide/show episodes field
-                const collectionOnlySelect = ruleRow.querySelector('.rule-collections-collection-only-select');
-                if (collectionOnlySelect) {
-                    collectionOnlySelect.addEventListener('change', function () {
-                        // Use the centralized visibility function to ensure consistency
-                        const fieldSelect = ruleRow.querySelector('.rule-field-select');
-                        const fieldValue = fieldSelect ? fieldSelect.value : '';
-                        SmartLists.updateCollectionsOptionsVisibility(ruleRow, fieldValue, page);
-                        // Update sort "Use Child Values" checkbox visibility when collection-only option changes
-                        if (SmartLists.updateUseChildValuesVisibility) {
-                            SmartLists.updateUseChildValuesVisibility(page);
-                        }
-                    }, listenerOptions);
-                }
-
-                // Add event listener for playlist-only select
-                const playlistOnlySelect = ruleRow.querySelector('.rule-playlists-playlist-only-select');
-                if (playlistOnlySelect) {
-                    playlistOnlySelect.addEventListener('change', function () {
-                        // Use the centralized visibility function to ensure consistency
-                        const fieldSelect = ruleRow.querySelector('.rule-field-select');
-                        const fieldValue = fieldSelect ? fieldSelect.value : '';
-                        SmartLists.updatePlaylistsOptionsVisibility(ruleRow, fieldValue, page);
-                        // Update sort "Use Child Values" checkbox visibility when playlist-only option changes
-                        if (SmartLists.updateUseChildValuesVisibility) {
-                            SmartLists.updateUseChildValuesVisibility(page);
-                        }
-                    }, listenerOptions);
-                }
 
                 // Re-style action buttons
                 const actionButtons = ruleRow.querySelectorAll('.rule-action-btn');
@@ -2078,7 +1989,12 @@
         // Get selected media types for filtering
         const selectedMediaTypes = page ? SmartLists.getSelectedMediaTypes(page, scope) : [];
         const listType = page ? SmartLists.getElementValue(page, '#listType', 'Playlist') : 'Playlist';
-        const filteredFieldGroups = SmartLists.filterFieldsByMediaType(fieldGroups, selectedMediaTypes, listType);
+        const containerMetadataOnly = SmartLists.isContainerMetadataOnlyMode(page, scope);
+        // Match-by-members mode evaluates rules against member items, which can be of
+        // any supported kind - bypass media-type gating so the full item field set is
+        // offered (listType gating, e.g. SeriesStatus, still applies)
+        const effectiveMediaTypes = SmartLists.isMatchByMembersMode(page, scope) ? [] : selectedMediaTypes;
+        const filteredFieldGroups = SmartLists.filterFieldsByMediaType(fieldGroups, effectiveMediaTypes, listType, containerMetadataOnly);
 
         // Get the current selected value before clearing
         const currentValue = selectElement.value;
@@ -2127,8 +2043,48 @@
             }
         });
 
+        // Preserve a restored field that the container-metadata gate filtered out
+        // (migrated include-only lists may carry item fields on their sibling rules)
+        // so the saved rule is kept selected instead of silently blanked on edit
+        const restoreValue = defaultValue || currentValue;
+        if (containerMetadataOnly && restoreValue && SmartLists.ensurePreservedFieldOption(selectElement, restoreValue, page, scope)) {
+            selectElement.value = restoreValue;
+        }
+
         // Refresh searchable select overlay if initialized
         SmartLists.refreshSearchableSelect(selectElement);
+    };
+
+    // In container-metadata-only mode the field picker is gated to container metadata
+    // fields, but a stored rule may carry an item field (e.g. migrated include-only
+    // lists whose sibling rules kept item fields). Append the saved field as an extra
+    // option so the rule survives editing - new rules still can't pick gated fields.
+    // Returns true when the option exists (already listed or appended here).
+    SmartLists.ensurePreservedFieldOption = function (selectElement, fieldValue, page, scope) {
+        if (!selectElement || !fieldValue) return false;
+        if (!SmartLists.isContainerMetadataOnlyMode(page, scope)) return false;
+        for (var i = 0; i < selectElement.options.length; i++) {
+            if (selectElement.options[i].value === fieldValue) return true;
+        }
+        // Only preserve fields the API actually knows about; look up the display label
+        var fieldLabel = null;
+        var fieldGroups = SmartLists.availableFields || {};
+        Object.keys(fieldGroups).forEach(function (groupKey) {
+            var fields = fieldGroups[groupKey];
+            if (fieldLabel === null && fields && Array.isArray(fields)) {
+                fields.forEach(function (field) {
+                    if (fieldLabel === null && field.Value === fieldValue) {
+                        fieldLabel = field.Label;
+                    }
+                });
+            }
+        });
+        if (fieldLabel === null) return false;
+        var option = document.createElement('option');
+        option.value = fieldValue;
+        option.textContent = fieldLabel;
+        selectElement.appendChild(option);
+        return true;
     };
 
     // Update all field selects across all rules when media types change
@@ -2142,6 +2098,11 @@
         // Hoist the two possible media-type arrays; each row picks by its scope below
         const mainTypes = SmartLists.getSelectedMediaTypes(page, 'main');
         const bumperTypes = SmartLists.getSelectedMediaTypes(page, 'bumper');
+        // Container-only + match-by-members off restricts fields to container metadata (main scope only)
+        const mainContainerMetadataOnly = SmartLists.isContainerMetadataOnlyMode(page, 'main');
+        // Container + match-by-members on evaluates member items of any kind - bypass
+        // media-type gating for main rows so the full item field set stays valid
+        const effectiveMainTypes = SmartLists.isMatchByMembersMode(page, 'main') ? [] : mainTypes;
 
         const allRuleRows = page.querySelectorAll('.rule-row');
         allRuleRows.forEach(function (ruleRow) {
@@ -2149,12 +2110,19 @@
             if (fieldSelect) {
                 // Resolve each row's scope so bumper rows use bumper media types
                 const rowScope = SmartLists.getRowScope(ruleRow);
-                const selectedMediaTypes = rowScope === 'bumper' ? bumperTypes : mainTypes;
+                const selectedMediaTypes = rowScope === 'bumper' ? bumperTypes : effectiveMainTypes;
+                const containerMetadataOnly = rowScope === 'bumper' ? false : mainContainerMetadataOnly;
                 const currentValue = fieldSelect.value;
                 SmartLists.populateFieldSelect(fieldSelect, SmartLists.availableFields, currentValue, page, rowScope);
 
+                // A saved field outside the container-metadata whitelist is preserved as
+                // an appended option by populateFieldSelect (migrated include-only lists
+                // may carry item fields) - treat it as valid instead of clearing the rule
+                const preservedContainerField = containerMetadataOnly && currentValue && fieldSelect.value === currentValue &&
+                    SmartLists.CONTAINER_METADATA_FIELDS.indexOf(currentValue) === -1;
+
                 // If the current field is no longer valid, clear it and reset the rule
-                if (currentValue && !SmartLists.shouldShowField(currentValue, selectedMediaTypes, listType)) {
+                if (currentValue && !preservedContainerField && !SmartLists.shouldShowField(currentValue, selectedMediaTypes, listType, containerMetadataOnly)) {
                     fieldSelect.value = '';
                     const valueContainer = ruleRow.querySelector('.rule-value-container');
                     if (valueContainer) {
@@ -2172,7 +2140,6 @@
                         SmartLists.updateNextUnwatchedOptionsVisibility(ruleRow, '', page);
                         SmartLists.updateUnknownDateOptionsVisibility(ruleRow, '');
                         SmartLists.updateCollectionsOptionsVisibility(ruleRow, '', page);
-                        SmartLists.updatePlaylistsOptionsVisibility(ruleRow, '', page);
                         SmartLists.updateTagsOptionsVisibility(ruleRow, '', page);
                         SmartLists.updateStudiosOptionsVisibility(ruleRow, '', page);
                         SmartLists.updateGenresOptionsVisibility(ruleRow, '', page);
@@ -2201,7 +2168,7 @@
         });
     };
 
-    SmartLists.filterFieldsByMediaType = function (fieldGroups, selectedMediaTypes, listType) {
+    SmartLists.filterFieldsByMediaType = function (fieldGroups, selectedMediaTypes, listType, containerMetadataOnly) {
         var needsMediaTypeFiltering = selectedMediaTypes && selectedMediaTypes.length > 0;
         var needsListTypeFiltering = listType && listType !== 'Collection';
 
@@ -2217,7 +2184,7 @@
             const fields = fieldGroups[groupKey];
             if (fields && Array.isArray(fields)) {
                 filteredGroups[groupKey] = fields.filter(function (field) {
-                    return SmartLists.shouldShowField(field.Value, selectedMediaTypes, listType);
+                    return SmartLists.shouldShowField(field.Value, selectedMediaTypes, listType, containerMetadataOnly);
                 });
             } else {
                 filteredGroups[groupKey] = fields;
@@ -2228,7 +2195,13 @@
     };
 
     // Field visibility definitions based on media types and list type
-    SmartLists.shouldShowField = function (fieldValue, selectedMediaTypes, listType) {
+    SmartLists.shouldShowField = function (fieldValue, selectedMediaTypes, listType, containerMetadataOnly) {
+        // Container-only selection with "Match by members" off: rules evaluate the
+        // container's own metadata, which only exists for a handful of fields
+        if (containerMetadataOnly && SmartLists.CONTAINER_METADATA_FIELDS.indexOf(fieldValue) === -1) {
+            return false;
+        }
+
         // Collection-only fields — hide regardless of media type selection.
         // Series items only exist in Collections, not Playlists, so SeriesStatus is meaningless there.
         // LastEpisodeAirDate is intentionally NOT restricted here — it applies to Episode items too.
@@ -2361,46 +2334,34 @@
 
     SmartLists.updateCollectionsOptionsVisibility = function (ruleRow, fieldValue, page) {
         const isCollectionsField = fieldValue === 'Collections';
+        // Name rules also carry the Collection search depth on container lists: the
+        // include-only migration stores the depth there, and a new Collection-media-type
+        // list has no Collections rule to hang it on. Offer the depth option on Name
+        // rules whenever the Collection media type is selected (scoped to this row's editor).
+        const ruleScope = SmartLists.getRowScope(ruleRow);
+        const selectedMediaTypes = page ? SmartLists.getSelectedMediaTypes(page, ruleScope) : [];
+        const isNameWithCollectionType = fieldValue === 'Name' && selectedMediaTypes.indexOf('Collection') !== -1;
         const collectionsOptionsDiv = ruleRow.querySelector('.rule-collections-options');
 
         if (collectionsOptionsDiv) {
-            if (isCollectionsField) {
-                // Get list type to determine visibility
-                const listType = page ? SmartLists.getElementValue(page, '#listType', 'Playlist') : 'Playlist';
-                const isCollection = listType === 'Collection';
-
-                // Show/hide collection-only option based on list type (only for Collections list type)
-                const collectionOnlyDiv = ruleRow.querySelector('.rule-collections-collection-only');
-                if (collectionOnlyDiv) {
-                    collectionOnlyDiv.style.display = isCollection ? 'block' : 'none';
-                }
-
-                // Get collection-only select value (only relevant for Collection list type)
-                const collectionOnlySelect = ruleRow.querySelector('.rule-collections-collection-only-select');
-                const isCollectionOnly = isCollection && collectionOnlySelect && collectionOnlySelect.value === 'true';
-
-                // Show/hide episodes option (hidden if collection-only is yes OR Episode media type is not selected)
+            if (isCollectionsField || isNameWithCollectionType) {
+                // Show/hide episodes option (hidden if Episode media type is not selected;
+                // never applies to Name rules)
                 const episodesDiv = ruleRow.querySelector('.rule-collections-episodes');
-                let episodesVisible = false;
                 if (episodesDiv) {
-                    // Get selected media types to check if Episode is selected (scoped to this row's editor)
-                    const ruleScope = SmartLists.getRowScope(ruleRow);
-                    const selectedMediaTypes = page ? SmartLists.getSelectedMediaTypes(page, ruleScope) : [];
                     const hasEpisode = selectedMediaTypes.indexOf('Episode') !== -1;
 
-                    // Show only if collection-only is disabled AND Episode media type is selected
-                    episodesVisible = !isCollectionOnly && hasEpisode;
-                    episodesDiv.style.display = episodesVisible ? 'block' : 'none';
+                    episodesDiv.style.display = (isCollectionsField && hasEpisode) ? 'block' : 'none';
                 }
 
-                // Depth option is always visible when Collection name rule is selected
+                // Depth option is always visible when the options panel is shown
                 // It's useful for both Playlist and Collection list types
                 const depthDiv = ruleRow.querySelector('.rule-collections-depth');
                 if (depthDiv) {
                     depthDiv.style.display = 'block';
                 }
 
-                // Show container if any inner option is visible (depth is always visible for Collections rule)
+                // Show container if any inner option is visible (depth is always visible here)
                 collectionsOptionsDiv.style.display = 'block';
             } else {
                 // Hide but preserve user's selection - don't reset value
@@ -2412,38 +2373,6 @@
     // Update visibility of Collections options for all rules when media types change
     SmartLists.updateAllCollectionsOptionsVisibility = function (page) {
         SmartLists.updateAllRules(page, SmartLists.updateCollectionsOptionsVisibility);
-    };
-
-    SmartLists.updatePlaylistsOptionsVisibility = function (ruleRow, fieldValue, page) {
-        const isPlaylistsField = fieldValue === 'Playlists';
-        const playlistsOptionsDiv = ruleRow.querySelector('.rule-playlists-options');
-
-        if (playlistsOptionsDiv) {
-            if (isPlaylistsField) {
-                // Get list type to determine visibility
-                const listType = page ? SmartLists.getElementValue(page, '#listType', 'Playlist') : 'Playlist';
-                const isCollection = listType === 'Collection';
-
-                // Show/hide playlist-only option based on list type (only for Collections)
-                const playlistOnlyDiv = ruleRow.querySelector('.rule-playlists-playlist-only');
-                if (playlistOnlyDiv) {
-                    playlistOnlyDiv.style.display = isCollection ? 'block' : 'none';
-                }
-
-                // Get playlist-only select value
-                // Only show the container if we're creating a collection
-                // Note: Playlists don't support recursion depth - they can only contain media items, not other playlists
-                playlistsOptionsDiv.style.display = isCollection ? 'block' : 'none';
-            } else {
-                // Hide but preserve user's selection - don't reset value
-                playlistsOptionsDiv.style.display = 'none';
-            }
-        }
-    };
-
-    // Update visibility of Playlists options for all rules when media types change
-    SmartLists.updateAllPlaylistsOptionsVisibility = function (page) {
-        SmartLists.updateAllRules(page, SmartLists.updatePlaylistsOptionsVisibility);
     };
 
     SmartLists.updateExternalListOptionsVisibility = function (ruleRow, fieldValue) {
@@ -2676,6 +2605,31 @@
         }
     };
 
+    // ===== MATCH BY MEMBERS VISIBILITY =====
+    // Show/hide the "Match by members" toggle based on selected media types
+    // (only meaningful when a container type - Collection/Playlist - is selected)
+    SmartLists.updateMatchByMembersVisibility = function (page) {
+        if (!page) return;
+        var container = page.querySelector('#matchByMembersContainer');
+        if (!container) return;
+
+        var selectedMediaTypes = SmartLists.getSelectedMediaTypes
+            ? SmartLists.getSelectedMediaTypes(page)
+            : [];
+
+        var hasContainerType = SmartLists.hasContainerMediaType(selectedMediaTypes);
+
+        container.style.display = hasContainerType ? '' : 'none';
+
+        // Uncheck if hiding
+        if (!hasContainerType) {
+            var checkbox = page.querySelector('#matchByMembers');
+            if (checkbox) {
+                checkbox.checked = false;
+            }
+        }
+    };
+
     // Generic helper to update all rules using a provided update function
     // Reduces duplication across updateAll* functions
     SmartLists.updateAllRules = function (page, updateFunction) {
@@ -2702,6 +2656,7 @@
         if (!container) { return expressionSets; }
         const selectedMediaTypes = SmartLists.getSelectedMediaTypes(page, scope);
         const hasEpisode = selectedMediaTypes.indexOf('Episode') !== -1;
+        const hasCollectionType = selectedMediaTypes.indexOf('Collection') !== -1;
         const hasAudioCapable = selectedMediaTypes.some(function (type) {
             return SmartLists.AUDIO_CAPABLE_TYPES.indexOf(type) !== -1;
         });
@@ -2778,30 +2733,15 @@
 
                     // Check for Collections specific options
                     if (memberName === 'Collections') {
-                        // Check for collection-only option (only for Collections type)
-                        const collectionOnlySelect = rule.querySelector('.rule-collections-collection-only-select');
-                        if (collectionOnlySelect) {
-                            const includeCollectionOnly = collectionOnlySelect.value === 'true';
-                            if (includeCollectionOnly) {
-                                expression.IncludeCollectionOnly = true;
-                            }
-                            // If false (default), don't include the parameter to save space
-                        }
-
-                        // Check for episodes option (only if Episode is selected and collection-only is not enabled)
+                        // Check for episodes option (only if Episode is selected)
                         const collectionsSelect = rule.querySelector('.rule-collections-select');
                         if (collectionsSelect && hasEpisode) {
-                            // Only process if collection-only is not enabled
-                            const collectionOnlySelect2 = rule.querySelector('.rule-collections-collection-only-select');
-                            const isCollectionOnly = collectionOnlySelect2 && collectionOnlySelect2.value === 'true';
-                            if (!isCollectionOnly) {
-                                // Convert string to boolean and only include if it's explicitly true
-                                const includeEpisodesWithinSeries = collectionsSelect.value === 'true';
-                                if (includeEpisodesWithinSeries) {
-                                    expression.IncludeEpisodesWithinSeries = true;
-                                }
-                                // If false (default), don't include the parameter to save space
+                            // Convert string to boolean and only include if it's explicitly true
+                            const includeEpisodesWithinSeries = collectionsSelect.value === 'true';
+                            if (includeEpisodesWithinSeries) {
+                                expression.IncludeEpisodesWithinSeries = true;
                             }
+                            // If false (default), don't include the parameter to save space
                         }
 
                         // Check for collection search depth
@@ -2813,18 +2753,17 @@
                             }
                             // If 0 (default), don't include the parameter to save space
                         }
-                    }
-
-                    // Check for Playlists specific options
-                    if (memberName === 'Playlists') {
-                        // Check for playlist-only option (only for Collections type)
-                        const playlistOnlySelect = rule.querySelector('.rule-playlists-playlist-only-select');
-                        if (playlistOnlySelect) {
-                            const includePlaylistOnly = playlistOnlySelect.value === 'true';
-                            if (includePlaylistOnly) {
-                                expression.IncludePlaylistOnly = true;
+                    } else if (memberName === 'Name' && hasCollectionType) {
+                        // Name rules carry the Collection search depth on container lists
+                        // (the include-only migration stores it there, and the depth input
+                        // is shown whenever the Collection media type is selected)
+                        const nameDepthInput = rule.querySelector('.rule-collections-depth-input');
+                        if (nameDepthInput) {
+                            const nameDepthValue = parseInt(nameDepthInput.value, 10);
+                            if (!isNaN(nameDepthValue) && nameDepthValue > 0) {
+                                expression.CollectionSearchDepth = Math.min(nameDepthValue, 10);
                             }
-                            // If false (default), don't include the parameter to save space
+                            // If 0 (default), don't include the parameter to save space
                         }
                     }
 
@@ -2980,6 +2919,10 @@
                 // Check if this is a people sub-field
                 const isPeopleSubFieldValue = SmartLists.isPeopleSubField(expression.MemberName);
 
+                // The field picker may be gated to container metadata fields; make sure
+                // the saved field's option exists so restoring it doesn't blank the rule
+                SmartLists.ensurePreservedFieldOption(fieldSelect, isPeopleSubFieldValue ? 'People' : expression.MemberName, page, SmartLists.getRowScope(ruleRow));
+
                 if (isPeopleSubFieldValue) {
                     // Set field select to "People" and submenu to the actual field
                     fieldSelect.value = 'People';
@@ -3005,7 +2948,6 @@
                 SmartLists.updateNextUnwatchedOptionsVisibility(ruleRow, actualMemberName, page);
                 SmartLists.updateUnknownDateOptionsVisibility(ruleRow, actualMemberName);
                 SmartLists.updateCollectionsOptionsVisibility(ruleRow, actualMemberName, page);
-                SmartLists.updatePlaylistsOptionsVisibility(ruleRow, actualMemberName, page);
                 SmartLists.updateExternalListOptionsVisibility(ruleRow, actualMemberName);
                 SmartLists.updateTagsOptionsVisibility(ruleRow, actualMemberName, page);
                 SmartLists.updateStudiosOptionsVisibility(ruleRow, actualMemberName, page);
@@ -3060,36 +3002,22 @@
                     unknownDateSelect.value = expression.IncludeUnknownDates === true ? 'true' : 'false';
                 }
             }
-            if (expression.MemberName === 'Collections') {
-                // Restore collection-only option
-                const collectionOnlySelect = ruleRow.querySelector('.rule-collections-collection-only-select');
-                if (collectionOnlySelect) {
-                    const includeCollectionOnlyValue = expression.IncludeCollectionOnly === true ? 'true' : 'false';
-                    collectionOnlySelect.value = includeCollectionOnlyValue;
-                    // Trigger change to update visibility of episodes field and depth field
-                    collectionOnlySelect.dispatchEvent(new Event('change'));
+            if (expression.MemberName === 'Collections' || expression.MemberName === 'Name') {
+                // Restore episodes option (Collections rules only)
+                if (expression.MemberName === 'Collections') {
+                    const collectionsSelect = ruleRow.querySelector('.rule-collections-select');
+                    if (collectionsSelect) {
+                        const includeValue = expression.IncludeEpisodesWithinSeries === true ? 'true' : 'false';
+                        collectionsSelect.value = includeValue;
+                    }
                 }
 
-                // Restore episodes option
-                const collectionsSelect = ruleRow.querySelector('.rule-collections-select');
-                if (collectionsSelect) {
-                    const includeValue = expression.IncludeEpisodesWithinSeries === true ? 'true' : 'false';
-                    collectionsSelect.value = includeValue;
-                }
-
-                // Restore collection search depth
+                // Restore collection search depth (the include-only migration stores it on
+                // the rewritten Name rule, so Name rules must round-trip it too)
                 const depthInput = ruleRow.querySelector('.rule-collections-depth-input');
                 if (depthInput) {
                     const depthValue = expression.CollectionSearchDepth !== undefined && expression.CollectionSearchDepth !== null ? expression.CollectionSearchDepth : 0;
                     depthInput.value = depthValue;
-                }
-            }
-            if (expression.MemberName === 'Playlists') {
-                // Restore playlist-only option
-                const playlistOnlySelect = ruleRow.querySelector('.rule-playlists-playlist-only-select');
-                if (playlistOnlySelect) {
-                    const includePlaylistOnlyValue = expression.IncludePlaylistOnly === true ? 'true' : 'false';
-                    playlistOnlySelect.value = includePlaylistOnlyValue;
                 }
             }
             if (expression.MemberName === 'Tags') {

--- a/Jellyfin.Plugin.SmartLists/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config.html
@@ -135,6 +135,30 @@
                             <div class="fieldDescription">Include extras (behind the scenes, deleted scenes, featurettes, trailers, etc.) in the item pool. Use the <b>Extra Type</b> rule field to filter specific types.</div>
                         </div>
 
+                        <div id="matchByMembersContainer" class="checkboxList paperList"
+                            style="padding: 0.5em 1em; margin-bottom: 1em; margin-top: 0; display: none;">
+                            <label class="emby-checkbox-label">
+                                <input type="checkbox" is="emby-checkbox" id="matchByMembers"
+                                    data-embycheckbox="true" class="emby-checkbox">
+                                <span class="checkboxLabel">
+                                    Match collections/playlists by the items inside them
+                                    <a href="https://jellyfin-smartlists-plugin.dinsten.se/user-guide/media-types/#match-by-members"
+                                        target="_blank" rel="noopener noreferrer" title="Documentation"
+                                        style="margin-left: 0.5em; text-decoration: none; color: inherit; display: inline-flex; align-items: center;">
+                                        <span class="material-icons" aria-hidden="true"
+                                            style="font-size: 1.1em; line-height: 0;">info_outline</span>
+                                    </a>
+                                </span>
+                                <span class="checkboxOutline">
+                                    <span class="material-icons checkboxIcon checkboxIcon-checked check"
+                                        aria-hidden="true"></span>
+                                    <span class="material-icons checkboxIcon checkboxIcon-unchecked"
+                                        aria-hidden="true"></span>
+                                </span>
+                            </label>
+                            <div class="fieldDescription">Off: rules match the collection/playlist itself (name, genres, studios, year, parental rating). On: rules match the items inside it &mdash; a collection/playlist is included when at least one of its items matches all rules in a rule group.</div>
+                        </div>
+
                         <div class="inputContainer" style="margin-bottom: 1em;">
                             <label class="inputLabel" style="display: flex; align-items: center;">
                                 Rules

--- a/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
@@ -121,6 +121,33 @@
                                 rule field to filter specific types.</div>
                         </div>
 
+                        <div id="matchByMembersContainer" class="checkboxList paperList"
+                            style="padding: 0.5em 1em; margin-bottom: 1em; margin-top: 0; display: none;">
+                            <label class="emby-checkbox-label">
+                                <input type="checkbox" is="emby-checkbox" id="matchByMembers"
+                                    data-embycheckbox="true" class="emby-checkbox">
+                                <span class="checkboxLabel">
+                                    Match collections/playlists by the items inside them
+                                    <a href="https://jellyfin-smartlists-plugin.dinsten.se/user-guide/media-types/#match-by-members"
+                                        target="_blank" rel="noopener noreferrer" title="Documentation"
+                                        style="margin-left: 0.5em; text-decoration: none; color: inherit; display: inline-flex; align-items: center;">
+                                        <span class="material-icons" aria-hidden="true"
+                                            style="font-size: 1.1em; line-height: 0;">info_outline</span>
+                                    </a>
+                                </span>
+                                <span class="checkboxOutline">
+                                    <span class="material-icons checkboxIcon checkboxIcon-checked check"
+                                        aria-hidden="true"></span>
+                                    <span class="material-icons checkboxIcon checkboxIcon-unchecked"
+                                        aria-hidden="true"></span>
+                                </span>
+                            </label>
+                            <div class="fieldDescription">Off: rules match the collection/playlist itself (name,
+                                genres, studios, year, parental rating). On: rules match the items inside it
+                                &mdash; a collection/playlist is included when at least one of its items matches
+                                all rules in a rule group.</div>
+                        </div>
+
                         <div class="inputContainer" style="margin-bottom: 1em;">
                             <label class="inputLabel" style="display: flex; align-items: center;">
                                 Rules

--- a/Jellyfin.Plugin.SmartLists/Core/Constants/MediaTypes.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Constants/MediaTypes.cs
@@ -42,6 +42,15 @@ namespace Jellyfin.Plugin.SmartLists.Core.Constants
         public const string Book = nameof(Book);
         public const string AudioBook = nameof(AudioBook);
 
+        // Container Types
+        // Collection media type (BoxSet): Not supported in Playlists (Jellyfin playlists can only
+        // contain media items; containers are silently dropped) but supported in Collections
+        public const string Collection = nameof(Collection);
+
+        // Playlist media type: Not supported in Playlists (same pattern as Collection)
+        // but supported in Collections
+        public const string Playlist = nameof(Playlist);
+
         // Fallback Type
         public const string Unknown = nameof(Unknown);
 
@@ -64,7 +73,11 @@ namespace Jellyfin.Plugin.SmartLists.Core.Constants
             // Season: Supported in Collections, not in Playlists
             { BaseItemKind.Season, Season },
             // MusicAlbum: Supported in Collections, not in Playlists
-            { BaseItemKind.MusicAlbum, MusicAlbum }
+            { BaseItemKind.MusicAlbum, MusicAlbum },
+            // Collection: Supported in Collections, not in Playlists
+            { BaseItemKind.BoxSet, Collection },
+            // Playlist: Supported in Collections, not in Playlists
+            { BaseItemKind.Playlist, Playlist }
         };
 
         /// <summary>
@@ -85,11 +98,15 @@ namespace Jellyfin.Plugin.SmartLists.Core.Constants
             // Season: Supported in Collections, not in Playlists
             { Season, BaseItemKind.Season },
             // MusicAlbum: Supported in Collections, not in Playlists
-            { MusicAlbum, BaseItemKind.MusicAlbum }
+            { MusicAlbum, BaseItemKind.MusicAlbum },
+            // Collection: Supported in Collections, not in Playlists
+            { Collection, BaseItemKind.BoxSet },
+            // Playlist: Supported in Collections, not in Playlists
+            { Playlist, BaseItemKind.Playlist }
         };
 
         /// <summary>
-        /// Gets all supported media types as an array (includes Series for Collections support)
+        /// Gets all supported media types as an array (includes Series and container types for Collections support)
         /// </summary>
         public static readonly string[] All = [.. BaseItemKindToMediaType
             .Select(static kvp => kvp.Value)];
@@ -124,6 +141,12 @@ namespace Jellyfin.Plugin.SmartLists.Core.Constants
         /// </summary>
         public static readonly string[] VideoStreamCapable = [Movie, Episode, MusicVideo, Video];
 
+        /// <summary>
+        /// Gets container media types (Collection, Playlist) - only valid for smart collections,
+        /// never for smart playlists (Jellyfin playlists can only contain media items)
+        /// </summary>
+        public static readonly string[] ContainerTypes = [Collection, Playlist];
+
         // HashSet variants for O(1) membership checks (performance optimization)
 
         /// <summary>
@@ -150,6 +173,16 @@ namespace Jellyfin.Plugin.SmartLists.Core.Constants
         /// HashSet variant of VideoStreamCapable for O(1) membership checks
         /// </summary>
         public static readonly HashSet<string> VideoStreamCapableSet = new(VideoStreamCapable, StringComparer.Ordinal);
+
+        /// <summary>
+        /// HashSet variant of ContainerTypes for O(1) membership checks
+        /// </summary>
+        public static readonly HashSet<string> ContainerTypesSet = new(ContainerTypes, StringComparer.Ordinal);
+
+        /// <summary>
+        /// Checks whether a media type is a container type (Collection or Playlist)
+        /// </summary>
+        public static bool IsContainerType(string mediaType) => ContainerTypesSet.Contains(mediaType);
 
         /// <summary>
         /// Gets BaseItemKind array for audio-only content (derived from centralized mapping)

--- a/Jellyfin.Plugin.SmartLists/Core/Models/SmartListDto.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Models/SmartListDto.cs
@@ -75,6 +75,15 @@ namespace Jellyfin.Plugin.SmartLists.Core.Models
         public bool IncludeExtras { get; set; } = false;
 
         /// <summary>
+        /// When true, container candidates (Collection/Playlist media types) are matched by their
+        /// member items: a container is included when at least one member passes the full rule
+        /// pipeline. When false (default), containers are matched against their own metadata
+        /// (Name, Genres, Studios, etc.) like any other item.
+        /// Only meaningful when a container media type is selected.
+        /// </summary>
+        public bool MatchByMembers { get; set; } = false;
+
+        /// <summary>
         /// When true, the Jellyfin playlist/collection is not created (and an existing one is
         /// removed) while the list's rules match zero items. It is recreated automatically
         /// once items match again. The smart list configuration itself is never deleted.

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
@@ -88,6 +88,28 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         }
 
         /// <summary>
+        /// Name equality with a container fallback: container candidates (Collection/Playlist
+        /// media types) also match on their name with the configured prefix/suffix stripped, so
+        /// users can target smart lists by base name (parity with the legacy include-only matcher).
+        /// Non-container items get plain case-insensitive equality.
+        /// </summary>
+        internal static bool NameEqualsWithContainerBaseName(string name, string itemType, string targetValue)
+        {
+            if (name == null || targetValue == null)
+            {
+                return false;
+            }
+
+            if (name.Equals(targetValue, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return MediaTypes.IsContainerType(itemType)
+                && NameFormatter.StripPrefixAndSuffix(name).Equals(targetValue, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
         /// Gets or creates a compiled regex pattern from the cache.
         /// </summary>
         /// <param name="pattern">The regex pattern</param>
@@ -171,6 +193,21 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                     return enumerableExpr;
                 }
                 // If BuildEnumerableExpression returns null, fall through to normal flow (shouldn't happen for List<string>)
+            }
+
+            // Name + Equal/NotEqual also matches container candidates (Collection/Playlist media
+            // types) on their name with the configured prefix/suffix stripped, so users can target
+            // smart lists by base name. The legacy include-only matcher had this fallback and the
+            // one-time migration rewrites include-only rules to Name rules, so the engine keeps it.
+            if (r.MemberName == "Name" && (r.Operator == "Equal" || r.Operator == "NotEqual") && !string.IsNullOrEmpty(r.TargetValue))
+            {
+                var nameProperty = System.Linq.Expressions.Expression.PropertyOrField(param, "Name");
+                var itemTypeProperty = System.Linq.Expressions.Expression.PropertyOrField(param, "ItemType");
+                var nameEqualsMethod = typeof(Engine).GetMethod(nameof(NameEqualsWithContainerBaseName), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+                if (nameEqualsMethod == null) throw new InvalidOperationException("Engine.NameEqualsWithContainerBaseName method not found");
+                var nameTargetConstant = System.Linq.Expressions.Expression.Constant(r.TargetValue, typeof(string));
+                var nameEqualsCall = System.Linq.Expressions.Expression.Call(nameEqualsMethod, nameProperty, itemTypeProperty, nameTargetConstant);
+                return r.Operator == "Equal" ? nameEqualsCall : System.Linq.Expressions.Expression.Not(nameEqualsCall);
             }
 
             // Get the property/field expression for non-user-specific fields

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Expression.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Expression.cs
@@ -20,11 +20,15 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? IncludeEpisodesWithinSeries { get; set; } = null;
 
-        // Collections-specific option - only serialize when meaningful
+        // Legacy - migration input only: SmartListFileSystem.ApplyPostProcessing rewrites this to
+        // the Collection media type on load (collections) or strips it (playlists), then clears it.
+        // Do NOT remove: this is an on-disk JSON key older saved lists still carry.
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? IncludeCollectionOnly { get; set; } = null;
 
-        // Playlists-specific option - only serialize when meaningful
+        // Legacy - migration input only: SmartListFileSystem.ApplyPostProcessing rewrites this to
+        // the Playlist media type on load (collections) or strips it (playlists), then clears it.
+        // Do NOT remove: this is an on-disk JSON key older saved lists still carry.
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? IncludePlaylistOnly { get; set; } = null;
 

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -997,7 +997,23 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 {
                     logger?.LogDebug("Building reference metadata for SimilarTo queries (once per filter run) using fields: {Fields}",
                         string.Join(", ", similarityComparisonFields));
-                    referenceMetadata = OperandFactory.BuildReferenceMetadata(fieldReqs.SimilarToExpressions, itemsArray, similarityComparisonFields, libraryManager, logger);
+
+                    // One reference set for the whole run: the pool plus, in MatchByMembers mode,
+                    // the members of every container candidate. Direct items and container members
+                    // are then scored against identical reference metadata - and a reference living
+                    // inside a candidate container is still found when the pool itself holds only
+                    // containers. Member enumeration here is cache-backed, so the later enumeration
+                    // in MatchContainersByMembers hits the same cache.
+                    IEnumerable<BaseItem> referenceUniverse = itemsArray;
+                    if (containerCandidates.Length > 0)
+                    {
+                        referenceUniverse = referenceUniverse.Concat(
+                            containerCandidates
+                                .SelectMany(c => GetContainerMembers(c, user, refreshCache, logger))
+                                .Where(m => m != null && !IsContainerKind(m)));
+                    }
+
+                    referenceMetadata = OperandFactory.BuildReferenceMetadata(fieldReqs.SimilarToExpressions, referenceUniverse, similarityComparisonFields, libraryManager, logger);
                 }
 
                 // RefreshCache is provided as parameter - shared across multiple playlists/collections for the same user
@@ -1075,7 +1091,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 // the full rule pipeline; passing members' group indices project onto the container
                 if (containerCandidates.Length > 0)
                 {
-                    var matchedContainers = MatchContainersByMembers(containerCandidates, itemsArray, libraryManager, user, userDataManager,
+                    var matchedContainers = MatchContainersByMembers(containerCandidates, libraryManager, user, userDataManager,
                         logger, fieldReqs, referenceMetadata, similarityComparisonFields, compiledRules, hasAnyRules, hasNonExpensiveRules, refreshCache);
                     results.AddRange(matchedContainers);
                 }
@@ -1743,7 +1759,6 @@ namespace Jellyfin.Plugin.SmartLists.Core
         /// </summary>
         private List<BaseItem> MatchContainersByMembers(
             BaseItem[] containerCandidates,
-            BaseItem[] poolItems,
             ILibraryManager libraryManager,
             User user,
             IUserDataManager? userDataManager,
@@ -1777,22 +1792,6 @@ namespace Jellyfin.Plugin.SmartLists.Core
                     }
                 }
 
-                // SimilarTo reference items are searched in the candidate pool, but for a
-                // container-only list the pool holds only containers - the reference (e.g. the
-                // movie a rule names) lives INSIDE a candidate. Rebuild the reference metadata
-                // over pool + members so member evaluation can find it; pool-typed candidates in
-                // a mixed list were already evaluated against the pool-built references, which
-                // are a subset of these.
-                if (fieldReqs.NeedsSimilarTo)
-                {
-                    referenceMetadata = OperandFactory.BuildReferenceMetadata(
-                        fieldReqs.SimilarToExpressions,
-                        poolItems.Concat(uniqueMembers.Values),
-                        similarityComparisonFields,
-                        libraryManager,
-                        logger);
-                }
-
                 // Evaluate every unique member exactly once through the same pipeline as regular
                 // items (two-phase filtering included). The DB-prefilter candidate set is NOT
                 // applied: it was built for the pool's media types, and members can be of any kind.
@@ -1823,11 +1822,13 @@ namespace Jellyfin.Plugin.SmartLists.Core
                     passedMemberIds.Count, uniqueMembers.Count, containerCandidates.Length);
 
                 bool trackGroups = NeedsGroupTracking();
+                bool trackScores = fieldReqs.NeedsSimilarTo;
                 foreach (var container in containerCandidates)
                 {
                     var members = membersByContainer[container.Id];
                     HashSet<int>? containerGroups = trackGroups ? [] : null;
                     bool anyMemberPassed = false;
+                    float bestScore = 0f;
 
                     foreach (var member in members)
                     {
@@ -1837,14 +1838,19 @@ namespace Jellyfin.Plugin.SmartLists.Core
                         }
 
                         anyMemberPassed = true;
-                        if (containerGroups == null)
+                        if (containerGroups == null && !trackScores)
                         {
-                            break; // No group tracking - the first passing member is enough
+                            break; // Nothing further to aggregate - the first passing member is enough
                         }
 
-                        if (_itemGroupMappings.TryGetValue(member.Id, out var memberGroups))
+                        if (containerGroups != null && _itemGroupMappings.TryGetValue(member.Id, out var memberGroups))
                         {
                             containerGroups.UnionWith(memberGroups);
+                        }
+
+                        if (trackScores && _similarityScores.TryGetValue(member.Id, out var memberScore) && memberScore > bestScore)
+                        {
+                            bestScore = memberScore;
                         }
                     }
 
@@ -1857,6 +1863,14 @@ namespace Jellyfin.Plugin.SmartLists.Core
                     if (containerGroups is { Count: > 0 })
                     {
                         TrackContainerGroupMapping(container.Id, [.. containerGroups]);
+                    }
+
+                    // Similarity sorting looks scores up by result-item id, and the container -
+                    // not its members - is the result item. Carry the best passing member's score
+                    // so SimilarityOrder ranks the container by its closest match instead of 0.
+                    if (trackScores)
+                    {
+                        _similarityScores[container.Id] = bestScore;
                     }
 
                     logger?.LogDebug("Container '{ContainerName}' matched via its members", container.Name);

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -1075,7 +1075,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 // the full rule pipeline; passing members' group indices project onto the container
                 if (containerCandidates.Length > 0)
                 {
-                    var matchedContainers = MatchContainersByMembers(containerCandidates, libraryManager, user, userDataManager,
+                    var matchedContainers = MatchContainersByMembers(containerCandidates, itemsArray, libraryManager, user, userDataManager,
                         logger, fieldReqs, referenceMetadata, similarityComparisonFields, compiledRules, hasAnyRules, hasNonExpensiveRules, refreshCache);
                     results.AddRange(matchedContainers);
                 }
@@ -1743,6 +1743,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
         /// </summary>
         private List<BaseItem> MatchContainersByMembers(
             BaseItem[] containerCandidates,
+            BaseItem[] poolItems,
             ILibraryManager libraryManager,
             User user,
             IUserDataManager? userDataManager,
@@ -1774,6 +1775,22 @@ namespace Jellyfin.Plugin.SmartLists.Core
                     {
                         uniqueMembers.TryAdd(member.Id, member);
                     }
+                }
+
+                // SimilarTo reference items are searched in the candidate pool, but for a
+                // container-only list the pool holds only containers - the reference (e.g. the
+                // movie a rule names) lives INSIDE a candidate. Rebuild the reference metadata
+                // over pool + members so member evaluation can find it; pool-typed candidates in
+                // a mixed list were already evaluated against the pool-built references, which
+                // are a subset of these.
+                if (fieldReqs.NeedsSimilarTo)
+                {
+                    referenceMetadata = OperandFactory.BuildReferenceMetadata(
+                        fieldReqs.SimilarToExpressions,
+                        poolItems.Concat(uniqueMembers.Values),
+                        similarityComparisonFields,
+                        libraryManager,
+                        logger);
                 }
 
                 // Evaluate every unique member exactly once through the same pipeline as regular

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -33,6 +33,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
         public List<SortOption>? SortOptions { get; set; }  // Original sort options (legacy: UseChildValues flag removed)
         public List<string>? MediaTypes { get; set; }
         public int CollectionSearchDepth { get; set; }  // Depth for traversing nested collections/playlists (0 = no recursion, 1-10 = levels)
+        public bool MatchByMembers { get; set; }  // Container candidates (Collection/Playlist media types) match when at least one member item passes the rules
         public List<ExpressionSet> ExpressionSets { get; set; }
         public int MaxItems { get; set; }
         public int MaxPlayTimeMinutes { get; set; }
@@ -195,6 +196,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
             }
 
             MediaTypes = dto.MediaTypes != null ? new List<string>(dto.MediaTypes) : null; // Create defensive copy to prevent corruption
+            MatchByMembers = dto.MatchByMembers;
             MaxItems = dto.MaxItems ?? 0; // Default to 0 (unlimited) for backwards compatibility
             MaxPlayTimeMinutes = dto.MaxPlayTimeMinutes ?? 0; // Default to 0 (unlimited) for backwards compatibility
             RandomGroupSelection = dto.RandomGroupSelection;
@@ -294,17 +296,6 @@ namespace Jellyfin.Plugin.SmartLists.Core
                             if (set?.Expressions == null)
                             {
                                 logger?.LogDebug("Skipping null expression set at index {SetIndex} for playlist '{PlaylistName}'", setIndex, Name);
-                                compiledRuleSets.Add([]);
-                                continue;
-                            }
-
-                            // Sets containing include-only rules (Collections "collection only" / Playlists "playlist only")
-                            // match collections/playlists as a whole - every rule in the set is evaluated against
-                            // the collection/playlist itself in GetMatchingCollections/GetMatchingPlaylists.
-                            // They never match individual media items, so no item rules are compiled for them.
-                            if (set.Expressions.Any(expr => IsCollectionOnlyExpression(expr) || IsPlaylistOnlyExpression(expr)))
-                            {
-                                logger?.LogDebug("Skipping expression set {SetIndex} for item evaluation in playlist '{PlaylistName}' - contains include-only rules (handled separately)", setIndex, Name);
                                 compiledRuleSets.Add([]);
                                 continue;
                             }
@@ -579,16 +570,11 @@ namespace Jellyfin.Plugin.SmartLists.Core
                     if (group == null)
                         continue; // Skip null groups
 
-                    // Groups containing include-only rules match collections/playlists as a whole
-                    // (all rules in the group AND together against the collection/playlist itself),
-                    // so they never match individual media items. Groups with only SimilarTo rules
-                    // are handled separately by similarity filtering.
-                    bool hasIncludeOnlyRule = group.Expressions != null &&
-                        group.Expressions.Any(expr => IsCollectionOnlyExpression(expr) || IsPlaylistOnlyExpression(expr));
+                    // Groups with only SimilarTo rules are handled separately by similarity filtering.
                     bool hasOnlySkippedRules = group.Expressions != null &&
                         group.Expressions.All(expr => expr?.MemberName == "SimilarTo");
 
-                    if (hasIncludeOnlyRule || hasOnlySkippedRules)
+                    if (hasOnlySkippedRules)
                     {
                         continue; // Handled separately - these groups don't match items
                     }
@@ -662,7 +648,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                     var groupRules = compiledRules[groupIndex];
 
                     if (group == null || groupRules == null || groupRules.Count == 0 || group.Expressions == null)
-                        continue; // Skip empty or null groups (include-only groups compile to empty rule sets)
+                        continue; // Skip empty or null groups
 
                     try
                     {
@@ -772,13 +758,32 @@ namespace Jellyfin.Plugin.SmartLists.Core
 
                 // Materialize items once to avoid double enumeration (Count + ToArray later)
                 var itemsArray = items as BaseItem[] ?? items.ToArray();
+
+                // Container candidates (Collection/Playlist media types) arrive through the normal
+                // media pool. A list must never include its own container, in either MatchByMembers
+                // mode - drop it from the pool before any evaluation (self-reference guard, #499).
+                var hasContainerTypes = MediaTypes?.Any(Constants.MediaTypes.IsContainerType) == true;
+                BaseItem[] containerCandidates = [];
+                if (hasContainerTypes)
+                {
+                    itemsArray = [.. itemsArray.Where(i => !(IsContainerKind(i) && Origin.Matches(i)))];
+
+                    if (MatchByMembers)
+                    {
+                        // Containers are matched by their member items instead of their own metadata -
+                        // pull them out of the pool and project member matches back onto them later
+                        containerCandidates = [.. itemsArray.Where(IsContainerKind)];
+                        itemsArray = [.. itemsArray.Where(i => !IsContainerKind(i))];
+                    }
+                }
+
                 var itemCount = itemsArray.Length;
 
                 logger?.LogDebug("FilterPlaylistItems called with {ItemCount} items, ExpressionSets={ExpressionSetCount}, MediaTypes={MediaTypes}",
                     itemCount, ExpressionSets?.Count ?? 0, MediaTypes != null ? string.Join(",", MediaTypes) : "None");
 
-                // Early return for empty item collections
-                if (itemCount == 0)
+                // Early return for empty item collections (container candidates still need matching)
+                if (itemCount == 0 && containerCandidates.Length == 0)
                 {
                     logger?.LogDebug("No items to filter for playlist '{PlaylistName}'", Name);
                     return [];
@@ -887,107 +892,6 @@ namespace Jellyfin.Plugin.SmartLists.Core
                     logger?.LogDebug(ex, "Error merging SimilarTo comparison fields into expensive-field requirements");
                 }
 
-                // Check if any Collections rule has IncludeCollectionOnly = true
-                var hasCollectionsIncludeCollectionOnly = ExpressionSets?.Any(set =>
-                    set.Expressions?.Any(expr =>
-                        expr.MemberName == "Collections" && expr.IncludeCollectionOnly == true) == true) == true;
-
-                // If IncludeCollectionOnly is enabled, fetch matching collections directly
-                if (hasCollectionsIncludeCollectionOnly)
-                {
-                    logger?.LogDebug("IncludeCollectionOnly is enabled - fetching matching collections directly");
-                    var matchingCollections = GetMatchingCollections(libraryManager, user, userDataManager, refreshCache, logger);
-                    if (matchingCollections.Count > 0)
-                    {
-                        logger?.LogDebug("Found {Count} matching collections to include directly", matchingCollections.Count);
-                        results.AddRange(matchingCollections);
-                    }
-                    else
-                    {
-                        logger?.LogDebug("No matching collections found for IncludeCollectionOnly mode");
-                    }
-                }
-
-                // Check if any Playlists rule has IncludePlaylistOnly = true
-                var hasPlaylistsIncludePlaylistOnly = ExpressionSets?.Any(set =>
-                    set.Expressions?.Any(expr =>
-                        expr.MemberName == "Playlists" && expr.IncludePlaylistOnly == true) == true) == true;
-
-                // If IncludePlaylistOnly is enabled, fetch matching playlists directly
-                if (hasPlaylistsIncludePlaylistOnly)
-                {
-                    logger?.LogDebug("IncludePlaylistOnly is enabled - fetching matching playlists directly");
-                    var matchingPlaylists = GetMatchingPlaylists(libraryManager, user, userDataManager, refreshCache, logger);
-                    if (matchingPlaylists.Count > 0)
-                    {
-                        logger?.LogDebug("Found {Count} matching playlists to include directly", matchingPlaylists.Count);
-                        results.AddRange(matchingPlaylists);
-                    }
-                    else
-                    {
-                        logger?.LogDebug("No matching playlists found for IncludePlaylistOnly mode");
-                    }
-                }
-
-                // Check if EVERY rule group contains an include-only rule. Such groups match
-                // collections/playlists as a whole (handled above) and never match individual
-                // media items, so there is nothing left to evaluate items against.
-                var allRulesAreIncludeOnly = ExpressionSets?.All(set =>
-                    set?.Expressions?.Any(expr =>
-                        IsCollectionOnlyExpression(expr) || IsPlaylistOnlyExpression(expr)) == true) == true;
-
-                if (allRulesAreIncludeOnly && (hasCollectionsIncludeCollectionOnly || hasPlaylistsIncludePlaylistOnly))
-                {
-                    logger?.LogDebug("All rules are IncludeCollectionOnly or IncludePlaylistOnly - skipping media item processing, applying sorting to {Count} items", results.Count);
-
-                    // Still need to apply sorting and limits to the collection/playlist results
-                    try
-                    {
-                        // Apply per-group limits and wire Rule Block Order group mappings - the
-                        // include-only matchers record _itemGroupMappings, so these work here too
-                        if (HasPerGroupLimits())
-                        {
-                            results = ApplyPerGroupLimits(results, user, userDataManager, logger, refreshCache);
-                            logger?.LogDebug("Include-only results limited to {Count} items after per-group MaxItems applied", results.Count);
-                        }
-
-                        foreach (var order in Orders)
-                        {
-                            if (order is Orders.RuleBlockOrder ruleBlockOrder)
-                            {
-                                ruleBlockOrder.GroupMappings = _itemGroupMappings;
-                            }
-                            else if (order is Orders.RuleBlockOrderDesc ruleBlockOrderDesc)
-                            {
-                                ruleBlockOrderDesc.GroupMappings = _itemGroupMappings;
-                            }
-                        }
-
-                        // Pre-compute Round Robin positions before sorting
-                        PrepareRoundRobinPositions(results, logger);
-
-                        // Apply multiple orders in cascade
-                        var orderedResults = ApplyMultipleOrders(results, user, userDataManager, logger, refreshCache);
-
-                        // Apply limits (items and/or time)
-                        if (MaxItems > 0 || MaxPlayTimeMinutes > 0)
-                        {
-                            var limitedResults = ApplyLimits(orderedResults, libraryManager, user, userDataManager, refreshCache, logger);
-                            logger?.LogDebug("Limited IncludeOnly results from {TotalCount} to {LimitedCount} items", results.Count, limitedResults.Count);
-                            return limitedResults.Select(x => x.Id);
-                        }
-                        else
-                        {
-                            return orderedResults.Select(x => x.Id);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        logger?.LogError(ex, "Error applying ordering and limits to IncludeOnly results. Returning unordered results.");
-                        return results.Select(x => x.Id);
-                    }
-                }
-
                 // Early validation of additional users to prevent exceptions during item processing
                 if (fieldReqs.AdditionalUserIds.Count > 0 && userDataManager != null)
                 {
@@ -1031,13 +935,11 @@ namespace Jellyfin.Plugin.SmartLists.Core
                     return [];
                 }
 
-                // Check if there are any rules to evaluate (including skipped ones like SimilarTo and IncludeCollectionOnly and IncludePlaylistOnly)
+                // Check if there are any rules to evaluate (including skipped ones like SimilarTo)
                 // This prevents "no rules = match everything" when all rules are skipped
                 bool hasAnyRules = compiledRules.Any(set => set?.Count > 0) ||
-                    ExpressionSets?.Any(set => set?.Expressions?.Any(expr => 
-                        expr?.MemberName == "SimilarTo" || 
-                        (expr?.MemberName == "Collections" && expr.IncludeCollectionOnly == true) ||
-                        (expr?.MemberName == "Playlists" && expr.IncludePlaylistOnly == true)) == true) == true;
+                    ExpressionSets?.Any(set => set?.Expressions?.Any(expr =>
+                        expr?.MemberName == "SimilarTo") == true) == true;
 
                 // Check if there are any non-expensive rules for two-phase filtering optimization
                 bool hasNonExpensiveRules = false;
@@ -1168,6 +1070,21 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 stopwatch.Stop();
                 logger?.LogDebug("Playlist filtering for '{PlaylistName}' completed in {ElapsedTime}ms: {InputCount} items → {OutputCount} items",
                     Name, stopwatch.ElapsedMilliseconds, totalItems, results.Count);
+
+                // MatchByMembers: a container is included when at least one of its members passes
+                // the full rule pipeline; passing members' group indices project onto the container
+                if (containerCandidates.Length > 0)
+                {
+                    var matchedContainers = MatchContainersByMembers(containerCandidates, libraryManager, user, userDataManager,
+                        logger, fieldReqs, referenceMetadata, similarityComparisonFields, compiledRules, hasAnyRules, hasNonExpensiveRules, refreshCache);
+                    results.AddRange(matchedContainers);
+                }
+
+                // Matched collections still pull nested collections up to CollectionSearchDepth
+                if (hasContainerTypes)
+                {
+                    AppendNestedCollections(results, libraryManager, user, refreshCache, logger);
+                }
 
                 // Check if we need to expand Collections based on media type selection
                 var expandedResults = ExpandCollectionsBasedOnMediaType(results, libraryManager, user, userDataManager, logger, refreshCache, fieldReqs);
@@ -1629,238 +1546,12 @@ namespace Jellyfin.Plugin.SmartLists.Core
         }
 
         /// <summary>
-        /// True when the expression is a Collections rule in "collection only" mode.
-        /// </summary>
-        private static bool IsCollectionOnlyExpression(Expression? expr) =>
-            expr?.MemberName == "Collections" && expr.IncludeCollectionOnly == true;
-
-        /// <summary>
-        /// True when the expression is a Playlists rule in "playlist only" mode.
-        /// </summary>
-        private static bool IsPlaylistOnlyExpression(Expression? expr) =>
-            expr?.MemberName == "Playlists" && expr.IncludePlaylistOnly == true;
-
-        /// <summary>
-        /// A rule group containing at least one include-only rule, prepared for evaluating
-        /// collections/playlists against the ENTIRE group with AND logic (issue #479).
-        /// </summary>
-        private sealed class IncludeOnlyRuleSet
-        {
-            /// <summary>Index of the originating ExpressionSet (for group tracking: per-group limits, Rule Block Order).</summary>
-            public int SetIndex { get; set; }
-
-            /// <summary>Include-only rules, matched against the collection/playlist name.</summary>
-            public List<Expression> NameRules { get; } = [];
-
-            /// <summary>Original sibling expressions (used for field-requirement analysis).</summary>
-            public List<Expression> SiblingExpressions { get; } = [];
-
-            /// <summary>Compiled sibling rules, evaluated against the collection/playlist itself.</summary>
-            public List<Func<Operand, bool>> SiblingRules { get; } = [];
-
-            /// <summary>True when the group can never match (e.g. it requires both a collection and a playlist).</summary>
-            public bool Impossible { get; set; }
-        }
-
-        /// <summary>
-        /// Builds the rule groups relevant for include-only matching of the given field.
-        /// Each returned group contains at least one include-only rule for <paramref name="fieldName"/>;
-        /// all other rules in the group are compiled so the whole group can be evaluated with AND logic
-        /// against the collection/playlist itself.
-        /// </summary>
-        /// <param name="fieldName">"Collections" or "Playlists"</param>
-        /// <param name="user">User context used as the default for user-specific rules</param>
-        /// <param name="logger">Logger for debugging</param>
-        private List<IncludeOnlyRuleSet> BuildIncludeOnlyRuleSets(string fieldName, User user, ILogger? logger)
-        {
-            var ruleSets = new List<IncludeOnlyRuleSet>();
-            if (ExpressionSets == null)
-                return ruleSets;
-
-            bool isCollections = fieldName == "Collections";
-            var defaultUserId = user.Id.ToString("N");
-
-            for (int setIndex = 0; setIndex < ExpressionSets.Count; setIndex++)
-            {
-                var expressions = ExpressionSets[setIndex]?.Expressions;
-                if (expressions == null)
-                    continue;
-
-                var ruleSet = new IncludeOnlyRuleSet { SetIndex = setIndex };
-
-                foreach (var expr in expressions)
-                {
-                    if (expr == null)
-                        continue;
-
-                    bool isOwnIncludeOnly = isCollections ? IsCollectionOnlyExpression(expr) : IsPlaylistOnlyExpression(expr);
-                    bool isOtherIncludeOnly = isCollections ? IsPlaylistOnlyExpression(expr) : IsCollectionOnlyExpression(expr);
-
-                    if (isOwnIncludeOnly)
-                    {
-                        ruleSet.NameRules.Add(expr);
-                        continue;
-                    }
-
-                    if (isOtherIncludeOnly)
-                    {
-                        // A group cannot require an item to be both a collection and a playlist
-                        if (!ruleSet.Impossible)
-                        {
-                            ruleSet.Impossible = true;
-                            logger?.LogWarning("Rule group in '{ListName}' combines collection-only and playlist-only rules - it can never match anything", Name);
-                        }
-                        continue;
-                    }
-
-                    if (expr.MemberName == "SimilarTo")
-                    {
-                        // Similar To cannot be evaluated against a collection/playlist itself.
-                        // Under AND semantics an unevaluable rule must not silently pass (issue #479).
-                        if (!ruleSet.Impossible)
-                        {
-                            ruleSet.Impossible = true;
-                            logger?.LogWarning("Similar To cannot be combined with {FieldName} include-only rules in the same group for '{ListName}' - the group will match nothing", fieldName, Name);
-                        }
-                        continue;
-                    }
-
-                    ruleSet.SiblingExpressions.Add(expr);
-                }
-
-                if (ruleSet.NameRules.Count == 0)
-                    continue; // Group has no include-only rule for this field - matched via normal item evaluation
-
-                if (!ruleSet.Impossible)
-                {
-                    foreach (var expr in ruleSet.SiblingExpressions)
-                    {
-                        // A sibling rule that fails to compile cannot be evaluated - fail closed
-                        // instead of silently widening the AND group to a name-only match
-                        try
-                        {
-                            var compiledRule = Engine.CompileRule<Operand>(expr, defaultUserId, logger);
-                            if (compiledRule != null)
-                            {
-                                ruleSet.SiblingRules.Add(compiledRule);
-                            }
-                            else
-                            {
-                                ruleSet.Impossible = true;
-                                logger?.LogWarning("Failed to compile rule '{Field} {Operator} {Value}' in an include-only group for '{ListName}' - the group will match nothing",
-                                    expr.MemberName, expr.Operator, expr.TargetValue, Name);
-                                break;
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            ruleSet.Impossible = true;
-                            logger?.LogError(ex, "Error compiling rule '{Field} {Operator} {Value}' in an include-only group for '{ListName}' - the group will match nothing",
-                                expr.MemberName, expr.Operator, expr.TargetValue, Name);
-                            break;
-                        }
-                    }
-                }
-
-                ruleSets.Add(ruleSet);
-            }
-
-            return ruleSets;
-        }
-
-        /// <summary>
-        /// Builds extraction options covering the fields referenced by sibling rules of include-only groups,
-        /// so those rules can be evaluated against the collection/playlist itself.
-        /// </summary>
-        private MediaTypeExtractionOptions BuildIncludeOnlyExtractionOptions(List<IncludeOnlyRuleSet> ruleSets)
-        {
-            var siblingSets = ruleSets
-                .Where(rs => !rs.Impossible && rs.SiblingExpressions.Count > 0)
-                .Select(rs => new ExpressionSet { Expressions = rs.SiblingExpressions })
-                .ToList();
-
-            var fieldReqs = FieldRequirements.Analyze(siblingSets);
-
-            return new MediaTypeExtractionOptions
-            {
-                RequiredGroups = fieldReqs.RequiredGroups,
-                CollectionRecursionDepth = Math.Max(1, CollectionSearchDepth),
-                IncludeUnwatchedSeries = fieldReqs.IncludeUnwatchedSeries,
-                AdditionalUserIds = fieldReqs.AdditionalUserIds,
-                Origin = this.Origin,
-            };
-        }
-
-        /// <summary>
-        /// Returns the indices of every include-only rule group the collection/playlist satisfies.
-        /// A group matches when ALL its include-only rules match the item's name AND all its
-        /// sibling rules match the item itself (AND logic within groups, OR across groups).
-        /// The indices feed _itemGroupMappings so per-group limits and Rule Block Order
-        /// treat matched collections/playlists like any other matched item.
-        /// </summary>
-        /// <param name="names">The item's name (single-element list)</param>
-        /// <param name="ruleSets">Prepared include-only rule groups</param>
-        /// <param name="nameMatcher">Field-specific name matcher (collection or playlist rules)</param>
-        /// <param name="operandProvider">Lazily builds the operand for sibling-rule evaluation; may return null on failure</param>
-        private static List<int> GetMatchingIncludeOnlySetIndices(
-            List<string> names,
-            List<IncludeOnlyRuleSet> ruleSets,
-            Func<List<string>, Expression, bool> nameMatcher,
-            Func<Operand?> operandProvider)
-        {
-            var matchedIndices = new List<int>();
-            Operand? operand = null;
-            bool operandLoaded = false;
-
-            foreach (var ruleSet in ruleSets)
-            {
-                if (ruleSet.Impossible)
-                    continue;
-
-                if (!ruleSet.NameRules.All(rule => nameMatcher(names, rule)))
-                    continue;
-
-                if (ruleSet.SiblingRules.Count > 0)
-                {
-                    if (!operandLoaded)
-                    {
-                        operand = operandProvider();
-                        operandLoaded = true;
-                    }
-
-                    if (operand == null)
-                        continue; // Extraction failed - conservatively treat sibling rules as not matching
-
-                    bool allSiblingsMatch = ruleSet.SiblingRules.All(rule =>
-                    {
-                        try
-                        {
-                            return rule(operand);
-                        }
-                        catch (Exception)
-                        {
-                            // Conservative approach: assume rule doesn't match if it fails
-                            return false;
-                        }
-                    });
-
-                    if (!allSiblingsMatch)
-                        continue;
-                }
-
-                matchedIndices.Add(ruleSet.SetIndex);
-            }
-
-            return matchedIndices;
-        }
-
-        /// <summary>
-        /// Records which rule groups a matched collection/playlist belongs to, so
+        /// Records which rule groups a matched container (collection/playlist) belongs to, so
         /// ApplyPerGroupLimits doesn't silently drop it and Rule Block Order places it
         /// in its group's block. Merges with any existing mapping (an item can be both
         /// a direct match and a nested child of another matched collection).
         /// </summary>
-        private void TrackIncludeOnlyGroupMapping(Guid itemId, List<int> matchedSetIndices)
+        private void TrackContainerGroupMapping(Guid itemId, List<int> matchedSetIndices)
         {
             _itemGroupMappings.AddOrUpdate(
                 itemId,
@@ -1879,11 +1570,9 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 return false;
 
             // Check if any collection matches any Collections rule
-            // Skip rules with IncludeCollectionOnly=true since those are handled separately
             return ExpressionSets?.Any(set =>
                 set.Expressions?.Any(expr =>
                     expr.MemberName == "Collections" &&
-                    expr.IncludeCollectionOnly != true && // Skip IncludeCollectionOnly rules
                     DoesCollectionMatchRule(collections, expr)) == true) == true;
         }
 
@@ -1928,118 +1617,6 @@ namespace Jellyfin.Plugin.SmartLists.Core
         }
 
         /// <summary>
-        /// Gets collections that match rule groups containing "collection only" rules.
-        /// The ENTIRE group must match: collection-only rules against the collection name,
-        /// sibling rules against the collection itself (AND logic, issue #479).
-        /// </summary>
-        /// <param name="libraryManager">Library manager to query collections</param>
-        /// <param name="user">User context</param>
-        /// <param name="userDataManager">User data manager for sibling-rule evaluation</param>
-        /// <param name="refreshCache">Cache for performance optimization</param>
-        /// <param name="logger">Logger for debugging</param>
-        /// <returns>List of matching collections</returns>
-        private List<BaseItem> GetMatchingCollections(ILibraryManager libraryManager, User user,
-            IUserDataManager? userDataManager, RefreshQueueService.RefreshCache refreshCache, ILogger? logger)
-        {
-            var matchingCollections = new List<BaseItem>();
-
-            try
-            {
-                // Query all collections (BoxSet items)
-                var collectionQuery = new InternalItemsQuery(user)
-                {
-                    IncludeItemTypes = [BaseItemKind.BoxSet],
-                    Recursive = true,
-                };
-
-                var allCollections = libraryManager.GetItemsResult(collectionQuery).Items;
-                var allCollectionsById = allCollections.ToDictionary(c => c.Id);
-                logger?.LogDebug("Found {Count} total collections to check against Collections rules with IncludeCollectionOnly=true", allCollections.Count);
-
-                // Get max recursion depth from Collections rules with IncludeCollectionOnly=true
-                var maxRecursionDepth = GetMaxCollectionRecursionDepth();
-                logger?.LogDebug("Using recursion depth {Depth} for IncludeCollectionOnly mode", maxRecursionDepth);
-
-                // Track visited collections to prevent duplicates and circular references
-                var visitedCollectionIds = new HashSet<Guid>();
-
-                // Prepare the rule groups containing collection-only rules - the whole group
-                // (name rules + sibling rules) must match for a collection to be included
-                var includeOnlyRuleSets = BuildIncludeOnlyRuleSets("Collections", user, logger);
-                var extractionOptions = BuildIncludeOnlyExtractionOptions(includeOnlyRuleSets);
-                bool trackGroups = NeedsGroupTracking();
-
-                // Check each collection against the collection-only rule groups
-                foreach (var collection in allCollections)
-                {
-                    if (collection == null) continue;
-
-                    // Skip if this collection is the one we're currently building (prevent self-reference)
-                    if (Origin.Matches(collection))
-                    {
-                        logger?.LogDebug("Skipping collection '{CollectionName}' - matches current collection being built (preventing self-reference)", collection.Name);
-                        continue;
-                    }
-
-                    // The whole rule group must match: name rules against the collection name,
-                    // sibling rules against the collection's own metadata
-                    var collectionNames = new List<string> { collection.Name };
-                    var matchedSetIndices = GetMatchingIncludeOnlySetIndices(collectionNames, includeOnlyRuleSets, DoesCollectionMatchRule, () =>
-                        {
-                            try
-                            {
-                                return OperandFactory.GetMediaType(libraryManager, collection, user, userDataManager, UserManager, logger, extractionOptions, refreshCache);
-                            }
-                            catch (Exception ex)
-                            {
-                                logger?.LogWarning(ex, "Error extracting fields from collection '{CollectionName}' for include-only rule matching", collection.Name);
-                                return null;
-                            }
-                        });
-                    if (matchedSetIndices.Count > 0)
-                    {
-                        // When tracking groups, collect every collection this root's walk reaches -
-                        // including ones already appended by an earlier root - so shared descendants
-                        // get mapped to every matching group, not just the first
-                        var encounteredIds = trackGroups ? new HashSet<Guid>() : null;
-
-                        // Add this collection and recursively add nested collections
-                        AddCollectionWithNestedCollections(
-                            collection,
-                            matchingCollections,
-                            visitedCollectionIds,
-                            allCollectionsById,
-                            user,
-                            logger,
-                            0,  // Start at depth 0 (root level)
-                            maxRecursionDepth,
-                            Origin,
-                            encounteredIds);
-
-                        if (encounteredIds != null)
-                        {
-                            // Map the matched collection and its nested children to the matched
-                            // groups so per-group limits and Rule Block Order see them
-                            foreach (var encounteredId in encounteredIds)
-                            {
-                                TrackIncludeOnlyGroupMapping(encounteredId, matchedSetIndices);
-                            }
-                        }
-                    }
-                }
-
-                logger?.LogDebug("Found {Count} matching collections (including nested) out of {TotalCount} total collections",
-                    matchingCollections.Count, allCollections.Count);
-            }
-            catch (Exception ex)
-            {
-                logger?.LogError(ex, "Error fetching matching collections for IncludeCollectionOnly mode");
-            }
-
-            return matchingCollections;
-        }
-
-        /// <summary>
         /// Recursively adds a collection and its nested collections up to the specified depth.
         /// When <paramref name="encounteredIds"/> is provided, every collection reached by this
         /// walk is recorded in it - including collections already appended by an earlier root -
@@ -2079,7 +1656,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
             {
                 visitedCollectionIds.Add(collection.Id);
                 matchingCollections.Add(collection);
-                logger?.LogDebug("Collection '{CollectionName}' matches Collections rules with IncludeCollectionOnly=true (depth={Depth})", collection.Name, currentDepth);
+                logger?.LogDebug("Collection '{CollectionName}' added by the nested-collection walk (depth={Depth})", collection.Name, currentDepth);
             }
 
             // If we haven't reached max depth, look for nested collections
@@ -2148,6 +1725,273 @@ namespace Jellyfin.Plugin.SmartLists.Core
             }
 
             return [];
+        }
+
+        /// <summary>
+        /// True when the item is a container candidate kind (BoxSet or Playlist).
+        /// </summary>
+        private static bool IsContainerKind(BaseItem item) =>
+            item.GetBaseItemKind() is BaseItemKind.BoxSet or BaseItemKind.Playlist;
+
+        /// <summary>
+        /// MatchByMembers mode: evaluates each container candidate's member items against the full
+        /// compiled rule pipeline and includes a container when at least one member passes. Members
+        /// shared across containers are evaluated exactly once - the unique member set runs through
+        /// the same chunked two-phase pipeline as regular items - then per-container inclusion is a
+        /// lookup. When group tracking is active (per-group limits / Rule Block Order), a container
+        /// maps to every rule group any of its passing members matched.
+        /// </summary>
+        private List<BaseItem> MatchContainersByMembers(
+            BaseItem[] containerCandidates,
+            ILibraryManager libraryManager,
+            User user,
+            IUserDataManager? userDataManager,
+            ILogger? logger,
+            FieldRequirements fieldReqs,
+            OperandFactory.ReferenceMetadata? referenceMetadata,
+            List<string> similarityComparisonFields,
+            List<List<Func<Operand, bool>>> compiledRules,
+            bool hasAnyRules,
+            bool hasNonExpensiveRules,
+            RefreshQueueService.RefreshCache refreshCache)
+        {
+            var matchedContainers = new List<BaseItem>();
+
+            try
+            {
+                // Enumerate direct members per container (cached - no per-container queries beyond
+                // an uncached first enumeration). Container-kind members are not evaluated as
+                // members; nested collections are handled by the nested-collection walk instead.
+                var membersByContainer = new Dictionary<Guid, BaseItem[]>();
+                var uniqueMembers = new Dictionary<Guid, BaseItem>();
+                foreach (var container in containerCandidates)
+                {
+                    var members = GetContainerMembers(container, user, refreshCache, logger)
+                        .Where(m => m != null && !IsContainerKind(m))
+                        .ToArray();
+                    membersByContainer[container.Id] = members;
+                    foreach (var member in members)
+                    {
+                        uniqueMembers.TryAdd(member.Id, member);
+                    }
+                }
+
+                // Evaluate every unique member exactly once through the same pipeline as regular
+                // items (two-phase filtering included). The DB-prefilter candidate set is NOT
+                // applied: it was built for the pool's media types, and members can be of any kind.
+                var passedMemberIds = new HashSet<Guid>();
+                if (uniqueMembers.Count > 0)
+                {
+                    var config = Plugin.Instance?.Configuration;
+                    var batchSize = config?.ProcessingBatchSize ?? 300;
+                    if (batchSize <= 0)
+                    {
+                        batchSize = 300;
+                    }
+
+                    var memberList = uniqueMembers.Values.ToList();
+                    for (int chunkStart = 0; chunkStart < memberList.Count; chunkStart += batchSize)
+                    {
+                        var chunk = memberList.Skip(chunkStart).Take(batchSize);
+                        var passingMembers = ProcessItemChunk(chunk, libraryManager, user, userDataManager, logger,
+                            fieldReqs, referenceMetadata, similarityComparisonFields, compiledRules, hasAnyRules, hasNonExpensiveRules, null, refreshCache);
+                        foreach (var member in passingMembers)
+                        {
+                            passedMemberIds.Add(member.Id);
+                        }
+                    }
+                }
+
+                logger?.LogDebug("MatchByMembers: {PassingCount}/{MemberCount} unique members passed the rules across {ContainerCount} container candidates",
+                    passedMemberIds.Count, uniqueMembers.Count, containerCandidates.Length);
+
+                bool trackGroups = NeedsGroupTracking();
+                foreach (var container in containerCandidates)
+                {
+                    var members = membersByContainer[container.Id];
+                    HashSet<int>? containerGroups = trackGroups ? [] : null;
+                    bool anyMemberPassed = false;
+
+                    foreach (var member in members)
+                    {
+                        if (!passedMemberIds.Contains(member.Id))
+                        {
+                            continue;
+                        }
+
+                        anyMemberPassed = true;
+                        if (containerGroups == null)
+                        {
+                            break; // No group tracking - the first passing member is enough
+                        }
+
+                        if (_itemGroupMappings.TryGetValue(member.Id, out var memberGroups))
+                        {
+                            containerGroups.UnionWith(memberGroups);
+                        }
+                    }
+
+                    if (!anyMemberPassed)
+                    {
+                        continue;
+                    }
+
+                    matchedContainers.Add(container);
+                    if (containerGroups is { Count: > 0 })
+                    {
+                        TrackContainerGroupMapping(container.Id, [.. containerGroups]);
+                    }
+
+                    logger?.LogDebug("Container '{ContainerName}' matched via its members", container.Name);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, "Error matching containers by members for '{ListName}'", Name);
+            }
+
+            return matchedContainers;
+        }
+
+        /// <summary>
+        /// Gets the direct member items of a container candidate, preferring the RefreshCache
+        /// (CollectionDirectChildren / CollectionChildItems / PlaylistChildItems) before falling
+        /// back to reflection. Uncached lookups are stored in the child-items caches; the
+        /// Factory-built CollectionDirectChildren cache is only read, never seeded, because its
+        /// builder treats a non-empty cache as fully built.
+        /// </summary>
+        private static BaseItem[] GetContainerMembers(BaseItem container, User user, RefreshQueueService.RefreshCache refreshCache, ILogger? logger)
+        {
+            if (container.GetBaseItemKind() == BaseItemKind.BoxSet)
+            {
+                if (refreshCache.CollectionDirectChildren.TryGetValue(container.Id, out var directChildren))
+                {
+                    return directChildren;
+                }
+
+                if (refreshCache.CollectionChildItems.TryGetValue(container.Id, out var cachedChildren))
+                {
+                    return cachedChildren;
+                }
+
+                var children = GetCollectionChildren(container, user, logger);
+                refreshCache.CollectionChildItems.TryAdd(container.Id, children);
+                return children;
+            }
+
+            if (refreshCache.PlaylistChildItems.TryGetValue(container.Id, out var cachedMembers))
+            {
+                return cachedMembers;
+            }
+
+            // GetCollectionChildren's GetChildren/GetLinkedChildren reflection works for playlists too
+            var members = GetCollectionChildren(container, user, logger);
+            refreshCache.PlaylistChildItems.TryAdd(container.Id, members);
+            return members;
+        }
+
+        /// <summary>
+        /// Appends nested collections of every matched collection in <paramref name="results"/> up
+        /// to CollectionSearchDepth via the existing <see cref="AddCollectionWithNestedCollections"/>
+        /// walk (Origin guard and group tracking included). Nested children inherit the matched
+        /// root's rule-group mapping so per-group limits and Rule Block Order see them.
+        /// Applies in both MatchByMembers modes.
+        /// </summary>
+        private void AppendNestedCollections(List<BaseItem> results, ILibraryManager libraryManager, User user,
+            RefreshQueueService.RefreshCache refreshCache, ILogger? logger)
+        {
+            try
+            {
+                var maxDepth = GetMaxCollectionRecursionDepth();
+                if (maxDepth <= 0 || results.Count == 0)
+                {
+                    return;
+                }
+
+                var matchedRoots = results.Where(static r => r.GetBaseItemKind() == BaseItemKind.BoxSet).ToList();
+                if (matchedRoots.Count == 0)
+                {
+                    return;
+                }
+
+                // All-collections lookup for resolving nested children (shared per-drain cache)
+                BaseItem[] allCollections;
+                if (refreshCache.AllCollections != null)
+                {
+                    allCollections = refreshCache.AllCollections;
+                }
+                else
+                {
+                    var collectionQuery = new InternalItemsQuery(user)
+                    {
+                        IncludeItemTypes = [BaseItemKind.BoxSet],
+                        Recursive = true,
+                    };
+                    allCollections = [.. libraryManager.GetItemsResult(collectionQuery).Items];
+                    refreshCache.AllCollections = allCollections;
+                }
+
+                var allCollectionsById = new Dictionary<Guid, BaseItem>();
+                foreach (var collection in allCollections)
+                {
+                    allCollectionsById.TryAdd(collection.Id, collection);
+                }
+
+                bool trackGroups = NeedsGroupTracking();
+                var walked = new List<BaseItem>();
+                var visitedCollectionIds = new HashSet<Guid>();
+
+                foreach (var root in matchedRoots)
+                {
+                    // When tracking groups, collect every collection this root's walk reaches -
+                    // including ones already appended by an earlier root - so shared descendants
+                    // get mapped to every matching group, not just the first
+                    var encounteredIds = trackGroups ? new HashSet<Guid>() : null;
+
+                    AddCollectionWithNestedCollections(
+                        root,
+                        walked,
+                        visitedCollectionIds,
+                        allCollectionsById,
+                        user,
+                        logger,
+                        0,  // Start at depth 0 (root level)
+                        maxDepth,
+                        Origin,
+                        encounteredIds);
+
+                    if (encounteredIds != null && _itemGroupMappings.TryGetValue(root.Id, out var rootGroups) && rootGroups.Count > 0)
+                    {
+                        // Nested children inherit the matched root's rule groups
+                        foreach (var encounteredId in encounteredIds)
+                        {
+                            TrackContainerGroupMapping(encounteredId, rootGroups);
+                        }
+                    }
+                }
+
+                // The walk re-adds the roots - append only collections not already in the results
+                var existingIds = new HashSet<Guid>(results.Select(static r => r.Id));
+                var appendedCount = 0;
+                foreach (var collection in walked)
+                {
+                    if (existingIds.Add(collection.Id))
+                    {
+                        results.Add(collection);
+                        appendedCount++;
+                    }
+                }
+
+                if (appendedCount > 0)
+                {
+                    logger?.LogDebug("Appended {AppendedCount} nested collection(s) for {RootCount} matched collection(s) (depth={Depth})",
+                        appendedCount, matchedRoots.Count, maxDepth);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, "Error appending nested collections for '{ListName}'", Name);
+            }
         }
 
         /// <summary>
@@ -2237,7 +2081,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
         }
 
         /// <summary>
-        /// Gets the collection search depth for IncludeCollectionOnly mode.
+        /// Gets the collection search depth for the nested-collection walk of matched collections.
         /// Uses the list-level CollectionSearchDepth setting.
         /// </summary>
         private int GetMaxCollectionRecursionDepth()
@@ -2246,130 +2090,6 @@ namespace Jellyfin.Plugin.SmartLists.Core
             // depth=0 means only matched collections, no nested collections
             // depth=1+ means include nested collections up to that depth
             return CollectionSearchDepth;
-        }
-
-        /// <summary>
-        /// Gets playlists that match rule groups containing "playlist only" rules.
-        /// The ENTIRE group must match: playlist-only rules against the playlist name,
-        /// sibling rules against the playlist itself (AND logic, issue #479).
-        /// Note: Playlists in Jellyfin are flat - they cannot contain other playlists or collections.
-        /// Therefore, no recursion is needed; we simply find playlists that match the rule criteria.
-        /// </summary>
-        /// <param name="libraryManager">Library manager to query playlists</param>
-        /// <param name="user">User context</param>
-        /// <param name="userDataManager">User data manager for sibling-rule evaluation</param>
-        /// <param name="refreshCache">Cache for performance optimization</param>
-        /// <param name="logger">Logger for debugging</param>
-        /// <returns>List of matching playlists</returns>
-        private List<BaseItem> GetMatchingPlaylists(ILibraryManager libraryManager, User user,
-            IUserDataManager? userDataManager, RefreshQueueService.RefreshCache refreshCache, ILogger? logger)
-        {
-            var matchingPlaylists = new List<BaseItem>();
-
-            try
-            {
-                // Query all playlists
-                var playlistQuery = new InternalItemsQuery(user)
-                {
-                    IncludeItemTypes = [BaseItemKind.Playlist],
-                    Recursive = true,
-                };
-
-                var allPlaylists = libraryManager.GetItemsResult(playlistQuery).Items;
-                logger?.LogDebug("Found {Count} total playlists to check against Playlists rules with IncludePlaylistOnly=true", allPlaylists.Count);
-
-                // Prepare the rule groups containing playlist-only rules - the whole group
-                // (name rules + sibling rules) must match for a playlist to be included
-                var includeOnlyRuleSets = BuildIncludeOnlyRuleSets("Playlists", user, logger);
-                var extractionOptions = BuildIncludeOnlyExtractionOptions(includeOnlyRuleSets);
-                bool trackGroups = NeedsGroupTracking();
-
-                // Check each playlist against the playlist-only rule groups
-                foreach (var playlist in allPlaylists)
-                {
-                    if (playlist == null) continue;
-
-                    // Skip if this playlist is the one we're currently building (prevent self-reference)
-                    if (Origin.Matches(playlist))
-                    {
-                        logger?.LogDebug("Skipping playlist '{PlaylistName}' - matches current list being built (preventing self-reference)", playlist.Name);
-                        continue;
-                    }
-
-                    // The whole rule group must match: name rules against the playlist name,
-                    // sibling rules against the playlist's own metadata
-                    var playlistNames = new List<string> { playlist.Name };
-                    var matchedSetIndices = GetMatchingIncludeOnlySetIndices(playlistNames, includeOnlyRuleSets, DoesPlaylistMatchRule, () =>
-                        {
-                            try
-                            {
-                                return OperandFactory.GetMediaType(libraryManager, playlist, user, userDataManager, UserManager, logger, extractionOptions, refreshCache);
-                            }
-                            catch (Exception ex)
-                            {
-                                logger?.LogWarning(ex, "Error extracting fields from playlist '{PlaylistName}' for include-only rule matching", playlist.Name);
-                                return null;
-                            }
-                        });
-                    if (matchedSetIndices.Count > 0)
-                    {
-                        matchingPlaylists.Add(playlist);
-                        if (trackGroups)
-                        {
-                            TrackIncludeOnlyGroupMapping(playlist.Id, matchedSetIndices);
-                        }
-                        logger?.LogDebug("Playlist '{PlaylistName}' matches a playlist-only rule group", playlist.Name);
-                    }
-                }
-
-                logger?.LogDebug("Found {Count} matching playlists out of {TotalCount} total playlists",
-                    matchingPlaylists.Count, allPlaylists.Count);
-            }
-            catch (Exception ex)
-            {
-                logger?.LogError(ex, "Error fetching matching playlists for IncludePlaylistOnly mode");
-            }
-
-            return matchingPlaylists;
-        }
-
-        /// <summary>
-        /// Checks if playlists match a specific Playlists rule.
-        /// </summary>
-        /// <param name="playlists">The playlist names to check</param>
-        /// <param name="expr">The expression rule to check against</param>
-        /// <returns>True if playlists match the rule, false otherwise</returns>
-        private static bool DoesPlaylistMatchRule(List<string> playlists, Expression expr)
-        {
-            if (string.IsNullOrEmpty(expr.TargetValue))
-                return false;
-
-            switch (expr.Operator)
-            {
-                case "Equal":
-                    // Check both exact name match and name without prefix/suffix
-                    return playlists.Any(p => 
-                        p != null && 
-                        (p.Equals(expr.TargetValue, StringComparison.OrdinalIgnoreCase) ||
-                         NameFormatter.StripPrefixAndSuffix(p).Equals(expr.TargetValue, StringComparison.OrdinalIgnoreCase)));
-
-                case "Contains":
-                    // Reuse Engine helper for consistency and null safety
-                    return Engine.AnyItemContains(playlists, expr.TargetValue);
-
-                case "IsIn":
-                    // Maintain parity with Engine's "contains any in list" semantics
-                    return Engine.AnyItemIsInList(playlists, expr.TargetValue);
-
-                case "MatchRegex":
-                    // Delegate to Engine to leverage compiled regex cache and uniform error handling
-                    try { return Engine.AnyRegexMatch(playlists, expr.TargetValue); }
-                    catch (ArgumentException) { return false; }
-
-                default:
-                    // Unknown operator - treat as no match
-                    return false;
-            }
         }
 
         /// <summary>
@@ -3025,6 +2745,14 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 return true;
             }
 
+            // Container candidates (Collection/Playlist media types) are outside the prefilter
+            // safety contract - candidate queries and name dumps target regular library items -
+            // so never shrink them away. Keeping too much is always safe.
+            if (IsContainerKind(item))
+            {
+                return true;
+            }
+
             return false;
         }
 
@@ -3073,15 +2801,6 @@ namespace Jellyfin.Plugin.SmartLists.Core
                         {
                             var set = ExpressionSets[setIndex];
                             if (set?.Expressions == null) continue;
-
-                            // Include-only groups never match individual media items (their compiled
-                            // set is empty) - exclude them here so Phase 1 doesn't mistake them for
-                            // expensive-only rule sets that force every item into Phase 2
-                            if (set.Expressions.Any(expr => IsCollectionOnlyExpression(expr) || IsPlaylistOnlyExpression(expr)))
-                            {
-                                logger?.LogDebug("Rule set {SetIndex}: contains include-only rules - excluded from item filtering", setIndex);
-                                continue;
-                            }
 
                             var cheapRules = new List<Func<Operand, bool>>();
                             int expensiveCount = 0;
@@ -3204,7 +2923,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                                 }
                                 else if (compiledRules.All(set => set?.Count == 0))
                                 {
-                                    // Special case: Only SimilarTo or IncludeCollectionOnly rules (no compiled rules)
+                                    // Special case: Only SimilarTo rules (no compiled rules)
                                     // In this case, start with matches = true and let similarity filter decide
                                     matches = true;
                                 }
@@ -3452,7 +3171,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                                 }
                                 else if (compiledRules.All(set => set?.Count == 0))
                                 {
-                                    // Special case: Only SimilarTo or IncludeCollectionOnly rules (no compiled rules)
+                                    // Special case: Only SimilarTo rules (no compiled rules)
                                     // In this case, start with matches = true and let similarity filter decide
                                     matches = true;
                                 }
@@ -3589,7 +3308,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
                         }
                         else if (compiledRules.All(set => set?.Count == 0))
                         {
-                            // Special case: Only SimilarTo or IncludeCollectionOnly rules (no compiled rules)
+                            // Special case: Only SimilarTo rules (no compiled rules)
                             // In this case, start with matches = true and let similarity filter decide
                             matches = true;
                         }
@@ -3678,6 +3397,10 @@ namespace Jellyfin.Plugin.SmartLists.Core
         /// <summary>
         /// Extracts the CollectionSearchDepth from the first Collections expression that has it set.
         /// This allows per-rule control of collection traversal depth.
+        /// Name rules are also considered: the include-only migration
+        /// (SmartListFileSystem.MigrateIncludeOnlyRulesToMediaTypes) rewrites legacy include-only
+        /// Collections/Playlists rules to Name rules and keeps their depth, so the configured
+        /// nested-collection walk depth must stay reachable on the migrated shape.
         /// </summary>
         /// <param name="expressionSets">The expression sets to search</param>
         /// <returns>The depth value if found, null otherwise</returns>
@@ -3688,14 +3411,16 @@ namespace Jellyfin.Plugin.SmartLists.Core
                 return null;
             }
 
-            // Find the first Collections expression that has CollectionSearchDepth set
+            // Find the first Collections expression that has CollectionSearchDepth set.
+            // Name rules only carry a depth when the include-only migration put it there.
             foreach (var set in expressionSets)
             {
                 if (set?.Expressions == null) continue;
 
                 foreach (var expr in set.Expressions)
                 {
-                    if (expr?.MemberName == "Collections" && expr.CollectionSearchDepth.HasValue)
+                    if (expr != null && expr.CollectionSearchDepth.HasValue &&
+                        (expr.MemberName == "Collections" || expr.MemberName == "Name"))
                     {
                         // Clamp to valid range (0-10)
                         return Math.Max(0, Math.Min(10, expr.CollectionSearchDepth.Value));

--- a/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
@@ -221,12 +221,6 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                     ItemRepository = _itemRepository, // ItemValues-backed name dumps for DB prefilters
                 };
 
-                // Query for collections if IncludeCollectionOnly is enabled
-                var allCollections = QueryIncludeOnlyItems(dto, "Collections", BaseItemKind.BoxSet, ownerUser, "collection");
-
-                // Query for playlists if IncludePlaylistOnly is enabled
-                var allPlaylists = QueryIncludeOnlyItems(dto, "Playlists", BaseItemKind.Playlist, ownerUser, "playlist");
-
                 // Log the collection rules
                 _logger.LogDebug("Processing collection {CollectionName} with {RuleSetCount} rule sets (Owner: {OwnerUser})", 
                     dto.Name, dto.ExpressionSets?.Count ?? 0, ownerUser.Username);
@@ -258,7 +252,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                     dto.Name, newItems.Length, allMedia.Length);
 
                 // Create a lookup dictionary for O(1) access while preserving order from newItems
-                // Include both media items and collections (if IncludeCollectionOnly is enabled) and playlists (if IncludePlaylistOnly is enabled)
+                // Container candidates (Collection/Playlist media types) are part of allMedia
                 var groupedMedia = allMedia.GroupBy(m => m.Id).ToList();
                 var duplicateMediaGroups = groupedMedia.Where(g => g.Count() > 1).ToList();
                 if (duplicateMediaGroups.Count > 0 && SmartListUtilities.UsesLibraryNameRule(dto))
@@ -275,8 +269,6 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                 }
 
                 var mediaLookup = groupedMedia.ToDictionary(g => g.Key, g => g.First());
-                AddIncludeOnlyItemsToLookup(mediaLookup, allCollections);
-                AddIncludeOnlyItemsToLookup(mediaLookup, allPlaylists);
                 var distinctNewItems = newItems.Distinct().ToArray();
                 if (distinctNewItems.Length != newItems.Length)
                 {
@@ -373,6 +365,11 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
 
                 var collectionName = dto.Name;
 
+                // Resolved member items for the written children - shared by the aggregate
+                // metadata roll-up in FinalizeCollectionMetadataAsync and the drain snapshot
+                // patches below, so the lookup is only walked once.
+                var writtenMembers = WrittenMembers(newLinkedChildren, mediaLookup);
+
                 if (existingCollectionItem != null && existingCollectionItem.GetBaseItemKind() == BaseItemKind.BoxSet)
                 {
                     var existingCollection = existingCollectionItem;
@@ -407,7 +404,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                     }
 
                     // Update the collection items
-                    await UpdateCollectionItemsAsync(existingCollection, newLinkedChildren, dto, ownerUser, cancellationToken);
+                    await UpdateCollectionItemsAsync(existingCollection, newLinkedChildren, writtenMembers, dto, ownerUser, cancellationToken);
 
                     _logger.LogDebug("Successfully updated existing collection: {CollectionName} with {ItemCount} items",
                         existingCollection.Name, newLinkedChildren.Length);
@@ -420,7 +417,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
 
                     // Keep this drain's membership snapshot current, or a list refreshed later in the
                     // same drain evaluates its Collections rules against the contents we just replaced.
-                    refreshCache.OnCollectionWritten(existingCollection, WrittenMembers(newLinkedChildren, mediaLookup));
+                    refreshCache.OnCollectionWritten(existingCollection, writtenMembers);
 
                     return (true, $"Updated collection '{existingCollection.Name}' with {newLinkedChildren.Length} items", existingCollection.Id.ToString("N"));
                 }
@@ -429,7 +426,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                     // Create new collection
                     _logger.LogDebug("Creating new collection: {CollectionName}", collectionName);
 
-                    var newCollectionId = await CreateNewCollectionAsync(collectionName, newLinkedChildren, dto, ownerUser, cancellationToken);
+                    var newCollectionId = await CreateNewCollectionAsync(collectionName, newLinkedChildren, writtenMembers, dto, ownerUser, cancellationToken);
 
                     // Check if collection creation actually succeeded
                     if (string.IsNullOrEmpty(newCollectionId))
@@ -458,7 +455,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                     if (Guid.TryParse(newCollectionId, out var writtenCollectionId)
                         && _libraryManager.GetItemById(writtenCollectionId) is BaseItem createdCollection)
                     {
-                        refreshCache.OnCollectionWritten(createdCollection, WrittenMembers(newLinkedChildren, mediaLookup));
+                        refreshCache.OnCollectionWritten(createdCollection, writtenMembers);
                     }
 
                     return (true, $"Created collection '{collectionName}' with {newLinkedChildren.Length} items", newCollectionId);
@@ -722,7 +719,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
             }
         }
 
-        private async Task UpdateCollectionItemsAsync(BaseItem collection, LinkedChild[] linkedChildren, SmartCollectionDto dto, User ownerUser, CancellationToken cancellationToken)
+        private async Task UpdateCollectionItemsAsync(BaseItem collection, LinkedChild[] linkedChildren, IReadOnlyList<BaseItem> members, SmartCollectionDto dto, User ownerUser, CancellationToken cancellationToken)
         {
             // Verify this is a BoxSet using BaseItemKind
             if (collection.GetBaseItemKind() != BaseItemKind.BoxSet)
@@ -774,11 +771,11 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
             var collectionAfterRefresh = _libraryManager.GetItemById(collection.Id);
             if (collectionAfterRefresh != null && collectionAfterRefresh.GetBaseItemKind() == BaseItemKind.BoxSet)
             {
-                await FinalizeCollectionMetadataAsync(collectionAfterRefresh, expectedName, linkedChildren, dto, ownerUser, cancellationToken).ConfigureAwait(false);
+                await FinalizeCollectionMetadataAsync(collectionAfterRefresh, expectedName, linkedChildren, members, dto, ownerUser, cancellationToken).ConfigureAwait(false);
             }
         }
 
-        private async Task<string> CreateNewCollectionAsync(string collectionName, LinkedChild[] linkedChildren, SmartCollectionDto dto, User ownerUser, CancellationToken cancellationToken)
+        private async Task<string> CreateNewCollectionAsync(string collectionName, LinkedChild[] linkedChildren, IReadOnlyList<BaseItem> members, SmartCollectionDto dto, User ownerUser, CancellationToken cancellationToken)
         {
             // Apply prefix/suffix to collection name using the same configuration as playlists
             var formattedName = NameFormatter.FormatPlaylistName(collectionName);
@@ -1025,7 +1022,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                 retrievedItem = _libraryManager.GetItemById(collectionId);
                 if (retrievedItem != null && retrievedItem.GetBaseItemKind() == BaseItemKind.BoxSet)
                 {
-                    await FinalizeCollectionMetadataAsync(retrievedItem, formattedName, linkedChildren, dto, ownerUser, cancellationToken).ConfigureAwait(false);
+                    await FinalizeCollectionMetadataAsync(retrievedItem, formattedName, linkedChildren, members, dto, ownerUser, cancellationToken).ConfigureAwait(false);
                 }
 
                 // Stamp the tether so the collection can be recovered if the stored ID goes stale.
@@ -1088,6 +1085,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
             BaseItem collection,
             string expectedName,
             LinkedChild[] linkedChildren,
+            IReadOnlyList<BaseItem> members,
             SmartCollectionDto dto,
             User ownerUser,
             CancellationToken cancellationToken)
@@ -1115,6 +1113,12 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                 metadataChanged = true;
             }
 
+            // Roll up member metadata (genres, studios, rating, runtime). The lock enforced
+            // above also suppresses Jellyfin's own child aggregation, so without this smart
+            // collections carry no genres/studios at all - invisible to rules on those fields
+            // and blank in the Jellyfin UI. Change-tracked so a no-op refresh writes nothing.
+            metadataChanged |= UpdateAggregateMetadata(collection, members);
+
             metadataChanged |= SetCollectionDisplayOrder(collection);
             if (metadataChanged)
             {
@@ -1123,6 +1127,66 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
 
             // Apply custom metadata after metadata refresh to prevent providers from overwriting.
             await ApplyCustomMetadataAsync(collection, dto, ownerUser, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Mirrors the child aggregation Jellyfin's provider refresh normally performs
+        /// (MetadataService.UpdateMetadataFromChildren): cumulative runtime, genres, studios,
+        /// and official rating. Counterpart of PlaylistService.UpdateAggregateMetadata.
+        /// Required because smart collections are metadata-locked (#433), which suppresses
+        /// core's own aggregation. Unlike the playlist version this deliberately does not
+        /// gate on IsLocked - the lock is the plugin's own and the plugin writes the item
+        /// directly, so the roll-up must run despite it.
+        /// </summary>
+        /// <param name="collection">The collection whose aggregate metadata to update.</param>
+        /// <param name="children">The resolved member items to aggregate from.</param>
+        /// <returns>True if any aggregate value actually changed, so callers skip the repository write on no-op refreshes.</returns>
+        internal static bool UpdateAggregateMetadata(BaseItem collection, IReadOnlyList<BaseItem> children)
+        {
+            var changed = false;
+
+            long ticks = 0;
+            foreach (var child in children)
+            {
+                if (!child.IsFolder)
+                {
+                    ticks += child.RunTimeTicks ?? 0;
+                }
+            }
+
+            if (collection.RunTimeTicks != ticks)
+            {
+                collection.RunTimeTicks = ticks;
+                changed = true;
+            }
+
+            // Sorted so the result is independent of member order - otherwise a mere reordering
+            // of the list would look like a metadata change and trigger a repository write.
+            var genres = children.SelectMany(c => c.Genres)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(g => g, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (!genres.SequenceEqual(collection.Genres, StringComparer.Ordinal))
+            {
+                collection.Genres = genres;
+                changed = true;
+            }
+
+            var studios = children.SelectMany(c => c.Studios)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (!studios.SequenceEqual(collection.Studios, StringComparer.Ordinal))
+            {
+                collection.Studios = studios;
+                changed = true;
+            }
+
+            var previousRating = collection.OfficialRating;
+            collection.UpdateRatingToItems(children);
+            changed |= !string.Equals(previousRating, collection.OfficialRating, StringComparison.Ordinal);
+
+            return changed;
         }
 
         /// <summary>
@@ -1325,27 +1389,49 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
             // Excludes internal folders like live TV recordings.
             var validTopParentIds = GetLibraryTopParentIds();
 
+            // Container kinds (BoxSet/Playlist) live in Jellyfin's internal collections/playlists
+            // folders, outside the library TopParentIds scope - query them separately without it
+            var containerKinds = baseItemKinds.Where(static k => k is BaseItemKind.BoxSet or BaseItemKind.Playlist).ToArray();
+            var itemKinds = baseItemKinds.Where(static k => k is not (BaseItemKind.BoxSet or BaseItemKind.Playlist)).ToArray();
+
             // Query all items the owner user has access to
             var includeVirtualItems = SmartListUtilities.UsesLibraryNameRule(dto);
-            var query = new InternalItemsQuery(ownerUser)
+            IReadOnlyList<BaseItem> items = [];
+            if (itemKinds.Length > 0)
             {
-                IncludeItemTypes = baseItemKinds,
-                Recursive = true,
-            };
+                var query = new InternalItemsQuery(ownerUser)
+                {
+                    IncludeItemTypes = itemKinds,
+                    Recursive = true,
+                };
 
-            LibraryManagerHelper.ApplyVirtualItemQueryScope(query, includeVirtualItems, validTopParentIds);
+                LibraryManagerHelper.ApplyVirtualItemQueryScope(query, includeVirtualItems, validTopParentIds);
 
-            var items = _libraryManager.GetItemsResult(query).Items;
+                items = _libraryManager.GetItemsResult(query).Items;
+            }
+
+            IEnumerable<BaseItem> allItems = items;
+            if (containerKinds.Length > 0)
+            {
+                var containerQuery = new InternalItemsQuery(ownerUser)
+                {
+                    IncludeItemTypes = containerKinds,
+                    Recursive = true,
+                };
+
+                allItems = allItems.Concat(_libraryManager.GetItemsResult(containerQuery).Items);
+            }
 
             if (dto?.IncludeExtras != true)
             {
-                return items;
+                return allItems;
             }
 
+            // Extras belong to regular library items only - containers have none
             var extras = LibraryManagerHelper.FetchExtras(
                 _libraryManager, ownerUser, validTopParentIds, items, extraOwnerMap, _logger, dto.Name);
 
-            return items.Concat(extras);
+            return allItems.Concat(extras);
         }
 
         private Guid[] GetLibraryTopParentIds() => LibraryManagerHelper.GetLibraryTopParentIds(_libraryManager);
@@ -2382,63 +2468,6 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
             => [.. linkedChildren
                 .Where(lc => lc.ItemId.HasValue && mediaLookup.ContainsKey(lc.ItemId.Value))
                 .Select(lc => mediaLookup[lc.ItemId!.Value])];
-
-        /// <summary>
-        /// Queries for items when IncludeOnly option is enabled for a field.
-        /// This is a shared helper for both Collections and Playlists fields.
-        /// </summary>
-        /// <param name="dto">The collection DTO containing expression sets</param>
-        /// <param name="fieldName">The field name to check (e.g., "Collections", "Playlists")</param>
-        /// <param name="itemKind">The item kind to query (e.g., BoxSet, Playlist)</param>
-        /// <param name="user">The user context for the query</param>
-        /// <param name="itemTypeName">Human-readable item type name for logging (e.g., "collection", "playlist")</param>
-        /// <returns>List of items if IncludeOnly is enabled, otherwise empty list</returns>
-        private List<BaseItem> QueryIncludeOnlyItems(
-            SmartCollectionDto dto,
-            string fieldName,
-            BaseItemKind itemKind,
-            User user,
-            string itemTypeName)
-        {
-            var hasIncludeOnly = dto.ExpressionSets?.Any(set =>
-                set.Expressions?.Any(expr =>
-                    expr.MemberName == fieldName && fieldName switch
-                    {
-                        "Collections" => expr.IncludeCollectionOnly == true,
-                        "Playlists" => expr.IncludePlaylistOnly == true,
-                        _ => false
-                    }) == true) == true;
-
-            if (!hasIncludeOnly)
-            {
-                return [];
-            }
-
-            _logger.LogDebug("Include{FieldName}Only is enabled - querying {ItemType}s for lookup", fieldName, itemTypeName);
-            var query = new InternalItemsQuery(user)
-            {
-                IncludeItemTypes = [itemKind],
-                Recursive = true,
-            };
-            var items = _libraryManager.GetItemsResult(query).Items.ToList();
-            _logger.LogDebug("Found {ItemCount} {ItemType}s for lookup", items.Count, itemTypeName);
-            
-            return items;
-        }
-
-        /// <summary>
-        /// Adds IncludeOnly items to the media lookup dictionary.
-        /// This is a shared helper for adding both collections and playlists to the lookup.
-        /// </summary>
-        /// <param name="mediaLookup">The lookup dictionary to add items to</param>
-        /// <param name="items">The items to add</param>
-        private static void AddIncludeOnlyItemsToLookup(Dictionary<Guid, BaseItem> mediaLookup, List<BaseItem> items)
-        {
-            foreach (var item in items)
-            {
-                mediaLookup[item.Id] = item;
-            }
-        }
 
     }
 }

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/AutoRefreshService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/AutoRefreshService.cs
@@ -507,7 +507,8 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
 
         private void AddPlaylistToRuleCache(SmartPlaylistDto playlist)
         {
-            var mediaTypes = playlist.MediaTypes?.ToList() ?? [.. MediaTypes.All];
+            // Container types (Collection/Playlist) are collection-only - never trigger playlists on them
+            var mediaTypes = playlist.MediaTypes?.ToList() ?? MediaTypes.All.Where(mt => !MediaTypes.IsContainerType(mt)).ToList();
 
             // Bumper pools select from their own media types - include them so library
             // changes to bumper-relevant items also trigger a refresh

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
@@ -539,6 +539,12 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                 progressCallback,
                 cancellationToken);
 
+            // The refresh wrote (or deleted) this list's Jellyfin playlist, so cached media for
+            // Playlist-typed lists is now stale. Drop those entries so later container lists in
+            // the same drain re-query - matching the per-refresh query the legacy include-only
+            // path performed. No-op when no list uses the Playlist media type.
+            InvalidateContainerMediaCaches(Core.Constants.MediaTypes.Playlist);
+
             if (!success)
             {
                 throw new InvalidOperationException($"Playlist refresh failed for user {user.Username}: {message}");
@@ -617,9 +623,35 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                 progressCallback,
                 cancellationToken);
 
+            // The refresh wrote (or deleted) this list's Jellyfin collection, so cached media for
+            // Collection-typed lists is now stale. Drop those entries so later container lists in
+            // the same drain re-query - matching the per-refresh query the legacy include-only
+            // path performed. No-op when no list uses the Collection media type.
+            InvalidateContainerMediaCaches(Core.Constants.MediaTypes.Collection);
+
             if (!success)
             {
                 throw new InvalidOperationException($"Collection refresh failed: {message}");
+            }
+        }
+
+        /// <summary>
+        /// Removes cached base-media entries whose media types include the given container type,
+        /// across every user's cache (a written container is visible to all users' queries).
+        /// The entry lazily re-queries on next use, so the cost is one query per subsequent
+        /// container-typed list refresh, and zero when no such list exists.
+        /// </summary>
+        private void InvalidateContainerMediaCaches(string containerMediaType)
+        {
+            foreach (var userCache in _userCaches.Values)
+            {
+                foreach (var key in userCache.Keys)
+                {
+                    if (key.ContainsType(containerMediaType))
+                    {
+                        userCache.TryRemove(key, out _);
+                    }
+                }
             }
         }
 

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/SmartListFileSystem.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/SmartListFileSystem.cs
@@ -245,6 +245,13 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
 
             // Migrate legacy fields (e.g. IsPlayed -> PlaybackStatus)
             playlist.MigrateLegacyFields();
+
+            // Legacy include-only flags never worked for playlists (Jellyfin playlists can only
+            // contain media items; container results were silently dropped) - strip them silently
+            StripIncludeOnlyFlags(playlist);
+
+            // Container media types are collection-only; drop any that slipped into stored JSON
+            playlist.MediaTypes.RemoveAll(Core.Constants.MediaTypes.IsContainerType);
         }
 
         /// <summary>
@@ -264,6 +271,147 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
 
             // Migrate legacy fields (e.g. IsPlayed -> PlaybackStatus)
             collection.MigrateLegacyFields();
+
+            // Migrate legacy per-rule include-only flags to Collection/Playlist media types
+            MigrateIncludeOnlyRulesToMediaTypes(collection);
+        }
+
+        /// <summary>
+        /// One-time migration of the legacy per-rule IncludeCollectionOnly/IncludePlaylistOnly
+        /// checkboxes to the Collection/Playlist media types. Each include-only Collections/
+        /// Playlists rule becomes a Name rule against the container itself (operator and value
+        /// preserved) - sibling rules already evaluated against the container and carry over
+        /// unchanged. Pure include-only lists (every rule group has an include-only rule) only
+        /// ever produced containers, so their item media types are replaced outright; mixed
+        /// lists keep their item types and gain the container type(s). MatchByMembers stays
+        /// false, preserving the legacy match-against-container-metadata behavior.
+        /// Idempotent: the flags are cleared, so rerunning is a no-op.
+        ///
+        /// A CollectionSearchDepth set on an include-only rule stays on the rewritten Name rule;
+        /// SmartList.ExtractCollectionSearchDepthFromExpressions reads Name rules too, so the
+        /// configured nested-collection walk depth survives migration.
+        ///
+        /// Behavior notes for the rewritten Name rules:
+        /// - Equal: the legacy matcher also matched the container name with the configured
+        ///   prefix/suffix stripped (users target smart lists by base name), so the engine must
+        ///   replicate that fallback when evaluating Name+Equal against container candidates -
+        ///   otherwise migrated pure include-only lists lose members.
+        /// - Negative operators (NotEqual/NotContains/IsNotIn): the legacy matcher's default arm
+        ///   matched nothing, so such rules produced empty groups. After migration they evaluate
+        ///   normally - accepted as a bug-fix, documented under "Existing lists may change".
+        /// </summary>
+        private static void MigrateIncludeOnlyRulesToMediaTypes(SmartCollectionDto collection)
+        {
+            if (collection.ExpressionSets == null || collection.ExpressionSets.Count == 0)
+            {
+                return;
+            }
+
+            // Mirrors the legacy engine's allRulesAreIncludeOnly check: such lists skipped media
+            // item processing entirely and returned only containers
+            var allSetsAreIncludeOnly = collection.ExpressionSets.All(set =>
+                set?.Expressions?.Any(expr =>
+                    (expr.MemberName == "Collections" && expr.IncludeCollectionOnly == true) ||
+                    (expr.MemberName == "Playlists" && expr.IncludePlaylistOnly == true)) == true);
+
+            var needsCollectionType = false;
+            var needsPlaylistType = false;
+
+            foreach (var set in collection.ExpressionSets)
+            {
+                if (set?.Expressions == null)
+                {
+                    continue;
+                }
+
+                foreach (var expression in set.Expressions)
+                {
+                    // The rewrite changes only MemberName - CollectionSearchDepth (when set) is
+                    // deliberately kept, and the depth extractor reads it from Name rules too
+                    if (expression.MemberName == "Collections" && expression.IncludeCollectionOnly == true)
+                    {
+                        expression.MemberName = "Name";
+                        needsCollectionType = true;
+                    }
+                    else if (expression.MemberName == "Playlists" && expression.IncludePlaylistOnly == true)
+                    {
+                        expression.MemberName = "Name";
+                        needsPlaylistType = true;
+                    }
+
+                    expression.IncludeCollectionOnly = null;
+                    expression.IncludePlaylistOnly = null;
+                }
+            }
+
+            if (!needsCollectionType && !needsPlaylistType)
+            {
+                return;
+            }
+
+            if (allSetsAreIncludeOnly)
+            {
+                // Pure include-only list: item media types never contributed results - drop them
+                collection.MediaTypes.Clear();
+            }
+
+            if (needsCollectionType && !collection.MediaTypes.Contains(Core.Constants.MediaTypes.Collection))
+            {
+                collection.MediaTypes.Add(Core.Constants.MediaTypes.Collection);
+            }
+
+            if (needsPlaylistType && !collection.MediaTypes.Contains(Core.Constants.MediaTypes.Playlist))
+            {
+                collection.MediaTypes.Add(Core.Constants.MediaTypes.Playlist);
+            }
+        }
+
+        /// <summary>
+        /// Strips the legacy IncludeCollectionOnly/IncludePlaylistOnly flags from a playlist's
+        /// rules. The include-only feature never worked for playlists (container results were
+        /// silently dropped by Jellyfin), so there is nothing to migrate. Idempotent.
+        /// </summary>
+        private static void StripIncludeOnlyFlags(SmartPlaylistDto playlist)
+        {
+            if (playlist.ExpressionSets == null)
+            {
+                return;
+            }
+
+            // The legacy engine skipped entire groups containing an include-only rule during item
+            // evaluation, so on a playlist such a group contributed nothing. Removing the group is
+            // the behavior-preserving migration - stripping only the flag would turn a dead group
+            // into an active item filter. (The UI never offered these checkboxes on playlist forms,
+            // so this only triggers on hand-edited JSON.)
+            var deadGroups = playlist.ExpressionSets
+                .Where(set => set?.Expressions?.Any(expr =>
+                    expr?.IncludeCollectionOnly == true || expr?.IncludePlaylistOnly == true) == true)
+                .ToList();
+
+            // If every group is include-only the legacy playlist was permanently empty; removing
+            // them all would flip it to "no rules = match everything". Strip just the flags instead
+            // so the groups keep filtering as regular rules - a visible result beats a silent flip.
+            if (deadGroups.Count > 0 && deadGroups.Count < playlist.ExpressionSets.Count)
+            {
+                foreach (var group in deadGroups)
+                {
+                    playlist.ExpressionSets.Remove(group);
+                }
+            }
+
+            foreach (var set in playlist.ExpressionSets)
+            {
+                if (set?.Expressions == null)
+                {
+                    continue;
+                }
+
+                foreach (var expression in set.Expressions)
+                {
+                    expression.IncludeCollectionOnly = null;
+                    expression.IncludePlaylistOnly = null;
+                }
+            }
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Utilities/DtoMapper.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/DtoMapper.cs
@@ -117,6 +117,7 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
                 Order = source.Order,
                 MediaTypes = source.MediaTypes,
                 IncludeExtras = source.IncludeExtras,
+                MatchByMembers = source.MatchByMembers,
                 HideWhenEmpty = source.HideWhenEmpty,
                 
                 // State and limits

--- a/Jellyfin.Plugin.SmartLists/Utilities/InputValidator.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/InputValidator.cs
@@ -279,6 +279,17 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
                 return mediaTypesResult;
             }
 
+            // Container media types (Collection/Playlist) are collection-only: Jellyfin playlists
+            // can only contain media items, so container results would be silently dropped
+            if (list is SmartPlaylistDto)
+            {
+                var containerType = list.MediaTypes?.FirstOrDefault(Core.Constants.MediaTypes.IsContainerType);
+                if (containerType != null)
+                {
+                    return SmartListValidationResult.Failure($"{containerType} media type is not supported for playlists. Jellyfin playlists can only contain media items - use a smart collection instead.");
+                }
+            }
+
             // Validate expression sets
             var ruleGroupsResult = ValidateRuleGroups(list.ExpressionSets, string.Empty);
             if (!ruleGroupsResult.IsValid)
@@ -314,7 +325,8 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
                 var unsupportedBumperType = bumpers.MediaTypes?.FirstOrDefault(mt =>
                     mt == Core.Constants.MediaTypes.Series
                     || mt == Core.Constants.MediaTypes.Season
-                    || mt == Core.Constants.MediaTypes.MusicAlbum);
+                    || mt == Core.Constants.MediaTypes.MusicAlbum
+                    || Core.Constants.MediaTypes.IsContainerType(mt));
                 if (unsupportedBumperType != null)
                 {
                     return SmartListValidationResult.Failure($"{unsupportedBumperType} media type is not supported for bumpers. Bumpers are woven into playlists, which cannot contain {unsupportedBumperType} items.");

--- a/Jellyfin.Plugin.SmartLists/Utilities/MediaTypesKey.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/MediaTypesKey.cs
@@ -58,6 +58,17 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
             return new MediaTypesKey(sortedTypes, collectionsExpansionFlag, includeExtrasFlag);
         }
 
+        /// <summary>
+        /// Whether this key's media types include the given type. Used to invalidate cached
+        /// container (Collection/Playlist) media after a refresh writes a container, so later
+        /// lists in the same drain see it - mirroring the per-refresh query the legacy
+        /// include-only path performed.
+        /// </summary>
+        public bool ContainsType(string mediaType)
+        {
+            return (_sortedTypes ?? []).Contains(mediaType, StringComparer.Ordinal);
+        }
+
         public bool Equals(MediaTypesKey other)
         {
             // Handle null arrays (default struct case) and use SequenceEqual for cleaner comparison

--- a/docs/content/changelog/rc.md
+++ b/docs/content/changelog/rc.md
@@ -13,6 +13,19 @@ A non-zero final segment is the RC number — older entries instead number the R
 itself (`v10.10.10.0-rc3`), which is the scheme used before the number moved into the version.
 
 
+## Unreleased
+
+**Features**
+
+- New **Collection** and **Playlist** media types for smart collections: build collections *of* collections or playlists, filtered by any rule, and mix them freely with the other media types (see [Media Types](../user-guide/media-types.md#container-media-types)). A new list-level toggle — **"Match collections/playlists by the items inside them"** — chooses what the rules check. Off (default): the collection/playlist's own metadata (name, genres, studios, year, parental rating). On: the items inside it — a collection is included when at least one of its items passes all rules in a rule group, so `Actors contains "Arnold Schwarzenegger" AND Production Year less than 1990` finds exactly the collections containing a pre-1990 Arnold movie. Replaces the per-rule **"Include collections only"** / **"Include playlist only"** checkboxes, whose sibling rules could only see the little metadata a collection carries itself (follow-up to [#479](https://github.com/jyourstone/jellyfin-smartlists-plugin/issues/479)).
+- Smart collections now aggregate **genres, studios, parental rating and total runtime** from their members, like smart playlists already did. They now display this metadata in the Jellyfin UI, and other smart lists' rules on those fields can match them.
+
+**Existing lists may change**
+
+- Lists using the old include-only checkboxes are migrated automatically. Lists whose every rule group had the checkbox (the common case) keep their membership: the include-only rule becomes a **Name** rule against the collection/playlist and the matching media type is selected. Lists that *mixed* include-only rule groups with normal item rule groups may change contents, because rule groups now apply to every selected media type — an item group can now also match collections, and the rewritten Name rule also applies to items. One exception applies to any list: include-only rules using a negative operator (**not equals** / **not contains** / **is not in**) previously matched nothing at all; after migration they evaluate normally, so such lists may gain members.
+- Because smart collections now carry aggregated genres/studios/runtime, other lists with rules on those fields may start matching them.
+
+
 ## v12.0.0.17-rc
 
 *2026-08-17 · [release notes](https://github.com/jyourstone/jellyfin-smartlists-plugin/releases/tag/v12.0.0.17-rc)*

--- a/docs/content/examples/advanced-examples.md
+++ b/docs/content/examples/advanced-examples.md
@@ -76,8 +76,9 @@ Create a hand-curated collection using IMDb or TMDb IDs — useful for award lis
 - Uses OR logic between rule groups to pull from multiple playlist categories
 
 ## Smart Collection of Music Playlists
-- **Playlist name** matches regex `(?i)(workout|running|gym)` with "Include playlist only" enabled
 - **List Type**: Collection
+- **Media Types**: Playlist
+- **Name** matches regex `(?i)(workout|running|gym)`
 - Creates a collection that contains your exercise-related playlist objects
 - Great for organizing themed playlists without duplicating content
 - Use regex for flexible pattern matching (e.g., case-insensitive matching of multiple keywords)
@@ -95,9 +96,9 @@ Create a collection of collections that automatically sorts by aggregated values
 **Configuration**:
 
 - **List Type**: Collection
-- **Rule**: **Collection name** contains "action" with:
-    - **Include collections only**: Yes
-    - **Collection search depth**: 1
+- **Media Types**: Collection, with **"Match collections/playlists by the items inside them"** left off
+- **Rule**: **Name** contains "action"
+- **Collection search depth** (under the **Name** rule's options): 1
 - **Sort by**: Production Year
 
 **Result with Production Year Ascending**:

--- a/docs/content/examples/common-use-cases.md
+++ b/docs/content/examples/common-use-cases.md
@@ -33,20 +33,30 @@ Here are some popular playlist and collection types you can create:
 
 ### Complete Franchise Collection
 - **Collection name** contains "Movie Franchise" (includes all movies in the franchise)
-- **Note**: For Playlists, this fetches all media items from within the collection. For Collections, you can optionally enable "Include collections only" to create a meta-collection that contains the collection object itself
+- **Note**: This fetches the media items from *within* the collection. To include collection objects themselves, use the **Collection** [media type](../user-guide/media-types.md#container-media-types) instead — see the next example
 
 ### Meta-Collection (Collection of Collections)
-- **Collection name** is in "Marvel;DC;Star Wars" with "Include collections only" enabled
 - **List Type**: Collection
-- **Note**: When "Include collections only" is enabled, your selected media types are ignored, and the collection will contain the actual collection objects rather than the media items within them
+- **Media Types**: Collection
+- **Name** is in "Marvel;DC;Star Wars"
 - Creates a single collection that organizes multiple collections together (e.g., a "Superhero Universes" collection containing your Marvel, DC, and other superhero collections)
+- **Note**: The **Collection** media type is only available for smart collections — Jellyfin playlists can only contain media items
 - **Important**: The smart collection will never include itself in the results, even if its name matches the rule. So you can safely name your meta-collection "Superhero Universes" and use rules that match "Marvel" without worrying about it including itself
 
 ### Filtered Meta-Collection (Marvel Collections Only)
-- **Collection name** contains "Collection" with "Include collections only" enabled AND **Studios** contains "Marvel"
 - **List Type**: Collection
-- Includes only the collections whose own metadata lists a Marvel studio — other rules in the same group filter the collections themselves, not the items inside them
-- **Note**: Jellyfin aggregates studios and genres from a collection's items, so fields like Studios and Genres work well here. Fields a collection doesn't have (playback status, resolution, etc.) won't match anything
+- **Media Types**: Collection, with **"Match collections/playlists by the items inside them"** left off
+- **Name** contains "Collection" AND **Studios** contains "Marvel"
+- With the toggle off, rules match the collections' **own** metadata — name, genres, studios, production year, parental rating. Jellyfin aggregates studios and genres from a collection's items, and SmartLists does the same for its own smart collections
+- **Note**: For item-level fields like actors, playback status or resolution, turn the toggle **on** — see the next example
+
+### Collections Containing a Pre-1990 Arnold Movie
+- **List Type**: Collection
+- **Media Types**: Collection, with **"Match collections/playlists by the items inside them"** turned **on**
+- **Actors** contains "Arnold Schwarzenegger" AND **Production Year** less than 1990
+- With the toggle on, rules are checked against the movies *inside* each collection: a collection is included when **at least one** of its items passes **all** rules in a rule group — here, at least one pre-1990 Arnold Schwarzenegger movie
+- A collection holding a 2015 Arnold movie and a 1985 movie without him does **not** match — a single item must satisfy the whole rule group
+- **Tip**: Add **Movie** to the media types to also include the matching movies themselves alongside the collections
 
 ### Combine Multiple Playlists
 - **Playlist name** is in "Favorites;Top Rated;Recent Additions"
@@ -57,9 +67,9 @@ Here are some popular playlist and collection types you can create:
 - **Important**: Only playlists you own or that are marked as public are accessible. The smart playlist will never include itself in the results.
 
 ### Playlist Organization Collection
-- **Playlist name** contains "workout" with "Include playlist only" enabled
 - **List Type**: Collection
-- **Note**: When "Include playlist only" is enabled, the collection contains the actual playlist objects (not the media items within them)
+- **Media Types**: Playlist
+- **Name** contains "workout"
 - Creates a collection that organizes your playlists by category (e.g., a "Workout Playlists" collection containing all your workout-related playlists)
 - Useful for managing large numbers of playlists by grouping them into categories
 - **Important**: The smart collection will never include itself, and only playlists you own or that are public are accessible

--- a/docs/content/user-guide/configuration.md
+++ b/docs/content/user-guide/configuration.md
@@ -38,11 +38,11 @@ Before creating your first list, it's important to understand the differences be
 - **No Max Playtime**: Collections cannot have a playtime limit
 - **User Reference**: While collections don't have an "owner" in the traditional sense, you must select a user whose context will be used when evaluating rules and filtering items. This user's library access permissions and user-specific data (like "Playback Status", "Is Favorite", etc.) are used to determine which items are included in the collection
 - **Automatic Image Generation**: Collections automatically generate cover images based on the media items they contain (see details below)
-- **Can Contain Collections**: Unlike playlists, collections can contain other collection objects (creating "meta-collections") when using the "Include collections only" option with the Collection name field
+- **Can Contain Collections and Playlists**: Unlike playlists, collections can contain other collection and playlist objects (creating "meta-collections") — select the **Collection** or **Playlist** [media types](media-types.md#container-media-types)
 - **Use cases**: Organizing related content for browsing (e.g., "Action Movies", "Holiday Collection", "Director's Collection")
 
 !!! info "Smart collections are metadata-locked"
-    SmartLists creates its collections with Jellyfin's **"Lock this item"** flag enabled, and re-applies it on every refresh. This prevents Jellyfin's metadata fetchers from matching the collection against online databases by name and stamping a foreign TMDB ID on it — a mismatch that causes the TMDbBoxSets plugin to delete the collection as "orphaned". The lock does not affect cover image generation or any metadata set through SmartLists. If you untick the lock manually, it will be re-enabled on the next refresh.
+    SmartLists creates its collections with Jellyfin's **"Lock this item"** flag enabled, and re-applies it on every refresh. This prevents Jellyfin's metadata fetchers from matching the collection against online databases by name and stamping a foreign TMDB ID on it — a mismatch that causes the TMDbBoxSets plugin to delete the collection as "orphaned". The lock does not affect cover image generation or any metadata set through SmartLists — SmartLists itself aggregates **genres, studios, parental rating, and total runtime** from the collection's members on every refresh, so smart collections still display this metadata despite the lock. If you untick the lock manually, it will be re-enabled on the next refresh.
 
 #### Automatic Image Generation
 

--- a/docs/content/user-guide/fields-and-operators.md
+++ b/docs/content/user-guide/fields-and-operators.md
@@ -243,19 +243,18 @@ Filter items based on Jellyfin collection membership.
 **Behavior:**
 
 - **Playlists**: Fetches items *from within* matching collections
-- **Collections**: By default fetches items from within collections. Optionally can include collection objects themselves.
+- **Collections**: Fetches items *from within* matching collections. To include collection objects themselves, select the **Collection** [media type](media-types.md#container-media-types) instead.
 
 **Options:**
 
-- **Include collections only** (Collections only, default: No) - Include the collection object instead of its contents. Creates "collections of collections" (meta-collections). Media type selection is ignored when enabled.
 - **Include episodes within series** (Playlists with Episodes, default: No) - Include individual episodes from series in collections.
 
-!!! note "Combining with other rules"
-    When **Include collections only** is enabled, every other rule in the same rule group applies to the **collection itself** rather than to individual media items — the whole group must match for a collection to be included. For example, `Collection Name contains "Collection"` (collections only) AND `Studios contains "Marvel"` includes only collections whose own metadata lists a Marvel studio (Jellyfin aggregates studios and genres from a collection's items). Fields a collection doesn't carry (e.g. playback status or resolution) won't match anything. A rule group containing a collections-only rule never adds individual media items — use a separate rule group (OR) to combine collections with loose items.
+!!! note "Collections of collections"
+    The **Include collections only** checkbox from older versions has been replaced by the **Collection** [media type](media-types.md#container-media-types). Select it to include collection objects themselves, filtered either by their own metadata or by the items inside them.
 
 ##### Collection Search Depth {#collection-search-depth}
 
-How deep to traverse nested collections (default: 0):
+How deep to traverse nested collections (default: 0). The option appears under a **Collection Name** rule's options, and under a **Name** rule's options when the **Collection** [media type](media-types.md#container-media-types) is selected:
 
 - 0 = Only items directly in the collection
 - 1 = Items in collection + one level of sub-collections
@@ -276,14 +275,10 @@ Filter items based on Jellyfin playlist membership.
 **Behavior:**
 
 - **Playlists**: Fetches items *from within* matching playlists (create "super playlists")
-- **Collections**: By default fetches items from playlists. Optionally can include playlist objects.
+- **Collections**: Fetches items *from within* matching playlists. To include playlist objects themselves, select the **Playlist** [media type](media-types.md#container-media-types) instead.
 
-**Options:**
-
-- **Include playlist only** (Collections only, default: No) - Include the playlist object instead of its contents. Media type selection is ignored when enabled.
-
-!!! note "Combining with other rules"
-    When **Include playlist only** is enabled, every other rule in the same rule group applies to the **playlist itself** — the whole group must match for a playlist to be included. A rule group containing a playlist-only rule never adds individual media items; use a separate rule group (OR) for that.
+!!! note "Collections of playlists"
+    The **Include playlist only** checkbox from older versions has been replaced by the **Playlist** [media type](media-types.md#container-media-types). Select it to include playlist objects themselves, filtered either by their own metadata or by the items inside them.
 
 !!! note "Permissions"
     Only playlists you own or that are marked as public are accessible.

--- a/docs/content/user-guide/media-types.md
+++ b/docs/content/user-guide/media-types.md
@@ -1,6 +1,6 @@
 # Media Types
 
-When creating a smart list, you must select at least one **Media Type** to specify what kind of content should be included. Media types in SmartLists correspond directly to the **Content type** options you see when adding a new Media Library in Jellyfin.
+When creating a smart list, you must select at least one **Media Type** to specify what kind of content should be included. Media types in SmartLists correspond directly to the **Content type** options you see when adding a new Media Library in Jellyfin — plus **Collection** and **Playlist**, which target Jellyfin's built-in collections and playlists rather than a library (see [below](#container-media-types)).
 
 !!! tip "Default Media Types"
     If you usually create lists with the same media types, admins can set **Default Media Types** in the Settings tab of the admin configuration page. New lists created there will start with those types pre-selected (types only available for collections are skipped when the new list is a playlist).
@@ -20,6 +20,48 @@ When creating a smart list, you must select at least one **Media Type** to speci
 | **Photo** | Home Videos and Photos | Photo content |
 | **Books** | Books | E-book content |
 | **AudioBooks** | Books | Audiobook content |
+| **Collection** | Collections | Jellyfin collections themselves (collections only, see [below](#container-media-types)) |
+| **Playlist** | Playlists | Jellyfin playlists themselves (collections only, see [below](#container-media-types)) |
+
+## Collection & Playlist Media Types {#container-media-types}
+
+Smart **collections** can also select **Collection** and **Playlist** as media types, to build lists *of* collections or playlists — a "Superhero Universes" collection containing your Marvel and DC collections, or a collection that groups all your workout playlists. These types are not offered for smart playlists, because Jellyfin playlists can only contain media items.
+
+Collection and Playlist mix freely with the other media types: `Movie + Collection` is a valid selection, and — just like selecting `Movie + Series` — every rule group applies to every selected media type.
+
+### Match by members
+
+When a Collection or Playlist media type is selected, a list-level toggle appears: **"Match collections/playlists by the items inside them"**.
+
+**Toggle off (default)** — rules are checked against the collection or playlist **itself**. When *only* container types are selected, the rule field dropdown is limited to the fields a collection or playlist actually carries:
+
+- **Name**
+- **Genres** and **Studios** (Jellyfin aggregates these from a collection's items, and SmartLists writes them for its own smart collections and playlists)
+- **Production Year**, **Release Date**, **Parental Rating**
+- **Date Created**, **Last Metadata Refresh**, **Last Database Save**
+- **Collection Name** (membership in another collection)
+
+**Toggle on** — rules are checked against the **items inside** each collection or playlist, exactly as they would be for an item list. A collection or playlist is included when **at least one of its items passes all rules in a rule group** (rule groups still combine with OR). Every item field works: actors, tags, playback status, resolution, audio languages, and so on.
+
+For example, with the **Collection** media type and the toggle on:
+
+```
+Actors contains "Arnold Schwarzenegger"
+AND Production Year less than 1990
+```
+
+matches the collections that contain a pre-1990 Arnold Schwarzenegger movie. A **single item** must satisfy the whole rule group — a collection holding one 2015 Arnold movie and one 1985 movie without him does not match. Use separate rule groups (OR) when each condition may be satisfied by different items.
+
+In a mixed selection like `Movie + Collection`, item candidates are still evaluated directly: the example above produces the pre-1990 Arnold movies *and* the collections containing one.
+
+!!! note "Nested collections"
+    A matched collection still pulls in its nested collections up to the configured [Collection search depth](fields-and-operators.md#collection-search-depth), in both toggle modes.
+
+!!! note "Self-reference prevention"
+    A smart list never includes its own collection or playlist in the results, in either toggle mode, even when it matches the rules.
+
+!!! info "Replaces the old include-only checkboxes"
+    Older versions used per-rule **"Include collections only"** / **"Include playlist only"** checkboxes on the **Collection name** and **Playlist name** fields. Existing lists are migrated automatically on load: the include-only rule becomes a **Name** rule, the matching media type is selected, and the toggle stays off. See the [changelog](../changelog/rc.md) for details on lists that mixed include-only rules with normal item rules.
 
 ## Extras (Special Features)
 

--- a/docs/content/user-guide/media-types.md
+++ b/docs/content/user-guide/media-types.md
@@ -45,7 +45,7 @@ When a Collection or Playlist media type is selected, a list-level toggle appear
 
 For example, with the **Collection** media type and the toggle on:
 
-```
+```text
 Actors contains "Arnold Schwarzenegger"
 AND Production Year less than 1990
 ```

--- a/docs/content/user-guide/sorting-and-limits.md
+++ b/docs/content/user-guide/sorting-and-limits.md
@@ -337,7 +337,7 @@ When creating a **smart collection that contains other collections**, you can so
 
 When you have a "collection of collections" (a smart collection containing child collections), you may want to sort by the earliest, most recent, or highest-rated item **within** each child collection, rather than by the collection's own metadata.
 
-This feature is **automatically enabled** when your Collection name rule has a **Collection search depth** greater than 0 and you're sorting by one of the supported fields.
+This feature is **automatically enabled** when the list's **Collection search depth** is greater than 0 and you're sorting by one of the supported fields.
 
 ### Supported Sort Fields
 
@@ -355,9 +355,9 @@ The aggregation method depends on sort direction to ensure consistent, intuitive
 ### Configuration
 
 1. Set the output type to **Collection**
-2. Add a rule using the **Collection name** field
-3. Set **"Include collections only"** to **"Yes"** (to include the collection objects themselves)
-4. Set the **Collection search depth** field to 1 or higher (this controls how deep to look for items to aggregate)
+2. Select the **Collection** [media type](media-types.md#container-media-types), leaving **Match collections/playlists by the items inside them** off
+3. Add a rule matching the collections you want (e.g. **Name** contains "action")
+4. Set the **Collection search depth** to 1 or higher — the field appears under the **Name** rule's options whenever the **Collection** media type is selected (it controls how deep to look for items to aggregate; lists migrated from the old **Include collections only** checkbox keep their configured depth)
 5. Select a supported sort field (e.g., Production Year)
 
 !!! info "See Also"
@@ -402,8 +402,8 @@ When using multiple OR blocks, you can set a **Max Items limit for each individu
 !!! tip "Combining with Global Limits"
     Per-group limits are applied first, then the global Max Items limit. Example: 3 blocks × 50 items each = 150 total, then global limit of 100 = final result of 100 items.
 
-!!! note "Collection-only / playlist-only groups"
-    OR blocks using "collection only" or "playlist only" mode participate like any other block: their matched collections/playlists count toward that block's own limit and are unaffected by limits set on other blocks.
+!!! note "Collection / Playlist media types"
+    Collections and playlists matched via the [Collection/Playlist media types](media-types.md#container-media-types) participate like any other results: they count toward the limit of the OR block that matched them (with **Match by members** on, the block whose rules their member items passed) and are unaffected by limits set on other blocks.
 
 !!! info "See Examples"
     For detailed examples using per-group limits, see [Common Use Cases](../examples/common-use-cases.md#balanced-mix-with-per-group-limits) and [Advanced Examples](../examples/advanced-examples.md#advanced-per-group-limit-techniques).


### PR DESCRIPTION
## Summary

Successor to the #479 follow-up reports: with "include collections only", AND'd sibling rules were evaluated against the BoxSet's own metadata, which Jellyfin only partially aggregates — genres, studios, year and rating roll up from members, but **people and tags never do** (nor playback state, resolution, etc.), so rules like `Actors contains X` silently matched nothing. Smart collections were worse off still: they are metadata-locked (#433), which also suppresses Jellyfin's own aggregation, so they matched nothing on *any* field except name.

This replaces the per-rule "include collections only" / "include playlists only" checkboxes with proper **Collection and Playlist media types** plus a list-level **"Match collections/playlists by the items inside them"** toggle.

### Semantics

- **Media types**: `Collection` (BoxSet) and `Playlist`, offered for smart collections only (Jellyfin playlists can only contain media items — same gating as Series/Season/MusicAlbum). Mixing with item types is allowed; every rule group applies to every selected type.
- **Toggle off**: rules evaluate against the container itself (name, genres, studios, year, rating — the rule-field picker is gated to fields a container actually has).
- **Toggle on**: rules evaluate **per member item**, exactly as for an item list; a container is included when at least one member passes the full rule pipeline. Per-member AND: `Actors contains Arnold AND ProductionYear < 1990` means "collections containing a pre-1990 Arnold movie". Negative operators keep their item-level meaning. Members are evaluated once each and projected onto their containers via the drain's membership caches.
- Self-reference guard (#499) and the nested-collection walk (`CollectionSearchDepth`) apply in both modes.

### Migration (one-time, at load)

- Include-only rules are rewritten to `Name` rules against the container and the matching container media type is added; pure include-only lists are behavior-preserving (including Equal's prefix/suffix-stripped name matching and search depth).
- Playlist DTOs: include-only groups contributed nothing on playlists (containers were dropped at write), so dead groups are removed; if every group is include-only the flags are stripped instead to avoid a "no rules = match everything" flip.
- All legacy engine paths are deleted — containers now flow through the normal candidate pipeline.

### Aggregate metadata roll-up

`CollectionService` now mirrors `PlaylistService.UpdateAggregateMetadata`: smart collections get genres, studios, official rating and cumulative runtime from their members despite the metadata lock, sorted for order-independent change detection.

### Cache coherence

After a refresh writes a container, cached base media for container-typed lists is invalidated so later lists in the same drain see it (same class of bug as #503).

## Testing

- 1545 unit tests green (318 new/updated: migration, per-member AND, projection, self-reference, mixed types, roll-up), both TFMs build with 0 warnings.
- e2e against a live Jellyfin 12 container with a TMDB-backed fixture (Terminator/Predator/Conan/Expendables/Rocky/Rambo/Die Hard box sets): member matching on Actors, per-member AND dropping The Expendables for pre-1990, mixed [Movie, Collection] output, toggle-off name matching, Playlist container parity, playlist-form rejection with a clear 400, self-reference exclusion, and roll-up visible on a locked smart collection.

## Existing lists may change

- Mixed legacy lists (include-only groups alongside normal item groups): rule groups now apply to all selected media types uniformly — membership can change (documented in the changelog).
- Migrated lists using negative operators on the old include-only rule: legacy matched nothing for those operators; they now evaluate normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDJnQyHXcbGFUoGYXitjY3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Collection and Playlist media types for smart collections.
  * Added member-based or metadata-based container matching.
  * Smart collections now aggregate runtime, genres, studios, and ratings from members.
  * Added nested collection support, container-aware name matching, and duplicate-free results.

* **Bug Fixes**
  * Improved refresh handling and cache invalidation for collections and playlists.
  * Prevented self-references and invalid container selections in playlists.
  * Migrated legacy include-only collection and playlist rules safely.

* **Documentation**
  * Updated guides, examples, and migration notes for container matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->