### PR TITLE
feat: Group results into collections

### DIFF
--- a/Jellyfin.Plugin.SmartLists.Tests/Core/GroupIntoCollectionsTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/GroupIntoCollectionsTests.cs
@@ -1,0 +1,561 @@
+using Jellyfin.Plugin.SmartLists.Core;
+using Jellyfin.Plugin.SmartLists.Core.Models;
+using Jellyfin.Plugin.SmartLists.Core.QueryEngine;
+using Jellyfin.Plugin.SmartLists.Services.Shared;
+using Jellyfin.Plugin.SmartLists.Tests.Support;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
+using Expression = Jellyfin.Plugin.SmartLists.Core.QueryEngine.Expression;
+using MediaTypeConstants = Jellyfin.Plugin.SmartLists.Core.Constants.MediaTypes;
+using Movie = MediaBrowser.Controller.Entities.Movies.Movie;
+
+namespace Jellyfin.Plugin.SmartLists.Tests.Core;
+
+/// <summary>
+/// Covers <c>GroupIntoCollections</c> - the smart-collection toggle that replaces every matched item
+/// with the Jellyfin collections that DIRECTLY contain it, turning an item search into a search that
+/// produces collections.
+///
+/// The semantics pinned here, all of which depend on the step running at exactly one point in
+/// <c>FilterPlaylistItems</c> (after container matching / nested-collection appending / media-type
+/// expansion, before sorting and before BOTH limit kinds):
+///
+/// - Items in no collection, and results that are themselves containers, pass through unchanged.
+/// - Emitted collections are de-duplicated, so N matched members produce ONE entry.
+/// - Episodes and Seasons resolve through their series, which is what a TV collection actually holds.
+/// - Direct membership only: a grandparent collection is never emitted, even when the rule that
+///   matched the item deliberately used a deeper Collection search depth.
+/// - The list's own collection is never emitted, and an item whose only container is that collection
+///   stays itself rather than vanishing - or, for an episode/season, falls through to its series.
+/// - An emitted collection INHERITS its members' rule-group mappings and best similarity score, so
+///   Rule Block Order places it in its members' block and per-block MaxItems keeps it alive.
+/// - Because grouping precedes both limiters, a grouped entry is what MaxItems counts.
+///
+/// HARNESS NOTE: membership is inverted out of <c>RefreshCache.AllCollections</c> +
+/// <c>CollectionDirectChildren</c>, and <see cref="SeedCollection"/> always seeds BOTH. That is
+/// mandatory, not tidiness: <see cref="TestLibraryManager"/> throws <see cref="NotSupportedException"/>
+/// for unstubbed <c>GetItemsResult</c>, and <c>BuildDirectCollectionMembershipIndex</c> swallows the
+/// throw and returns an EMPTY index - grouping would then silently no-op against a dead fixture.
+/// Rules are cheap (Genres) except where a Collections/SimilarTo rule is the point of the test, and
+/// container children are never resolved by reflection because the cache answers first.
+/// </summary>
+public class GroupIntoCollectionsTests
+{
+    // ---------------------------------------------------------------------------------------
+    // Fixture builders
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>A BoxSet - what Jellyfin calls a collection. Name before SortName, as ever.</summary>
+    private static BoxSet CollectionNamed(string name, params string[] genres)
+    {
+        var boxSet = new BoxSet { Id = Guid.NewGuid(), Name = name, Genres = genres };
+        boxSet.SortName = name;
+        return boxSet;
+    }
+
+    /// <summary>
+    /// A collection this plugin generates, identified the way <see cref="ListOrigin"/> identifies
+    /// one: by the SmartLists provider-ID tether written at creation. Grouping must skip these.
+    /// </summary>
+    private static BoxSet SmartCollectionNamed(string name, string listKey)
+    {
+        var boxSet = CollectionNamed(name);
+        boxSet.ProviderIds = new Dictionary<string, string> { ["SmartLists"] = listKey };
+        return boxSet;
+    }
+
+    private static Movie MovieNamed(string name, params string[] genres)
+    {
+        var movie = new Movie { Id = Guid.NewGuid(), Name = name, Genres = genres };
+        movie.SortName = name;
+        return movie;
+    }
+
+    /// <summary>
+    /// An Episode tethered to a registered <see cref="Series"/> via <c>SeriesId</c> - the link the
+    /// grouping fallback follows, since a TV collection holds the Series and never the episodes.
+    /// </summary>
+    private static Episode EpisodeOf(Series series, string name, params string[] genres)
+    {
+        var episode = new Episode
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            SeriesName = series.Name,
+            SeriesId = series.Id,
+            Genres = genres,
+        };
+        episode.SortName = name;
+        return episode;
+    }
+
+    /// <summary>
+    /// A Season tethered to a registered <see cref="Series"/> via <c>SeriesId</c> - the same link the
+    /// Episode fallback follows, and the other arm of the grouping switch.
+    /// </summary>
+    private static Season SeasonOf(Series series, string name, params string[] genres)
+    {
+        var season = new Season
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            SeriesName = series.Name,
+            SeriesId = series.Id,
+            Genres = genres,
+        };
+        season.SortName = name;
+        return season;
+    }
+
+    /// <summary>
+    /// Registers a collection AND its direct children. Both halves are required - see the harness
+    /// note on the class: seeding only the children leaves <c>AllCollections</c> null, which sends
+    /// the index builder to the throwing library manager and silently disables grouping.
+    /// </summary>
+    private static void SeedCollection(RefreshQueueService.RefreshCache cache, BoxSet boxSet, params BaseItem[] directChildren)
+    {
+        cache.AllCollections = [.. cache.AllCollections ?? [], boxSet];
+        cache.CollectionDirectChildren[boxSet.Id] = directChildren;
+    }
+
+    private static ExpressionSet GenreBlock(string genre, int? maxItems = null)
+        => new() { Expressions = [new Expression("Genres", "Contains", genre)], MaxItems = maxItems };
+
+    /// <summary>A smart COLLECTION with the grouping toggle on (the only list kind that accepts it).</summary>
+    private static SmartList MakeList(
+        List<string> mediaTypes,
+        List<ExpressionSet> expressionSets,
+        bool groupIntoCollections = true,
+        bool matchByMembers = false,
+        string? orderName = null,
+        int? maxItems = null,
+        string? jellyfinCollectionId = null)
+    {
+        var dto = new SmartCollectionDto
+        {
+            Id = Guid.NewGuid().ToString(),
+            Name = "Grouping Test List",
+            MediaTypes = mediaTypes,
+            MatchByMembers = matchByMembers,
+            GroupIntoCollections = groupIntoCollections,
+            MaxItems = maxItems,
+            JellyfinCollectionId = jellyfinCollectionId,
+            ExpressionSets = expressionSets,
+            Order = orderName == null ? null : new OrderDto { Name = orderName },
+        };
+
+        return new SmartList(dto);
+    }
+
+    private static Guid[] Filter(SmartList list, RefreshQueueService.RefreshCache cache, params BaseItem[] pool)
+        => [.. list.FilterPlaylistItems(pool, BaseItem.LibraryManager, TestItems.User, cache)];
+
+    // ---------------------------------------------------------------------------------------
+    // The projection itself
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void ReplacesMatchedItemsWithTheirCollections()
+    {
+        // The whole feature in one assertion: the movie matched, but the COLLECTION is the result.
+        var movie = MovieNamed("Predator", "Action");
+        var box = CollectionNamed("Arnold Movies");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedCollection(cache, box, movie);
+
+        var list = MakeList([MediaTypeConstants.Movie], [GenreBlock("Action")]);
+
+        Assert.Equal([box.Id], Filter(list, cache, movie));
+    }
+
+    [Fact]
+    public void DedupesItemsSharingACollection()
+    {
+        // Ten matched Marvel movies must produce ONE Marvel collection, not ten copies of it -
+        // the emitted-id set is what makes the result a collection list rather than a multiset.
+        var predator = MovieNamed("Predator", "Action");
+        var commando = MovieNamed("Commando", "Action");
+        var box = CollectionNamed("Arnold Movies");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedCollection(cache, box, predator, commando);
+
+        var list = MakeList([MediaTypeConstants.Movie], [GenreBlock("Action")]);
+
+        Assert.Equal([box.Id], Filter(list, cache, predator, commando));
+    }
+
+    [Fact]
+    public void ItemsInNoCollectionPassThrough()
+    {
+        // Grouping is a projection, not a filter: an item nobody collected is NOT dropped, it stays
+        // itself. Asserting both halves in one run also proves the fixture is live - a dead
+        // membership index would leave the collected movie as itself too, and the boxed id absent.
+        var uncollected = MovieNamed("Lone Ranger", "Action");
+        var collected = MovieNamed("Predator", "Action");
+        var box = CollectionNamed("Zulu Box");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedCollection(cache, box, collected);
+
+        var list = MakeList([MediaTypeConstants.Movie], [GenreBlock("Action")]);
+
+        var result = Filter(list, cache, uncollected, collected);
+
+        // Default sort is Name ascending: "Lone Ranger" before "Zulu Box".
+        Assert.Equal([uncollected.Id, box.Id], result);
+        Assert.DoesNotContain(collected.Id, result);
+    }
+
+    [Fact]
+    public void ContainerResultsPassThroughUnchanged()
+    {
+        // A result that is ALREADY a collection (matched on its own metadata via the Collection
+        // media type) must not be collapsed into the collection that contains IT. Without the
+        // container guard the box would be replaced by its own parent box, so asserting the parent
+        // is absent is what makes this discriminating.
+        var taggedBox = CollectionNamed("Curated Action", "Action");
+        var parentBox = CollectionNamed("Everything Box");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedCollection(cache, taggedBox);               // no members of its own
+        SeedCollection(cache, parentBox, taggedBox);    // ...but it IS a member of another collection
+
+        var list = MakeList([MediaTypeConstants.Movie, MediaTypeConstants.Collection], [GenreBlock("Action")]);
+
+        Assert.Equal([taggedBox.Id], Filter(list, cache, taggedBox));
+    }
+
+    [Fact]
+    public void EpisodesGroupIntoTheirSeriesCollection()
+    {
+        // Grouping runs AFTER media-type expansion, so an Episodes list holds Episode items - and
+        // an episode is never a direct BoxSet member, its SERIES is. Without the series fallback
+        // this feature would silently do nothing for every TV library.
+        //
+        // The second episode's series is in no collection, so it pins that the fallback is a
+        // lookup and not a blanket "episodes always become something else".
+        var boxedShow = TestItems.Show("Breaking Bad");
+        var loneShow = TestItems.Show("Firefly");
+        var boxedEpisode = EpisodeOf(boxedShow, "Breaking Bad S01E01", "Drama");
+        var loneEpisode = EpisodeOf(loneShow, "Firefly S01E01", "Drama");
+        var box = CollectionNamed("Award Winners");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedCollection(cache, box, boxedShow);
+
+        var list = MakeList([MediaTypeConstants.Episode], [GenreBlock("Drama")]);
+
+        var result = Filter(list, cache, boxedEpisode, loneEpisode);
+
+        // Name ascending: "Award Winners" before "Firefly S01E01".
+        Assert.Equal([box.Id, loneEpisode.Id], result);
+        Assert.DoesNotContain(boxedEpisode.Id, result);
+    }
+
+    [Fact]
+    public void SeasonsGroupIntoTheirSeriesCollection()
+    {
+        // Season is a collection-only media type in its own right, and a season is no more a direct
+        // BoxSet member than an episode is - the collection holds the Series. The Episode test above
+        // does not cover this: the two arms of the SeriesId switch are separate, and deleting the
+        // Season arm leaves every other test in the suite green.
+        var boxedShow = TestItems.Show("Breaking Bad");
+        var loneShow = TestItems.Show("Firefly");
+        var boxedSeason = SeasonOf(boxedShow, "Breaking Bad Season 1", "Drama");
+        var loneSeason = SeasonOf(loneShow, "Firefly Season 1", "Drama");
+        var box = CollectionNamed("Award Winners");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedCollection(cache, box, boxedShow);
+
+        var list = MakeList([MediaTypeConstants.Season], [GenreBlock("Drama")]);
+
+        var result = Filter(list, cache, boxedSeason, loneSeason);
+
+        // Name ascending: "Award Winners" before "Firefly Season 1".
+        Assert.Equal([box.Id, loneSeason.Id], result);
+        Assert.DoesNotContain(boxedSeason.Id, result);
+    }
+
+    [Fact]
+    public void IgnoresCollectionSearchDepth()
+    {
+        // Direct membership only. The rule deliberately needs depth 2 to match at all - the movie
+        // is a direct member of "Trilogy", and only the nested walk lets it see "Franchise" - so
+        // the depth setting is provably live for MATCHING while grouping still emits nothing but
+        // the direct parent. A grouping step that reused the depth walk would emit both boxes.
+        var movie = MovieNamed("Predator", "Action");
+        var inner = CollectionNamed("Trilogy");
+        var outer = CollectionNamed("Franchise");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedCollection(cache, inner, movie);
+        SeedCollection(cache, outer, inner);
+
+        var list = MakeList(
+            [MediaTypeConstants.Movie],
+            [
+                new ExpressionSet
+                {
+                    Expressions = [new Expression("Collections", "Contains", "Franchise") { CollectionSearchDepth = 2 }],
+                },
+            ]);
+
+        Assert.Equal([inner.Id], Filter(list, cache, movie));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Self-reference guard (#499)
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void NeverEmitsTheListsOwnCollection()
+    {
+        // Two things at once, and the second is the one that is easy to get wrong:
+        // - a matched item that also sits in an unrelated collection emits THAT collection only;
+        // - a matched item whose ONLY container is the list being built stays ITSELF rather than
+        //   disappearing, because "replaced" is only set when a parent actually got emitted.
+        var self = CollectionNamed("Action Collection [Smart]");
+        var other = CollectionNamed("Manually Curated Action");
+        var onlyInSelf = MovieNamed("Commando", "Action");
+        var alsoElsewhere = MovieNamed("Predator", "Action");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedCollection(cache, self, onlyInSelf, alsoElsewhere);
+        SeedCollection(cache, other, alsoElsewhere);
+
+        var list = MakeList(
+            [MediaTypeConstants.Movie],
+            [GenreBlock("Action")],
+            jellyfinCollectionId: self.Id.ToString());
+
+        var result = Filter(list, cache, onlyInSelf, alsoElsewhere);
+
+        Assert.Equal([onlyInSelf.Id, other.Id], result);
+        Assert.DoesNotContain(self.Id, result);
+    }
+
+    [Fact]
+    public void NeverEmitsAnotherSmartCollection()
+    {
+        // Not just this list's own collection - ANY plugin-generated one. A smart collection is
+        // rebuilt on every refresh, so grouping into one makes the result depend on refresh order,
+        // and in a library with a few smart lists it buries the real collections in unrelated ones
+        // that merely happen to hold a matched item. Verified against the dev library, where an
+        // Arnold search returned 4 real collections and 3 unrelated smart ones.
+        var curated = CollectionNamed("Predator Collection");
+        var otherSmart = SmartCollectionNamed("Unrelated Test List [Smart]", "some-other-list-id");
+        var inBoth = MovieNamed("Predator", "Action");
+        var onlyInSmart = MovieNamed("Commando", "Action");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedCollection(cache, curated, inBoth);
+        SeedCollection(cache, otherSmart, inBoth, onlyInSmart);
+
+        var list = MakeList([MediaTypeConstants.Movie], [GenreBlock("Action")]);
+
+        var result = Filter(list, cache, inBoth, onlyInSmart);
+
+        // The curated collection replaces its member; the movie only the smart list holds stays
+        // itself rather than collapsing into that smart list.
+        Assert.Equal(2, result.Length);
+        Assert.Contains(curated.Id, result);
+        Assert.Contains(onlyInSmart.Id, result);
+        Assert.DoesNotContain(otherSmart.Id, result);
+    }
+
+    [Fact]
+    public void OwnCollectionDoesNotShadowTheSeriesFallback()
+    {
+        // The second-refresh case, and the reason the self-reference guard has to run BEFORE the
+        // series fallback rather than after it. Refresh #1 found no collection for the episode and
+        // wrote it into the list's own collection - so on refresh #2 the episode DOES have a direct
+        // parent: this very list. Treating that as a hit would stop the fallback from ever running,
+        // and the list would re-emit its own members forever, never picking up the show's new box.
+        var self = CollectionNamed("Best Drama TV [Smart]");
+        var awardWinners = CollectionNamed("Award Winners");
+        var show = TestItems.Show("Breaking Bad");
+        var episode = EpisodeOf(show, "Breaking Bad S01E01", "Drama");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedCollection(cache, self, episode);          // written by the previous refresh
+        SeedCollection(cache, awardWinners, show);     // the collection the user added afterwards
+
+        var list = MakeList(
+            [MediaTypeConstants.Episode],
+            [GenreBlock("Drama")],
+            jellyfinCollectionId: self.Id.ToString());
+
+        var result = Filter(list, cache, episode);
+
+        Assert.Equal([awardWinners.Id], result);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Inheritance - the emitted collection stands in for its members
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void RuleBlockOrder_CollectionInheritsMemberGroups()
+    {
+        // Rule Block Order sorts by matched block index and puts UNMAPPED items LAST. The grouped
+        // collection's contributing item matches block 0 while the ungrouped item matches block 1,
+        // so a collection that failed to inherit its member's mapping would sort second instead of
+        // first - the assertion flips, rather than merely losing an item.
+        var actionMovie = MovieNamed("Predator", "Action");
+        var dramaMovie = MovieNamed("The Notebook", "Drama");
+        var box = CollectionNamed("Drama Box");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedCollection(cache, box, dramaMovie);
+
+        var list = MakeList(
+            [MediaTypeConstants.Movie],
+            [GenreBlock("Drama"), GenreBlock("Action")],
+            orderName: "Rule Block Order Ascending");
+
+        Assert.Equal([box.Id, actionMovie.Id], Filter(list, cache, actionMovie, dramaMovie));
+    }
+
+    [Fact]
+    public void PerGroupLimits_CollectionSurvivesInItsMembersGroup()
+    {
+        // ApplyPerGroupLimits rebuilds its result from the group mappings alone and silently DROPS
+        // anything unmapped, so this is the strongest indirect proof that the emitted collection
+        // really inherited its member's block. Landing in block 0 instead would also kill it: that
+        // block's single slot goes to "Alpha Action" on the Name sort.
+        var alpha = MovieNamed("Alpha Action", "Action");
+        var beta = MovieNamed("Beta Action", "Action");
+        var dramaMovie = MovieNamed("Drama Movie", "Drama");
+        var boxedDrama = MovieNamed("The Notebook", "Drama");
+        var box = CollectionNamed("Zebra Box");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedCollection(cache, box, boxedDrama);
+
+        var list = MakeList(
+            [MediaTypeConstants.Movie],
+            [GenreBlock("Action", maxItems: 1), GenreBlock("Drama")]);
+
+        var result = Filter(list, cache, alpha, beta, dramaMovie, boxedDrama);
+
+        Assert.Equal(3, result.Length);
+        Assert.Contains(alpha.Id, result);       // block 0's single slot
+        Assert.Contains(dramaMovie.Id, result);
+        Assert.Contains(box.Id, result);         // the collection kept its block-1 slot
+        Assert.DoesNotContain(boxedDrama.Id, result);
+    }
+
+    [Fact]
+    public void SimilarTo_CollectionInheritsBestMemberScore()
+    {
+        // Similarity sorting looks scores up by RESULT id, and the result is now the collection.
+        // Its members score 4 (the reference itself) and 2; the ungrouped item scores 3. Taking the
+        // BEST member score puts the collection first, while taking the last-written score (2) or
+        // no score at all (0) sinks it behind the ungrouped item - so the order, not the contents,
+        // is what fails on a regression. The weak member is deliberately processed last.
+        var predator = MovieNamed("Predator", "Action", "Sci-Fi", "Thriller", "Horror");
+        var weakMember = MovieNamed("Twins", "Action", "Sci-Fi");
+        var midItem = MovieNamed("Aliens", "Action", "Sci-Fi", "Thriller");
+        var box = CollectionNamed("Arnold Movies");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedCollection(cache, box, predator, weakMember);
+
+        // SimilarTo with no explicit sort resolves to Similarity descending.
+        var list = MakeList(
+            [MediaTypeConstants.Movie],
+            [new ExpressionSet { Expressions = [new Expression("SimilarTo", "Equal", "Predator")] }]);
+
+        Assert.Equal([box.Id, midItem.Id], Filter(list, cache, predator, weakMember, midItem));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Position in the pipeline - grouping precedes the limiters
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void GroupedEntriesCountTowardMaxItems()
+    {
+        // Four matched movies, two of them sharing one collection, and MaxItems=2. Grouping first
+        // gives THREE pre-limit entries - the collection plus the two uncollected movies - so the
+        // collection occupies a slot on the Name sort and "Charlie Movie" is the one cut.
+        //
+        // Every wrong insertion point produces a visibly different answer:
+        // - limiter before grouping: the two uncollected movies take both slots and the collection
+        //   never appears at all, giving [Bravo, Charlie];
+        // - no limit applied: three entries instead of two.
+        var boxedFirst = MovieNamed("Mike Movie", "Action");
+        var boxedSecond = MovieNamed("November Movie", "Action");
+        var survivor = MovieNamed("Bravo Movie", "Action");
+        var cutByTheCollection = MovieNamed("Charlie Movie", "Action");
+        var box = CollectionNamed("Alpha Box");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedCollection(cache, box, boxedFirst, boxedSecond);
+
+        var list = MakeList([MediaTypeConstants.Movie], [GenreBlock("Action")], maxItems: 2);
+
+        var result = Filter(list, cache, boxedFirst, boxedSecond, survivor, cutByTheCollection);
+
+        Assert.Equal([box.Id, survivor.Id], result);
+        Assert.DoesNotContain(cutByTheCollection.Id, result);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Coexistence with MatchByMembers
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void CoexistsWithMatchByMembers()
+    {
+        // The two toggles work in opposite directions and must not interfere: MatchByMembers pulls
+        // container candidates out of the pool and admits them on a member match, then grouping
+        // projects the plain item results onto their parents. The member-matched container is
+        // emitted as ITSELF (it is a container result), while the plain movie is replaced.
+        var memberBox = CollectionNamed("Arnold Movies");
+        var boxedMovie = MovieNamed("Predator", "Action");     // member only - never in the pool
+        var plainMovie = MovieNamed("Commando", "Action");
+        var otherBox = CollectionNamed("Manually Curated");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedCollection(cache, memberBox, boxedMovie);
+        SeedCollection(cache, otherBox, plainMovie);
+
+        var list = MakeList(
+            [MediaTypeConstants.Movie, MediaTypeConstants.Collection],
+            [GenreBlock("Action")],
+            matchByMembers: true);
+
+        var result = Filter(list, cache, plainMovie, memberBox);
+
+        Assert.Equal(2, result.Length);
+        Assert.Contains(memberBox.Id, result);
+        Assert.Contains(otherBox.Id, result);
+        Assert.DoesNotContain(plainMovie.Id, result);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // The toggle is a toggle
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void ToggleOff_LeavesMatchedItemsAlone()
+    {
+        // The control case for every assertion above: identical fixture, flag off, items unchanged.
+        // Without this, a grouping step that silently no-opped (empty membership index, wrong
+        // insertion point) would look the same as one that was never asked to run.
+        var movie = MovieNamed("Predator", "Action");
+        var box = CollectionNamed("Arnold Movies");
+
+        var cache = new RefreshQueueService.RefreshCache();
+        SeedCollection(cache, box, movie);
+
+        var list = MakeList([MediaTypeConstants.Movie], [GenreBlock("Action")], groupIntoCollections: false);
+
+        Assert.Equal([movie.Id], Filter(list, cache, movie));
+    }
+}

--- a/Jellyfin.Plugin.SmartLists.Tests/Services/Shared/SmartListFileSystemMigrationTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Services/Shared/SmartListFileSystemMigrationTests.cs
@@ -3,6 +3,7 @@ using Jellyfin.Plugin.SmartLists.Core;
 using Jellyfin.Plugin.SmartLists.Core.Models;
 using Jellyfin.Plugin.SmartLists.Core.QueryEngine;
 using Jellyfin.Plugin.SmartLists.Services.Shared;
+using Jellyfin.Plugin.SmartLists.Utilities;
 using MediaTypeConstants = Jellyfin.Plugin.SmartLists.Core.Constants.MediaTypes;
 
 namespace Jellyfin.Plugin.SmartLists.Tests.Services.Shared;
@@ -79,6 +80,29 @@ public class SmartListFileSystemMigrationTests
 
         // Toggle stays off: migrated lists keep matching containers by their own metadata
         Assert.False(dto.MatchByMembers);
+    }
+
+    [Fact]
+    public void LegacyCollectionJson_LoadsWithGroupIntoCollectionsOff()
+    {
+        // Goes through the real load path (Deserialize -> ApplyPostProcessing) rather than building
+        // the DTO in C#, because the risk is on the JSON side: legacy files predate the
+        // GroupIntoCollections key entirely, and anything that made it load true would silently turn
+        // every existing smart collection into a collection-of-collections on first start.
+        const string LegacyJson = """
+            {
+              "Name": "Legacy",
+              "MediaTypes": ["Movie"],
+              "ExpressionSets": [
+                { "Expressions": [ { "MemberName": "Genres", "Operator": "Contains", "TargetValue": "Action" } ] }
+              ]
+            }
+            """;
+
+        var dto = JsonSerializer.Deserialize<SmartCollectionDto>(LegacyJson, SmartListFileSystem.SharedJsonOptions)!;
+        SmartListFileSystem.ApplyPostProcessing(dto);
+
+        Assert.False(dto.GroupIntoCollections);
     }
 
     [Fact]
@@ -272,6 +296,63 @@ public class SmartListFileSystemMigrationTests
         SmartListFileSystem.ApplyPostProcessing(dto);
 
         Assert.Equal([MediaTypeConstants.Movie], dto.MediaTypes);
+    }
+
+    [Fact]
+    public void PlaylistWithGroupIntoCollections_HasTheFlagCleared()
+    {
+        // Same shape as the container-media-type sanitizer above: the flag lives on the shared base
+        // DTO, so hand-edited (or converted) playlist JSON can carry it. Left set, the list would
+        // fail validation on every save; cleared at load, it just saves as a normal playlist.
+        var dto = new SmartPlaylistDto
+        {
+            Name = "Hand-edited",
+            MediaTypes = [MediaTypeConstants.Movie],
+            GroupIntoCollections = true,
+            ExpressionSets = [Group(new Expression("Genres", "Contains", "Action"))],
+        };
+
+        SmartListFileSystem.ApplyPostProcessing(dto);
+
+        Assert.False(dto.GroupIntoCollections);
+    }
+
+    [Fact]
+    public void CollectionWithMaxPlayTime_HasTheLimitCleared()
+    {
+        // Max Playtime is playlist-only and its input is hidden for collections - but the config
+        // page seeded the server-wide Default Max Playtime into every new list regardless of type
+        // and sent it, so collections created by an admin with a non-zero default are silently
+        // truncated by a limit their form never showed. Clearing it at load repairs those lists.
+        var dto = new SmartCollectionDto
+        {
+            Name = "Truncated By A Hidden Limit",
+            MediaTypes = [MediaTypeConstants.Movie],
+            MaxPlayTimeMinutes = 120,
+            ExpressionSets = [Group(new Expression("Genres", "Contains", "Action"))],
+        };
+
+        SmartListFileSystem.ApplyPostProcessing(dto);
+
+        Assert.Null(dto.MaxPlayTimeMinutes);
+    }
+
+    [Fact]
+    public void ConvertingAPlaylistToACollection_DropsMaxPlayTime()
+    {
+        // The other half of the same leak: Convert to Collection would otherwise carry the
+        // playlist's Max Playtime onto a list whose form has no way to see or clear it.
+        var playlist = new SmartPlaylistDto
+        {
+            Name = "Two Hours Of Action",
+            MediaTypes = [MediaTypeConstants.Movie],
+            MaxPlayTimeMinutes = 120,
+            ExpressionSets = [Group(new Expression("Genres", "Contains", "Action"))],
+        };
+
+        var collection = DtoMapper.ToCollectionDto(playlist);
+
+        Assert.Null(collection.MaxPlayTimeMinutes);
     }
 
     // ---------------------------------------------------------------------------------

--- a/Jellyfin.Plugin.SmartLists.Tests/Utilities/InputValidatorTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Utilities/InputValidatorTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Jellyfin.Plugin.SmartLists.Core.Constants;
+using Jellyfin.Plugin.SmartLists.Core.Enums;
 using Jellyfin.Plugin.SmartLists.Core.Models;
 using Jellyfin.Plugin.SmartLists.Core.QueryEngine;
 using Jellyfin.Plugin.SmartLists.Utilities;
@@ -728,6 +729,22 @@ public class InputValidatorTests
     [Theory]
     [InlineData(MediaTypeConstants.Collection)]
     [InlineData(MediaTypeConstants.Playlist)]
+    public void ValidateSmartList_ContainerMediaTypeOnCollectionBoundAsPlaylistDto_IsAccepted(string mediaType)
+    {
+        // The user page binds EVERY create body as a SmartPlaylistDto and only converts to a
+        // collection DTO after validation has run, so the CLR type says "playlist" for a list the
+        // user is creating as a collection. Gating on the Type discriminator is what keeps this
+        // legal; a `list is SmartPlaylistDto` check rejects it with the playlist error instead.
+        var dto = ValidPlaylist();
+        dto.Type = SmartListType.Collection;
+        dto.MediaTypes = [MediaTypeConstants.Movie, mediaType];
+
+        Assert.True(InputValidator.ValidateSmartList(dto).IsValid);
+    }
+
+    [Theory]
+    [InlineData(MediaTypeConstants.Collection)]
+    [InlineData(MediaTypeConstants.Playlist)]
     public void ValidateSmartList_ContainerMediaTypeOnCollection_IsAccepted(string mediaType)
     {
         var dto = new SmartCollectionDto
@@ -736,6 +753,52 @@ public class InputValidatorTests
             MediaTypes = [mediaType],
             ExpressionSets = [Group(Rule())],
         };
+
+        AssertValid(InputValidator.ValidateSmartList(dto));
+    }
+
+    [Fact]
+    public void ValidateSmartList_GroupIntoCollectionsOnPlaylist_IsRejected()
+    {
+        // Grouping emits BoxSets, and PlaylistService dereferences its media lookup unguarded, so
+        // a BoxSet id reaching the playlist write path throws. Unlike the container media types
+        // there is no natural gate on the flag - this rule IS the gate.
+        var dto = ValidPlaylist();
+        dto.GroupIntoCollections = true;
+
+        AssertInvalid(
+            InputValidator.ValidateSmartList(dto),
+            "Group results into collections is not supported for playlists");
+    }
+
+    [Fact]
+    public void ValidateSmartList_GroupIntoCollectionsOnCollection_IsAccepted()
+    {
+        // The mirror case, and the reason the rejection has to test the list type rather than the
+        // flag: the identical flag is the whole point of the feature on a smart collection. No
+        // container media type is required for it, either.
+        var dto = new SmartCollectionDto
+        {
+            Name = "Valid List",
+            MediaTypes = [MediaTypeConstants.Movie],
+            GroupIntoCollections = true,
+            ExpressionSets = [Group(Rule())],
+        };
+
+        AssertValid(InputValidator.ValidateSmartList(dto));
+    }
+
+    [Fact]
+    public void ValidateSmartList_GroupIntoCollectionsOnCollectionBoundAsPlaylistDto_IsAccepted()
+    {
+        // The shape the user page actually posts: UserSmartListController.CreateUserSmartList binds
+        // EVERY create body as a SmartPlaylistDto and only calls DtoMapper.ToCollectionDto after
+        // validation has run. Keying the rejection off the CLR type instead of Type would therefore
+        // make a grouped collection impossible to create from the user page - it could only be added
+        // by editing an existing collection, which binds the abstract DTO and converts up front.
+        var dto = ValidPlaylist();
+        dto.Type = SmartListType.Collection;
+        dto.GroupIntoCollections = true;
 
         AssertValid(InputValidator.ValidateSmartList(dto));
     }

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
@@ -472,6 +472,7 @@
         SmartLists.setElementChecked(page, '#playlistIsPublic', config.DefaultMakePublic || false);
         SmartLists.setElementChecked(page, '#playlistIncludeExtras', false);
         SmartLists.setElementChecked(page, '#matchByMembers', false);
+        SmartLists.setElementChecked(page, '#groupIntoCollections', false);
         // Cache the resolved default so template application can read it even
         // after the checkbox has been toggled (e.g. by a previous template)
         page._defaultHideWhenEmpty = SmartLists.getDefaultHideWhenEmpty(config);
@@ -531,6 +532,7 @@
         SmartLists.setElementChecked(page, '#playlistIsPublic', false);
         SmartLists.setElementChecked(page, '#playlistIncludeExtras', false);
         SmartLists.setElementChecked(page, '#matchByMembers', false);
+        SmartLists.setElementChecked(page, '#groupIntoCollections', false);
         page._defaultHideWhenEmpty = SmartLists.getDefaultHideWhenEmpty(null);
         SmartLists.setElementChecked(page, '#playlistHideWhenEmpty', page._defaultHideWhenEmpty);
         SmartLists.setElementChecked(page, '#playlistIsEnabled', true);

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -349,6 +349,8 @@
             // reset whenever the toggle is hidden, so reading it directly is safe
             const matchByMembers = SmartLists.getElementChecked(page, '#matchByMembers', false);
             const hideWhenEmpty = SmartLists.getElementChecked(page, '#playlistHideWhenEmpty', false);
+            // Collection-only: the flag is never sent for a playlist regardless of UI state
+            const groupIntoCollections = isCollection && SmartLists.getElementChecked(page, '#groupIntoCollections', false);
             const isEnabled = SmartLists.getElementChecked(page, '#playlistIsEnabled', true); // Default to true
             const autoRefreshMode = SmartLists.getElementValue(page, '#autoRefreshMode', 'Never');
 
@@ -369,10 +371,13 @@
                 maxItems = (isNaN(parsedValue) || parsedValue < 0) ? 0 : parsedValue;
             }
 
-            // Handle maxPlayTimeMinutes with helper function
+            // Handle maxPlayTimeMinutes with helper function. Playlist-only: the input is hidden
+            // for collections, so never send whatever it happens to hold (the server-wide default
+            // is seeded into it regardless of list type) - a collection would be silently
+            // truncated by a limit its form never showed.
             const maxPlayTimeMinutesInput = SmartLists.getElementValue(page, '#playlistMaxPlayTimeMinutes');
             let maxPlayTimeMinutes;
-            if (maxPlayTimeMinutesInput === '') {
+            if (isCollection || maxPlayTimeMinutesInput === '') {
                 maxPlayTimeMinutes = 0;
             } else {
                 const parsedValue = parseInt(maxPlayTimeMinutesInput, 10);
@@ -445,6 +450,7 @@
                 Enabled: isEnabled,
                 IncludeExtras: includeExtras,
                 MatchByMembers: matchByMembers,
+                GroupIntoCollections: groupIntoCollections,
                 HideWhenEmpty: hideWhenEmpty,
                 MediaTypes: selectedMediaTypes,
                 MaxItems: maxItems,
@@ -748,6 +754,9 @@
         if (playlist.HideWhenEmpty) {
             chips.push('Hide when empty');
         }
+        if (playlist.GroupIntoCollections) {
+            chips.push('Group into collections');
+        }
         if (playlist.SortTitle || playlist.Overview || playlist.Favorite === true || playlist.Favorite === false ||
             (playlist.Tags && playlist.Tags.length > 0)) {
             chips.push('Metadata');
@@ -982,6 +991,7 @@
         SmartLists.setElementChecked(page, '#playlistIsEnabled', playlist.Enabled !== false); // Default to true for backward compatibility
         SmartLists.setElementChecked(page, '#playlistIncludeExtras', playlist.IncludeExtras || false);
         SmartLists.setElementChecked(page, '#matchByMembers', playlist.MatchByMembers || false);
+        SmartLists.setElementChecked(page, '#groupIntoCollections', playlist.GroupIntoCollections || false);
         SmartLists.setElementChecked(page, '#playlistHideWhenEmpty', playlist.HideWhenEmpty || false);
 
         // Handle AutoRefresh with backward compatibility
@@ -2068,6 +2078,13 @@
             (playlist.HideWhenEmpty ?
                 '<tr style="border-bottom: 1px solid var(--jf-palette-divider);">' +
                 '<td style="padding: 0.5em 0.75em; font-weight: bold; opacity: 0.8; width: 40%; border-right: 1px solid var(--jf-palette-divider);">Hide When Empty</td>' +
+                '<td style="padding: 0.5em 0.75em; ">Yes</td>' +
+                '</tr>' :
+                ''
+            ) +
+            (playlist.GroupIntoCollections ?
+                '<tr style="border-bottom: 1px solid var(--jf-palette-divider);">' +
+                '<td style="padding: 0.5em 0.75em; font-weight: bold; opacity: 0.8; width: 40%; border-right: 1px solid var(--jf-palette-divider);">Group Into Collections</td>' +
                 '<td style="padding: 0.5em 0.75em; ">Yes</td>' +
                 '</tr>' :
                 ''

--- a/Jellyfin.Plugin.SmartLists/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config.html
@@ -465,6 +465,29 @@
                             </label>
                             <div class="fieldDescription">Don't create the playlist or collection while it has no matching items. If a refresh finds no items, the existing Jellyfin playlist/collection is removed and recreated automatically once items match again.</div>
                         </div>
+                        <div id="groupIntoCollectionsContainer" class="checkboxList paperList collection-only-field"
+                            style="padding: 0.5em 1em; margin-bottom: 1em; margin-top: 0.5em;">
+                            <label class="emby-checkbox-label">
+                                <input type="checkbox" is="emby-checkbox" id="groupIntoCollections"
+                                    data-embycheckbox="true" class="emby-checkbox">
+                                <span class="checkboxLabel">
+                                    Group results into collections
+                                    <a href="https://jellyfin-smartlists-plugin.dinsten.se/user-guide/media-types/#group-into-collections"
+                                        target="_blank" rel="noopener noreferrer" title="Documentation"
+                                        style="margin-left: 0.5em; text-decoration: none; color: inherit; display: inline-flex; align-items: center;">
+                                        <span class="material-icons" aria-hidden="true"
+                                            style="font-size: 1.1em; line-height: 0;">info_outline</span>
+                                    </a>
+                                </span>
+                                <span class="checkboxOutline">
+                                    <span class="material-icons checkboxIcon checkboxIcon-checked check"
+                                        aria-hidden="true"></span>
+                                    <span class="material-icons checkboxIcon checkboxIcon-unchecked"
+                                        aria-hidden="true"></span>
+                                </span>
+                            </label>
+                            <div class="fieldDescription">Every matched item that sits in a Jellyfin collection is replaced by that collection, so the result is a collection of collections. Items that aren't in any collection are kept as-is. Only direct membership counts &mdash; nested collections are not traversed. Grouping happens before sorting and before Max Items, so the limit counts collections, not the items inside them.</div>
+                        </div>
                         <div class="inputContainer" style="margin-bottom: 1em;">
                             <label class="inputLabel" style="display: flex; align-items: center;">
                                 Custom Images

--- a/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
@@ -402,6 +402,33 @@
                             </label>
                             <div class="fieldDescription">Don't create the playlist or collection while it has no matching items. If a refresh finds no items, the existing Jellyfin playlist/collection is removed and recreated automatically once items match again.</div>
                         </div>
+                        <div id="groupIntoCollectionsContainer" class="checkboxList paperList collection-only-field"
+                            style="padding: 0.5em 1em; margin-bottom: 1em; margin-top: 0.5em;">
+                            <label class="emby-checkbox-label">
+                                <input type="checkbox" is="emby-checkbox" id="groupIntoCollections"
+                                    data-embycheckbox="true" class="emby-checkbox">
+                                <span class="checkboxLabel">
+                                    Group results into collections
+                                    <a href="https://jellyfin-smartlists-plugin.dinsten.se/user-guide/media-types/#group-into-collections"
+                                        target="_blank" rel="noopener noreferrer" title="Documentation"
+                                        style="margin-left: 0.5em; text-decoration: none; color: inherit; display: inline-flex; align-items: center;">
+                                        <span class="material-icons" aria-hidden="true"
+                                            style="font-size: 1.1em; line-height: 0;">info_outline</span>
+                                    </a>
+                                </span>
+                                <span class="checkboxOutline">
+                                    <span class="material-icons checkboxIcon checkboxIcon-checked check"
+                                        aria-hidden="true"></span>
+                                    <span class="material-icons checkboxIcon checkboxIcon-unchecked"
+                                        aria-hidden="true"></span>
+                                </span>
+                            </label>
+                            <div class="fieldDescription">Every matched item that sits in a Jellyfin collection is replaced by
+                                that collection, so the result is a collection of collections. Items that aren't in any
+                                collection are kept as-is. Only direct membership counts &mdash; nested collections are
+                                not traversed. Grouping happens before sorting and before Max Items, so the limit counts
+                                collections, not the items inside them.</div>
+                        </div>
                         <div class="inputContainer" style="margin-bottom: 1em;">
                             <label class="inputLabel" style="display: flex; align-items: center;">
                                 Custom Images
@@ -596,6 +623,8 @@
                         // User can only create playlists - hide the selector and set to Playlist
                         listTypeContainer.style.display = 'none';
                         listTypeSelect.value = 'Playlist';
+                        // Setting .value doesn't fire change, so collection-only fields would stay visible
+                        listTypeSelect.dispatchEvent(new Event('change', { bubbles: true }));
                     }
                 } catch (error) {
                     console.error('Error loading user capabilities:', error);
@@ -603,7 +632,11 @@
                     const listTypeContainer = document.getElementById('listTypeContainer');
                     const listTypeSelect = document.getElementById('listType');
                     if (listTypeContainer) listTypeContainer.style.display = 'none';
-                    if (listTypeSelect) listTypeSelect.value = 'Playlist';
+                    if (listTypeSelect) {
+                        listTypeSelect.value = 'Playlist';
+                        // Setting .value doesn't fire change, so collection-only fields would stay visible
+                        listTypeSelect.dispatchEvent(new Event('change', { bubbles: true }));
+                    }
                 }
             };
         </script>

--- a/Jellyfin.Plugin.SmartLists/Core/Models/SmartListDto.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Models/SmartListDto.cs
@@ -84,6 +84,15 @@ namespace Jellyfin.Plugin.SmartLists.Core.Models
         public bool MatchByMembers { get; set; } = false;
 
         /// <summary>
+        /// Collections only. When true, every matched item that is a direct member of one or more
+        /// Jellyfin collections is replaced by those collections. Items in no collection - and results
+        /// that are themselves collections/playlists - pass through unchanged. Grouping runs before
+        /// sorting and before both limit kinds, so grouped entries are what MaxItems counts.
+        /// Direct membership only: the Collection search depth setting is not used.
+        /// </summary>
+        public bool GroupIntoCollections { get; set; } = false;
+
+        /// <summary>
         /// When true, the Jellyfin playlist/collection is not created (and an existing one is
         /// removed) while the list's rules match zero items. It is recreated automatically
         /// once items match again. The smart list configuration itself is never deleted.

--- a/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/SmartList.cs
@@ -35,6 +35,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
         public List<string>? MediaTypes { get; set; }
         public int CollectionSearchDepth { get; set; }  // Depth for traversing nested collections/playlists (0 = no recursion, 1-10 = levels)
         public bool MatchByMembers { get; set; }  // Container candidates (Collection/Playlist media types) match when at least one member item passes the rules
+        public bool GroupIntoCollections { get; set; }  // Collections only: matched items are replaced by the collections that directly contain them
         public List<ExpressionSet> ExpressionSets { get; set; }
         public int MaxItems { get; set; }
         public int MaxPlayTimeMinutes { get; set; }
@@ -198,6 +199,7 @@ namespace Jellyfin.Plugin.SmartLists.Core
 
             MediaTypes = dto.MediaTypes != null ? new List<string>(dto.MediaTypes) : null; // Create defensive copy to prevent corruption
             MatchByMembers = dto.MatchByMembers;
+            GroupIntoCollections = dto.GroupIntoCollections;
             MaxItems = dto.MaxItems ?? 0; // Default to 0 (unlimited) for backwards compatibility
             MaxPlayTimeMinutes = dto.MaxPlayTimeMinutes ?? 0; // Default to 0 (unlimited) for backwards compatibility
             RandomGroupSelection = dto.RandomGroupSelection;
@@ -1160,6 +1162,13 @@ namespace Jellyfin.Plugin.SmartLists.Core
 
                 expandedResults = ApplyRandomGroupSelection(expandedResults, libraryManager, user, userDataManager, logger, refreshCache);
 
+                // Group matched items into the collections that contain them, before any sorting
+                // or limits so grouped entries are what MaxItems counts
+                if (GroupIntoCollections)
+                {
+                    expandedResults = GroupResultsIntoCollections(expandedResults, user, libraryManager, refreshCache, fieldReqs.NeedsSimilarTo, logger);
+                }
+
                 // Configure '(all users)' orders before any sorting runs - ApplyPerGroupLimits below
                 // calls ApplyMultipleOrders per rule group and would otherwise sort with
                 // unconfigured aggregate users.
@@ -1938,6 +1947,151 @@ namespace Jellyfin.Plugin.SmartLists.Core
         }
 
         /// <summary>
+        /// Resolves the collections an item groups into: its own direct collections first, falling
+        /// back to its series' collections for Episodes and Seasons - TV collections hold Series
+        /// items, so an episode is never a direct member of one.
+        /// </summary>
+        private bool TryGetGroupingParents(
+            BaseItem item,
+            Dictionary<Guid, List<BaseItem>> membership,
+            out List<BaseItem> parents)
+        {
+            if (TryGetEmittableParents(item.Id, membership, out parents))
+            {
+                return true;
+            }
+
+            var seriesId = item switch
+            {
+                Episode episode => episode.SeriesId,
+                Season season => season.SeriesId,
+                _ => Guid.Empty,
+            };
+
+            return seriesId != Guid.Empty && TryGetEmittableParents(seriesId, membership, out parents);
+        }
+
+        /// <summary>
+        /// Grouping only emits collections a user actually curated. A collection this plugin
+        /// generates is skipped: its own list (self-reference guard), and equally any OTHER smart
+        /// collection, because those are rebuilt on every refresh - grouping into one would make
+        /// results depend on refresh order and fill the list with unrelated smart lists that merely
+        /// happen to hold a matched item. Identified by the SmartLists provider-ID tether, the same
+        /// identity <see cref="ListOrigin"/> uses.
+        /// </summary>
+        private bool IsEmittableParent(BaseItem parent) =>
+            !Origin.Matches(parent)
+            && string.IsNullOrEmpty(parent.GetProviderId(Constants.ProviderKeys.SmartLists));
+
+        /// <summary>
+        /// The collections directly containing <paramref name="itemId"/> that this list is allowed to
+        /// emit. Returns false when nothing is left, so the caller falls through to the series lookup
+        /// instead of stopping here: once a refresh has written the list, its members ARE direct
+        /// children of it, and treating that as a real hit would freeze an Episodes list in whatever
+        /// state it was first written in.
+        /// </summary>
+        private bool TryGetEmittableParents(
+            Guid itemId,
+            Dictionary<Guid, List<BaseItem>> membership,
+            out List<BaseItem> parents)
+        {
+            if (!membership.TryGetValue(itemId, out var all))
+            {
+                parents = [];
+                return false;
+            }
+
+            // The shared list is reused across items, so filter into a copy rather than mutating it
+            parents = all.TrueForAll(IsEmittableParent) ? all : [.. all.Where(IsEmittableParent)];
+            return parents.Count > 0;
+        }
+
+        /// <summary>
+        /// GroupIntoCollections: replaces every matched non-container item that is a direct member of
+        /// one or more Jellyfin collections with those collections; Episodes and Seasons resolve
+        /// through their series. Items in no collection - and results that are themselves containers
+        /// (matched via the Collection/Playlist media types) - pass through unchanged. Results are
+        /// de-duplicated by id and no plugin-generated smart collection is ever emitted, this list's
+        /// own included (self-reference guard).
+        /// Direct membership only: CollectionSearchDepth is deliberately not consulted. Runs before
+        /// sorting and before both limit kinds, so grouped entries are what per-block MaxItems and
+        /// global MaxItems count.
+        /// When group tracking is active, an emitted collection inherits the union of the rule groups
+        /// of the items that collapsed into it; with SimilarTo it inherits their best similarity
+        /// score - the same projection MatchContainersByMembers performs for member matches.
+        /// </summary>
+        private List<BaseItem> GroupResultsIntoCollections(
+            List<BaseItem> items,
+            User user,
+            ILibraryManager libraryManager,
+            RefreshQueueService.RefreshCache refreshCache,
+            bool trackScores,
+            ILogger? logger)
+        {
+            if (items.Count == 0)
+            {
+                return items;
+            }
+
+            try
+            {
+                var membership = BuildDirectCollectionMembershipIndex(user, libraryManager, refreshCache, logger);
+                if (membership.Count == 0)
+                {
+                    return items;
+                }
+
+                bool trackGroups = NeedsGroupTracking();
+                var emittedIds = new HashSet<Guid>();
+                var grouped = new List<BaseItem>();
+                var collapsedCount = 0;
+
+                foreach (var item in items)
+                {
+                    // Containers, items in no collection, and items whose only collection is this
+                    // list's own all stay themselves rather than vanishing
+                    if (IsContainerKind(item) || !TryGetGroupingParents(item, membership, out var parents))
+                    {
+                        if (emittedIds.Add(item.Id))
+                        {
+                            grouped.Add(item);
+                        }
+
+                        continue;
+                    }
+
+                    collapsedCount++;
+                    foreach (var parent in parents)
+                    {
+                        if (emittedIds.Add(parent.Id))
+                        {
+                            grouped.Add(parent);
+                        }
+
+                        if (trackGroups && _itemGroupMappings.TryGetValue(item.Id, out var itemGroups) && itemGroups.Count > 0)
+                        {
+                            TrackContainerGroupMapping(parent.Id, itemGroups);
+                        }
+
+                        if (trackScores && _similarityScores.TryGetValue(item.Id, out var itemScore))
+                        {
+                            _similarityScores.AddOrUpdate(parent.Id, itemScore, (_, existing) => Math.Max(existing, itemScore));
+                        }
+                    }
+                }
+
+                logger?.LogDebug("GroupIntoCollections for '{ListName}': {Collapsed} of {Input} matched items collapsed into collections, {Output} results",
+                    Name, collapsedCount, items.Count, grouped.Count);
+                return grouped;
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, "Error grouping results into collections for '{ListName}'. Returning ungrouped results.", Name);
+                return items;
+            }
+        }
+
+        /// <summary>
         /// Gets the direct member items of a container candidate, preferring the RefreshCache
         /// (CollectionDirectChildren / CollectionChildItems / PlaylistChildItems) before falling
         /// back to reflection. Uncached lookups are stored in the child-items caches; the
@@ -2079,21 +2233,21 @@ namespace Jellyfin.Plugin.SmartLists.Core
         }
 
         /// <summary>
-        /// Builds an item id → collection name map for Round Robin "Collections" grouping.
-        /// TV collections contain Series items, so episodes resolve membership through their
-        /// parent series; movies (and any direct members) resolve by their own id.
-        /// When an item belongs to multiple collections, the alphabetically-first collection
-        /// name wins (consistent with the Genres/Studios "first value" convention).
+        /// Inverts the per-drain collection caches into memberId → the collections that directly
+        /// contain it, ordered by collection name so callers needing a single winner take the first.
+        /// Ensures RefreshCache.AllCollections and CollectionDirectChildren are populated; the
+        /// children cache is seeded all-or-nothing once the walk has completed, because
+        /// OperandFactory.ExtractCollections treats a non-empty cache as fully built and a partial
+        /// seed would leave every collection not reached with permanently empty children.
         /// Direct members only — nested collections are not flattened.
         /// </summary>
-        private static Dictionary<Guid, string> BuildCollectionGroupKeyMap(
-            IReadOnlyList<BaseItem> pool,
+        private static Dictionary<Guid, List<BaseItem>> BuildDirectCollectionMembershipIndex(
             User user,
             ILibraryManager libraryManager,
             RefreshQueueService.RefreshCache? refreshCache,
             ILogger? logger)
         {
-            var map = new Dictionary<Guid, string>();
+            var index = new Dictionary<Guid, List<BaseItem>>();
 
             try
             {
@@ -2116,8 +2270,9 @@ namespace Jellyfin.Plugin.SmartLists.Core
                     }
                 }
 
-                // memberId -> collection name; alphabetically-first collection wins
-                var memberToCollection = new Dictionary<Guid, string>();
+                // memberId -> collections, walked in name order so index[memberId][0] is the
+                // alphabetically-first collection the member belongs to
+                var uncachedChildren = new List<(Guid CollectionId, BaseItem[] Children)>();
                 foreach (var collection in allCollections.OrderBy(c => c.Name ?? string.Empty, OrderUtilities.SharedNaturalComparer))
                 {
                     BaseItem[] children;
@@ -2128,33 +2283,79 @@ namespace Jellyfin.Plugin.SmartLists.Core
                     else
                     {
                         children = GetCollectionChildren(collection, user, logger);
-                        refreshCache?.CollectionDirectChildren.TryAdd(collection.Id, children);
+                        uncachedChildren.Add((collection.Id, children));
                     }
 
                     foreach (var child in children)
                     {
-                        if (!memberToCollection.ContainsKey(child.Id))
+                        if (!index.TryGetValue(child.Id, out var parents))
                         {
-                            memberToCollection[child.Id] = collection.Name ?? string.Empty;
+                            parents = [];
+                            index[child.Id] = parents;
                         }
+
+                        parents.Add(collection);
                     }
                 }
+
+                // Seeded only after the whole walk succeeded - a partial cache would be read as
+                // complete by every later consumer
+                if (refreshCache != null)
+                {
+                    foreach (var (collectionId, children) in uncachedChildren)
+                    {
+                        refreshCache.CollectionDirectChildren.TryAdd(collectionId, children);
+                    }
+                }
+
+                logger?.LogDebug("Direct collection membership index: {MemberCount} members across {CollectionCount} collections",
+                    index.Count, allCollections.Length);
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex, "Error building direct collection membership index - collection membership will be treated as empty");
+            }
+
+            return index;
+        }
+
+        /// <summary>
+        /// Builds an item id → collection name map for Round Robin "Collections" grouping.
+        /// TV collections contain Series items, so episodes resolve membership through their
+        /// parent series; movies (and any direct members) resolve by their own id.
+        /// When an item belongs to multiple collections, the alphabetically-first collection
+        /// name wins (consistent with the Genres/Studios "first value" convention).
+        /// Direct members only — nested collections are not flattened.
+        /// </summary>
+        private static Dictionary<Guid, string> BuildCollectionGroupKeyMap(
+            IReadOnlyList<BaseItem> pool,
+            User user,
+            ILibraryManager libraryManager,
+            RefreshQueueService.RefreshCache? refreshCache,
+            ILogger? logger)
+        {
+            var map = new Dictionary<Guid, string>();
+
+            try
+            {
+                // Name-ordered, so the first collection of each member is the alphabetical winner
+                var membership = BuildDirectCollectionMembershipIndex(user, libraryManager, refreshCache, logger);
 
                 foreach (var item in pool)
                 {
-                    if (memberToCollection.TryGetValue(item.Id, out var directName))
+                    if (membership.TryGetValue(item.Id, out var direct))
                     {
-                        map[item.Id] = directName;
+                        map[item.Id] = direct[0].Name ?? string.Empty;
                     }
                     else if (item is Episode episode && episode.SeriesId != Guid.Empty &&
-                             memberToCollection.TryGetValue(episode.SeriesId, out var seriesCollectionName))
+                             membership.TryGetValue(episode.SeriesId, out var seriesParents))
                     {
-                        map[item.Id] = seriesCollectionName;
+                        map[item.Id] = seriesParents[0].Name ?? string.Empty;
                     }
                 }
 
-                logger?.LogDebug("Collection group map: {MappedCount} of {PoolCount} items belong to a collection ({CollectionCount} collections checked)",
-                    map.Count, pool.Count, allCollections.Length);
+                logger?.LogDebug("Collection group map: {MappedCount} of {PoolCount} items belong to a collection",
+                    map.Count, pool.Count);
             }
             catch (Exception ex)
             {

--- a/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
@@ -284,6 +284,26 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                         string.Join(", ", duplicateIds));
                 }
 
+                // Grouped results are collections projected onto the matched items' parents - they were never
+                // part of allMedia (which only queries BoxSets when a container media type is selected), so
+                // hydrate them or the ContainsKey guard below would silently drop every grouped entry.
+                if (dto.GroupIntoCollections)
+                {
+                    foreach (var itemId in distinctNewItems)
+                    {
+                        if (mediaLookup.ContainsKey(itemId))
+                        {
+                            continue;
+                        }
+
+                        var groupedItem = _libraryManager.GetItemById(itemId);
+                        if (groupedItem != null)
+                        {
+                            mediaLookup[itemId] = groupedItem;
+                        }
+                    }
+                }
+
                 var newLinkedChildren = distinctNewItems
                     .Where(itemId => mediaLookup.ContainsKey(itemId))
                     .Select(itemId => LinkedChildFactory.Create(itemId, mediaLookup[itemId]))

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/SmartListFileSystem.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/SmartListFileSystem.cs
@@ -252,6 +252,9 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
 
             // Container media types are collection-only; drop any that slipped into stored JSON
             playlist.MediaTypes.RemoveAll(Core.Constants.MediaTypes.IsContainerType);
+
+            // Collection-only flag; drop it if it slipped into stored JSON so the list still saves
+            playlist.GroupIntoCollections = false;
         }
 
         /// <summary>
@@ -274,6 +277,15 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
 
             // Migrate legacy per-rule include-only flags to Collection/Playlist media types
             MigrateIncludeOnlyRulesToMediaTypes(collection);
+
+            // Max Playtime is playlist-only and its input is hidden for collections, but the
+            // server-wide Default Max Playtime used to be written into new collections anyway -
+            // clear it so those lists stop being truncated by a limit their form never showed.
+            // Back to unset rather than 0, so a collection that never carried one is untouched.
+            if (collection.MaxPlayTimeMinutes is > 0)
+            {
+                collection.MaxPlayTimeMinutes = null;
+            }
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Utilities/DtoMapper.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/DtoMapper.cs
@@ -118,12 +118,16 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
                 MediaTypes = source.MediaTypes,
                 IncludeExtras = source.IncludeExtras,
                 MatchByMembers = source.MatchByMembers,
+                GroupIntoCollections = source.GroupIntoCollections,
                 HideWhenEmpty = source.HideWhenEmpty,
-                
+
                 // State and limits
                 Enabled = source.Enabled,
                 MaxItems = source.MaxItems,
-                MaxPlayTimeMinutes = source.MaxPlayTimeMinutes,
+
+                // MaxPlayTimeMinutes is deliberately NOT mapped: Max Playtime is a playlist-only
+                // limit and its input is hidden for collections, so carrying a value across would
+                // truncate a collection by a limit its form never showed.
                 RandomGroupSelection = source.RandomGroupSelection,
                 
                 // Auto-refresh

--- a/Jellyfin.Plugin.SmartLists/Utilities/InputValidator.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/InputValidator.cs
@@ -280,14 +280,25 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
             }
 
             // Container media types (Collection/Playlist) are collection-only: Jellyfin playlists
-            // can only contain media items, so container results would be silently dropped
-            if (list is SmartPlaylistDto)
+            // can only contain media items, so container results would be silently dropped.
+            // Gated on the Type discriminator rather than the CLR type: the user page binds every
+            // create body as a SmartPlaylistDto and only converts to a collection DTO after
+            // validation has run, so a CLR-type check rejects legitimate smart collections there.
+            if (list.Type != Core.Enums.SmartListType.Collection)
             {
                 var containerType = list.MediaTypes?.FirstOrDefault(Core.Constants.MediaTypes.IsContainerType);
                 if (containerType != null)
                 {
                     return SmartListValidationResult.Failure($"{containerType} media type is not supported for playlists. Jellyfin playlists can only contain media items - use a smart collection instead.");
                 }
+            }
+
+            // Grouping emits BoxSets, which Jellyfin playlists cannot contain. Gated on the Type
+            // discriminator rather than the CLR type: the user page binds every create body as a
+            // SmartPlaylistDto and only converts to a collection DTO after validation has run.
+            if (list.Type != Core.Enums.SmartListType.Collection && list.GroupIntoCollections)
+            {
+                return SmartListValidationResult.Failure("Group results into collections is not supported for playlists. Jellyfin playlists can only contain media items - use a smart collection instead.");
             }
 
             // Validate expression sets

--- a/docs/content/changelog/rc.md
+++ b/docs/content/changelog/rc.md
@@ -13,6 +13,20 @@ A non-zero final segment is the RC number — older entries instead number the R
 itself (`v10.10.10.0-rc3`), which is the scheme used before the number moved into the version.
 
 
+## v12.0.0.20-rc
+
+*2026-08-26 · [release notes](https://github.com/jyourstone/jellyfin-smartlists-plugin/releases/tag/v12.0.0.20-rc)*
+
+**Features**
+
+- New **Group results into collections** toggle for smart collections. Every matched item that sits in a Jellyfin collection is replaced by that collection, turning an item search into a collection of collections — "every collection holding a highly-rated action movie" instead of the movies themselves. Items that aren't in any collection are kept as-is, duplicates collapse into one entry, and grouping runs before sorting and Max Items so the limit counts collections ([Media types](../user-guide/media-types.md#group-into-collections)).
+
+**Bug Fixes**
+
+- Creating a smart **collection** with the **Collection** or **Playlist** media type from the user configuration page failed with *"media type is not supported for playlists"*. The user page sends every new list in the playlist shape and only converts it afterwards, so the check saw a playlist no matter what the list type was set to.
+- Smart collections no longer inherit the server-wide **Default Max Playtime**. Max Playtime applies to playlists only and its input is hidden for collections, but the default was written into every new list and sent anyway — so an admin with a non-zero default got collections quietly truncated by a limit their form never showed. Existing collections carrying a leaked value have it cleared on load, and **Convert to Collection** no longer carries the playlist's limit across.
+
+
 ## v12.0.0.19-rc
 
 *2026-08-24 · [release notes](https://github.com/jyourstone/jellyfin-smartlists-plugin/releases/tag/v12.0.0.19-rc)*

--- a/docs/content/examples/common-use-cases.md
+++ b/docs/content/examples/common-use-cases.md
@@ -58,6 +58,15 @@ Here are some popular playlist and collection types you can create:
 - A collection holding a 2015 Arnold movie and a 1985 movie without him does **not** match — a single item must satisfy the whole rule group
 - **Tip**: Add **Movie** to the media types to also include the matching movies themselves alongside the collections
 
+### Collections of Your Best Action Movies
+- **List Type**: Collection
+- **Media Types**: Movie, with **["Group results into collections"](../user-guide/media-types.md#group-into-collections)** turned **on**
+- **Genres** contains "Action" AND **Community Rating** greater than 8
+- The rules still match movies, but every matched movie is replaced by the collections it belongs to — the result is a collection of every collection holding a highly-rated action movie
+- Duplicates collapse, so ten matching movies from the same franchise produce that one collection rather than ten entries. Movies that aren't in any collection are kept as they are
+- **Note**: Only direct membership counts, and grouping happens before sorting and Max Items, so the limit counts collections rather than the movies inside them
+- **Tip**: The two collection toggles are opposites — use **Match by members** to match *against* a collection's contents, and **Group results into collections** to *produce* collections from item matches
+
 ### Combine Multiple Playlists
 - **Playlist name** is in "Favorites;Top Rated;Recent Additions"
 - **List Type**: Playlist

--- a/docs/content/user-guide/configuration.md
+++ b/docs/content/user-guide/configuration.md
@@ -215,6 +215,7 @@ The remaining fields live inside the collapsed **More options** section, grouped
 - **Presentation**
   - Upload custom images and set metadata such as sort title, overview, tags and favorite (see [Custom Images](#custom-images) and [Metadata](#metadata) above)
   - Hide the Jellyfin playlist/collection while the list matches no items (see [Hide When Empty](#hide-when-empty))
+  - Replace matched items with the collections that contain them (collections only, see [Group results into collections](media-types.md#group-into-collections))
 
 !!! info "User Page Differences"
     On the **User Page**, you can only select yourself for playlists and must use your own account as the reference user for collections. Admins can select any user(s) from the dropdown.

--- a/docs/content/user-guide/fields-and-operators.md
+++ b/docs/content/user-guide/fields-and-operators.md
@@ -263,6 +263,8 @@ How deep to traverse nested collections (default: 0). The option appears under a
 - 1 = Items in collection + one level of sub-collections
 - 2+ = Continue traversing nested collections
 
+**[Group results into collections](media-types.md#group-into-collections)** never uses this setting to decide which collections a matched item is replaced by — that is always direct membership. It does still apply to the *results* of grouping in the usual way: at depth 1 or higher, sorts like Community Rating or Production Year [aggregate over each collection's children](sorting-and-limits.md#child-item-sorting) instead of reading the collection's own (usually empty) value.
+
 !!! warning "Performance"
     Higher search depths require more database queries. Start with depth 0 and increase only if needed.
 

--- a/docs/content/user-guide/media-types.md
+++ b/docs/content/user-guide/media-types.md
@@ -63,6 +63,33 @@ In a mixed selection like `Movie + Collection`, item candidates are still evalua
 !!! info "Replaces the old include-only checkboxes"
     Older versions used per-rule **"Include collections only"** / **"Include playlist only"** checkboxes on the **Collection name** and **Playlist name** fields. Existing lists are migrated automatically on load: the include-only rule becomes a **Name** rule, the matching media type is selected, and the toggle stays off. See the [changelog](../changelog/rc.md) for details on lists that mixed include-only rules with normal item rules.
 
+### Group results into collections {#group-into-collections}
+
+Smart collections have a second list-level toggle, **"Group results into collections"**, under **More options → Presentation**. Where [Match by members](#match-by-members) checks a collection by the items *inside* it, this one works the other way round — it turns an ordinary item search *into* collections. It is available on every smart collection and, unlike Match by members, needs no container media type.
+
+With the toggle on, every matched item that is a direct member of one or more Jellyfin collections is replaced by those collections. Items that are in no collection are kept as they are, and results that already *are* collections or playlists pass through unchanged. Results are de-duplicated, so ten matched Marvel movies produce a single Marvel collection rather than ten copies of it — while an item sitting in several collections is replaced by all of them.
+
+For example, on a smart collection with the **Movie** media type and the toggle on:
+
+```text
+Genres contains "Action"
+AND Community Rating greater than 8
+```
+
+produces a collection of every collection holding a highly-rated action movie, instead of a collection of the movies themselves.
+
+!!! note "Direct membership only"
+    Only the collections that contain a matched item **directly** are used — nested collections are not traversed, and the [Collection search depth](fields-and-operators.md#collection-search-depth) setting has no say in which collections are emitted (it still affects how they are *sorted*, see below). Episodes and seasons are never direct collection members themselves, so they are grouped through their **series**: an episode is replaced by the collections holding its show.
+
+!!! note "Which collections are used"
+    Grouping uses the Jellyfin collections the [reference user](user-selection.md#collections-reference-user) can see: manually created ones and the collections Jellyfin creates automatically for movie franchises. **Smart collections are never emitted** — neither the list's own (the self-reference prevention described above) nor any other one this plugin manages. They are regenerated on every refresh, so grouping into one would make a list's contents depend on refresh order, and any smart collection that happened to hold a matched item would crowd out the real collections. To build a list *of* smart collections, use the [Collection media type](#container-media-types) instead.
+
+!!! note "Grouping runs before sorting and limits"
+    Items are grouped before the list is sorted and before **Max Items** is applied, so that limit — global and [per OR block](sorting-and-limits.md#per-group-max-items) — counts collections, not the items that collapsed into them. A grouped collection inherits the rule blocks of the items it replaced, so it counts toward those blocks' limits. Sorting by **Round Robin** grouped by *Collection* adds nothing here: every result is already a collection, so each one forms a group of its own.
+
+!!! tip "Sorting grouped results by a member value"
+    Grouped results are collections, and a collection usually carries no community rating, year or release date of its own — so sorting by one of those fields leaves every entry at zero unless [Collection search depth](fields-and-operators.md#collection-search-depth) is set to **1 or higher**, which is what switches those sorts over to [aggregating the values of a collection's children](sorting-and-limits.md#child-item-sorting). The depth setting never changes *which* collections grouping emits.
+
 ## Extras (Special Features)
 
 Jellyfin supports "extras" — behind the scenes, deleted scenes, featurettes, trailers, and other bonus content attached to movies and TV shows. By default, extras are **not included** in smart lists because they are owned by their parent items and excluded from standard library queries.

--- a/docs/content/user-guide/sorting-and-limits.md
+++ b/docs/content/user-guide/sorting-and-limits.md
@@ -422,6 +422,8 @@ When using multiple OR blocks, you can set a **Max Items limit for each individu
 !!! note "Collection / Playlist media types"
     Collections and playlists matched via the [Collection/Playlist media types](media-types.md#container-media-types) participate like any other results: they count toward the limit of the OR block that matched them (with **Match by members** on, the block whose rules their member items passed) and are unaffected by limits set on other blocks.
 
+    The same holds with **[Group results into collections](media-types.md#group-into-collections)** on: grouping runs before both limits, so it is the grouped collection that counts toward the per-block and global limits, never the items that collapsed into it. It inherits the rule blocks of those items, so it survives a limit set on their block.
+
 !!! note "Similar To blocks"
     A block containing a **Similar To** rule scores similarity against [its own block's reference items](fields-and-operators.md#similar-to), so per-block limits behave as expected: each block's limit is filled from the items similar to *that block's* reference. An item similar to several blocks' references counts toward the first of those blocks with a free slot, never twice.
 


### PR DESCRIPTION
Follow-up to #479. Adds a list-level toggle for smart collections — **Group results into collections** (More options → Presentation) — that replaces every matched item with the Jellyfin collections that directly contain it. Items in no collection pass through unchanged, so one rule produces "the collections holding a match, plus the loose items".

That shape is what the reporter was hand-rolling with brittle heuristics (`LibraryName not contains "Collection"` to exclude BoxSets, `Name contains "Collection"` to select them). It worked for Studios, which Jellyfin rolls up onto a BoxSet, but not for Actors, which it never does — and turning on **Match by members** to fix that made every rule evaluate against the member movie, collapsing the heuristics. There was no way to scope a rule block to collections vs items. This toggle removes the need to.

```
Genres contains "Action"      →  8 collections + 11 uncollected movies
```

## Semantics

- **Smart collections only.** Jellyfin playlists can't contain BoxSets; rejected server-side.
- **Direct membership only.** Nested collections are not traversed and *Collection search depth* has no say in which collections are emitted.
- **Episodes and seasons resolve through their series** — TV collections hold the series, never the episodes — so the toggle isn't a silent no-op on TV libraries.
- **Before sorting and before both limit kinds**, so **Max Items** counts collections, not the items that collapsed into them.
- **A grouped collection inherits the rule blocks** of the items it replaced (and their best similarity score), so it survives per-block limits and sorts correctly under Rule Block Order and Similar To.
- **Smart collections are never emitted**, this list's own included. They are regenerated on every refresh, so grouping into one would make results depend on refresh order. Verified against a real library: without this, an Arnold search returned 4 real collections and 3 unrelated smart lists that merely held a match. To build a list *of* smart collections, the Collection media type is still the tool.

## Notable

`CollectionService` now hydrates grouped BoxSets into the media lookup. Without it the `ContainsKey` guard dropped every grouped entry and the collection saved empty — unit tests can't reach this, so it's covered by the e2e run below.

`BuildDirectCollectionMembershipIndex` is extracted from `BuildCollectionGroupKeyMap` (behaviour-neutral) and now seeds the direct-children cache all-or-nothing; a partial seed left every collection not reached with permanently empty children.

## Two pre-existing bugs fixed

- Creating a smart **collection** with the Collection/Playlist media type **from the user config page** failed with *"not supported for playlists"*. That page binds every create body in the playlist shape and converts afterwards, so a `is SmartPlaylistDto` check saw a playlist regardless of list type. Both container checks now gate on the `Type` discriminator.
- Smart collections inherited the server-wide **Default Max Playtime** — a playlist-only limit whose input is hidden for collections — and were silently truncated by it. No longer sent, no longer carried across by *Convert to Collection*, and cleared on load for lists that already carry one.

## Verification

- Both ABIs (`net9.0` / `net10.0`) Release, 0 warnings.
- **1614 tests pass** (+25). Mutation-tested: neutralising the grouping call site fails 11 of 13 grouping tests; each review fix was verified the same way.
- e2e against a live Jellyfin: grouped output is BoxSets with a non-zero item count, uncollected items pass through, the checkbox is collection-only and hidden for playlists, and edit mode restores it with the advanced fold auto-expanded and its chip shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9Qe3VFG7DQsuWdbfW6qra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a collection-only **Group results into collections** option for smart collections.
  * Matched items can be replaced by their direct Jellyfin collections, with duplicates collapsed and unmatched items preserved.
  * Episodes and seasons can group through their series collections.
  * Grouping occurs before sorting and item limits, so collections count toward limits.

* **Bug Fixes**
  * Prevented playlist-only settings from carrying over to collections.
  * Improved reliability when grouped collection entries are not initially loaded.

* **Documentation**
  * Added configuration guidance, usage examples, and details on grouping, sorting, limits, and membership behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->