### PR TITLE
fix: allow special characters in list names (#514)

### DIFF
--- a/Jellyfin.Plugin.SmartLists.Tests/Utilities/InputValidatorTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Utilities/InputValidatorTests.cs
@@ -131,10 +131,10 @@ public class InputValidatorTests
     }
 
     [Fact]
-    public void ValidateName_NulByte_IsReportedAsControlCharacterNotAsDangerousChar()
+    public void ValidateName_NulByte_IsReportedAsAControlCharacter()
     {
-        // NUL appears in both the control-character check and DangerousFileNameChars.
-        // The control check runs first; this pins which message a caller actually sees.
+        // NUL is in Jellyfin core's sanitized set too, but the control-character check catches it
+        // first and is the only thing that rejects it here; this pins the message a caller sees.
         var result = InputValidator.ValidateName("My\0List");
 
         Assert.False(result.IsValid);
@@ -144,17 +144,46 @@ public class InputValidatorTests
     [Theory]
     [InlineData("My<List")]
     [InlineData("My>List")]
-    [InlineData("My:List")]
-    [InlineData("My\"List")]
-    [InlineData("My/List")]
-    [InlineData("My\\List")]
-    [InlineData("My|List")]
-    [InlineData("My?List")]
-    [InlineData("My*List")]
-    public void ValidateName_FileSystemHostileCharacters_AreRejected(string name)
+    [InlineData("Marvel: Phase One")]
+    [InlineData("Rock \"n\" Roll")]
+    [InlineData("Action/Adventure")]
+    [InlineData("AC\\DC")]
+    [InlineData("Comedy|Drama")]
+    [InlineData("Who? What!")]
+    [InlineData("Action*")]
+    public void ValidateName_CharactersJellyfinSanitizes_AreAccepted(string name)
     {
-        // Names become file names on disk, so these must not get through.
-        AssertInvalid(InputValidator.ValidateName(name), "List name contains invalid characters:");
+        // These are DISPLAY names, not file names. This plugin's own storage is GUID-keyed
+        // (SmartListFileSystem.GetSmartListFolderPath), and the only other consumer is Jellyfin
+        // core, which runs the name through ManagedFileSystem.GetValidFilename before building the
+        // collection/playlist folder while keeping the raw name as the item's display name.
+        // Rejecting them here just broke names like "Marvel: Phase One" for no gain (issue #514).
+        AssertValid(InputValidator.ValidateName(name));
+    }
+
+    [Theory]
+    [InlineData("***")]
+    [InlineData(":")]
+    [InlineData("  ?  ")]
+    [InlineData("<>|")]
+    public void ValidateName_NameThatSanitizesToBlank_IsRejected(string name)
+    {
+        // Core would replace every one of these with a space, leaving it to create a
+        // blank/trailing-space folder name - illegal on Windows. This is the one case core
+        // does not handle, so it is the one case still worth rejecting.
+        AssertInvalid(InputValidator.ValidateName(name), "must contain at least one character");
+    }
+
+    [Theory]
+    [InlineData(".")]
+    [InlineData("..")]
+    [InlineData("  ..  ")]
+    public void ValidateName_BareRelativePathSegments_AreRejected(string name)
+    {
+        // Core concatenates the sanitized name straight into Path.Combine, so a playlist named
+        // ".." would resolve to the parent directory. The separator-anchored traversal patterns
+        // miss the bare form.
+        AssertInvalid(InputValidator.ValidateName(name), "List name contains invalid characters");
     }
 
     [Theory]
@@ -164,8 +193,8 @@ public class InputValidatorTests
     [InlineData("Ω Alpha (Director's Cut) [4K] - #1, 50% off!")]
     public void ValidateName_UnicodeAndOrdinaryPunctuation_AreAccepted(string name)
     {
-        // Only the nine file-system-hostile characters are banned; everything else,
-        // including non-ASCII and astral-plane emoji, is a legal list name.
+        // No character is banned outright; only control characters, path traversal, and names
+        // that would sanitize to nothing are rejected. Non-ASCII and astral-plane emoji are fine.
         AssertValid(InputValidator.ValidateName(name));
     }
 
@@ -546,9 +575,9 @@ public class InputValidatorTests
     public void ValidateSmartList_InvalidName_ReportsTheNameProblem()
     {
         var dto = ValidPlaylist();
-        dto.Name = "Bad/Name";
+        dto.Name = "Bad\nName";
 
-        AssertInvalid(InputValidator.ValidateSmartList(dto), "List name contains invalid characters:");
+        AssertInvalid(InputValidator.ValidateSmartList(dto), "List name contains invalid control characters");
     }
 
     [Fact]

--- a/Jellyfin.Plugin.SmartLists.Tests/Utilities/InputValidatorTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Utilities/InputValidatorTests.cs
@@ -166,11 +166,12 @@ public class InputValidatorTests
     [InlineData(":")]
     [InlineData("  ?  ")]
     [InlineData("<>|")]
+    [InlineData("....")] // Windows drops trailing dots, leaving an empty path segment
     public void ValidateName_NameThatSanitizesToBlank_IsRejected(string name)
     {
         // Core would replace every one of these with a space, leaving it to create a
-        // blank/trailing-space folder name - illegal on Windows. This is the one case core
-        // does not handle, so it is the one case still worth rejecting.
+        // blank/trailing-space folder name - illegal on Windows. This is one of only two cases
+        // core does not handle, so it is one of only two still worth rejecting.
         AssertInvalid(InputValidator.ValidateName(name), "must contain at least one character");
     }
 
@@ -178,12 +179,25 @@ public class InputValidatorTests
     [InlineData(".")]
     [InlineData("..")]
     [InlineData("  ..  ")]
+    [InlineData("..:")] // sanitizes to ".. ", which Windows trims back to ".."
+    [InlineData("..*")]
+    [InlineData("?..")]
     public void ValidateName_BareRelativePathSegments_AreRejected(string name)
     {
         // Core concatenates the sanitized name straight into Path.Combine, so a playlist named
         // ".." would resolve to the parent directory. The separator-anchored traversal patterns
-        // miss the bare form.
-        AssertInvalid(InputValidator.ValidateName(name), "List name contains invalid characters");
+        // miss the bare form, and checking the RAW name would miss the sanitized variants - hence
+        // validating the folder name core actually derives.
+        AssertInvalid(InputValidator.ValidateName(name), "cannot be \'.\' or \'..\'");
+    }
+
+    [Theory]
+    [InlineData("Seasons 1..3")]
+    [InlineData("Volume 2..")]  // trailing dots are trimmed by Windows but "Volume 2" survives
+    [InlineData("...and Justice for All")]
+    public void ValidateName_DotsThatStillLeaveARealName_AreAccepted(string name)
+    {
+        AssertValid(InputValidator.ValidateName(name));
     }
 
     [Theory]

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-bulk-actions.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-bulk-actions.js
@@ -806,6 +806,7 @@
         let successCount = 0;
         let errorCount = 0;
         let enabledSuccessCount = 0;
+        let firstErrorMessage = null;
 
         // Clear selections immediately
         const selectAllCheckbox = page.querySelector('#selectAllCheckbox');
@@ -850,6 +851,11 @@
                 if (!putResponse.ok) {
                     const errorMessage = await SmartLists.extractErrorMessage(putResponse, 'HTTP ' + putResponse.status);
                     console.error('Error converting list:', listId, errorMessage);
+                    // Keep the first server message so the summary can say WHY, instead of
+                    // reporting a bare failure count the user cannot act on.
+                    if (!firstErrorMessage && errorMessage) {
+                        firstErrorMessage = errorMessage;
+                    }
                     errorCount++;
                 } else {
                     successCount++;
@@ -880,7 +886,11 @@
         }
         if (errorCount > 0) {
             var errorListWord = errorCount === 1 ? 'list' : 'lists';
-            SmartLists.showNotification('Failed to convert ' + errorCount + ' ' + errorListWord + '.', 'error');
+            var errorMessageText = 'Failed to convert ' + errorCount + ' ' + errorListWord + '.';
+            if (firstErrorMessage) {
+                errorMessageText += ' ' + firstErrorMessage;
+            }
+            SmartLists.showNotification(errorMessageText, 'error');
         }
 
         // Reload list to show updated state

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-bulk-actions.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-bulk-actions.js
@@ -865,6 +865,12 @@
                 }
             } catch (err) {
                 console.error('Error converting list:', listId, err);
+                // apiClient.ajax rejects with the Response on a 4xx, so a validation failure lands
+                // here rather than in the !ok branch above. Pull the reason out either way.
+                const errorMessage = await SmartLists.extractErrorMessage(err, null);
+                if (!firstErrorMessage && errorMessage) {
+                    firstErrorMessage = errorMessage;
+                }
                 errorCount++;
             }
         }
@@ -888,7 +894,11 @@
             var errorListWord = errorCount === 1 ? 'list' : 'lists';
             var errorMessageText = 'Failed to convert ' + errorCount + ' ' + errorListWord + '.';
             if (firstErrorMessage) {
-                errorMessageText += ' ' + firstErrorMessage;
+                // With several failures the captured reason belongs to only one of them, so label
+                // it rather than implying every list failed for the same reason.
+                errorMessageText += errorCount === 1
+                    ? ' ' + firstErrorMessage
+                    : ' First error: ' + firstErrorMessage;
             }
             SmartLists.showNotification(errorMessageText, 'error');
         }

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -661,10 +661,10 @@
                 const action = editState.editMode ? 'update' : 'create';
 
                 // For UPDATE operations: restore edit mode by reloading playlist from server
-                if (editState.editMode && editingPlaylistId) {
+                if (editState.editMode && editState.editingPlaylistId) {
                     // Reload the playlist to restore form state
                     if (SmartLists.editPlaylist) {
-                        SmartLists.editPlaylist(page, editingPlaylistId);
+                        SmartLists.editPlaylist(page, editState.editingPlaylistId);
                     }
                 }
                 // For CREATE operations: form remains populated, user can fix and retry

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -660,15 +660,10 @@
                 console.error('Error creating ' + listTypeName.toLowerCase() + ':', err);
                 const action = editState.editMode ? 'update' : 'create';
 
-                // For UPDATE operations: restore edit mode by reloading playlist from server
-                if (editState.editMode && editState.editingPlaylistId) {
-                    // Reload the playlist to restore form state
-                    if (SmartLists.editPlaylist) {
-                        SmartLists.editPlaylist(page, editState.editingPlaylistId);
-                    }
-                }
-                // For CREATE operations: form remains populated, user can fix and retry
-                // Stay on Create tab (already there)
+                // Edit mode is only exited in the success handler, so it is still active here and
+                // there is nothing to restore. Reloading the stored list would overwrite the form
+                // with the saved values and throw away everything the user just typed - so on both
+                // create and update the form stays populated and the user can fix and retry.
 
                 // Show error notification
                 SmartLists.handleApiError(err, 'Failed to ' + action + ' ' + listTypeName.toLowerCase() + ' ' + playlistName);
@@ -1312,7 +1307,10 @@
         var statusLink = SmartLists.createStatusPageLink('status page');
         var message = 'Refresh started';
         if (playlistName) {
-            message += ' for ' + (listTypeName || 'list') + ' "' + playlistName + '"';
+            // This notification is always rendered with { html: true } so the status-page link
+            // works, which means the name reaches innerHTML - escape it. A non-admin can name a
+            // list, and the admin sees that name here when they refresh it.
+            message += ' for ' + (listTypeName || 'list') + ' "' + SmartLists.escapeHtml(playlistName) + '"';
         }
         
         if (SmartLists.IS_USER_PAGE) {
@@ -1461,13 +1459,15 @@
             }
 
             // Show success message
-            var successMessage = 'List "' + listName + '" converted to ' + targetType.toLowerCase() + '.';
             var isEnabled = listData.Enabled !== false;
 
             // Only show status page link if list is enabled (will refresh) and on admin page
-            // Note: html option should only be true when we actually include HTML content (the statusLink)
-            // to avoid XSS from user-controlled listName being interpreted as HTML
             var includeStatusLink = !SmartLists.IS_USER_PAGE && isEnabled;
+
+            // The status link forces html: true, which sends the whole message through innerHTML -
+            // escape the user-controlled name in that case.
+            var displayName = includeStatusLink ? SmartLists.escapeHtml(listName) : listName;
+            var successMessage = 'List "' + displayName + '" converted to ' + targetType.toLowerCase() + '.';
             if (includeStatusLink) {
                 var statusLink = SmartLists.createStatusPageLink('status page');
                 successMessage += ' Check the ' + statusLink + ' for progress.';
@@ -1480,7 +1480,10 @@
             }
         } catch (err) {
             console.error('Error converting list:', listId, err);
-            SmartLists.showNotification('Failed to convert list: ' + (err.message || 'Unknown error'), 'error');
+            // apiClient.ajax rejects with the Response for a 4xx, and a Response has no .message -
+            // extractErrorMessage knows both shapes and pulls the ProblemDetails text out.
+            const errorMessage = await SmartLists.extractErrorMessage(err, 'Unknown error');
+            SmartLists.showNotification('Failed to convert list: ' + errorMessage, 'error');
         }
     };
 

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/BasicDirectoryService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/BasicDirectoryService.cs
@@ -19,6 +19,13 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
         public IReadOnlyList<string> GetFilePaths(string path) => [];
 #if NET10_0_OR_GREATER
         public IReadOnlyList<string> GetFilePaths(string path, bool clearCache) => GetFilePaths(path);
+        public void Invalidate(string path)
+        {
+        }
+
+        public void Move(string source, string destination)
+        {
+        }
 #endif
         public IReadOnlyList<string> GetFilePaths(string path, bool clearCache, bool sort) => GetFilePaths(path);
         public bool IsAccessible(string path) => false;

--- a/Jellyfin.Plugin.SmartLists/Utilities/InputValidator.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/InputValidator.cs
@@ -77,8 +77,17 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
             RegexOptions.Compiled
         );
 
-        // Dangerous characters for file names
-        private static readonly char[] DangerousFileNameChars = new[] { '<', '>', ':', '"', '/', '\\', '|', '?', '*', '\0' };
+        // Mirrors Jellyfin core's ManagedFileSystem._invalidPathCharacters
+        // (Emby.Server.Implementations/IO/ManagedFileSystem.cs). Core replaces each of these with a
+        // space when it derives the FOLDER name for a collection or playlist
+        // (CollectionManager.CreateCollectionAsync, PlaylistManager.CreatePlaylist) while storing the
+        // raw name as the item's display name. That list is a hardcoded literal in core, not
+        // Path.GetInvalidFileNameChars(), so it is identical on Linux and Windows - which is why this
+        // plugin neither rejects nor sanitizes these characters itself: doing so would double-sanitize,
+        // and since the display name is re-asserted after every refresh it would also make the
+        // sanitized form the user-visible name. Core's list also covers control chars 1-31, which the
+        // control-character check above already rejects outright.
+        private static readonly char[] JellyfinSanitizedChars = new[] { '"', '<', '>', '|', ':', '*', '?', '\\', '/' };
 
         /// <summary>
         /// Validates a smart list name.
@@ -107,13 +116,43 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
                 return SmartListValidationResult.Failure("List name contains invalid control characters");
             }
 
-            // Check for potentially dangerous characters that could cause issues with file systems
-            if (name.Any(c => DangerousFileNameChars.Contains(c)))
+            // A name built only from characters core strips would sanitize to whitespace, leaving core
+            // to create a blank folder name - which fails outright on Windows, where a path segment
+            // cannot be blank or end in a space. Reject only that degenerate case; every other use of
+            // ": * ? < > | \" / \\" is a legitimate display name that core handles for us.
+            if (SanitizesToBlank(name))
             {
-                return SmartListValidationResult.Failure("List name contains invalid characters: < > : \" / \\ | ? *");
+                return SmartListValidationResult.Failure("List name must contain at least one character that is valid in a file name");
+            }
+
+            // "." and ".." are relative path segments rather than names: core concatenates the
+            // sanitized name straight into Path.Combine, so a playlist named ".." would resolve to the
+            // parent directory. The traversal patterns above are separator-anchored and miss this.
+            var trimmed = name.Trim();
+            if (string.Equals(trimmed, ".", StringComparison.Ordinal) || string.Equals(trimmed, "..", StringComparison.Ordinal))
+            {
+                return SmartListValidationResult.Failure("List name contains invalid characters");
             }
 
             return SmartListValidationResult.Success();
+        }
+
+        /// <summary>
+        /// Returns true when every character in <paramref name="name"/> is either whitespace or one
+        /// that Jellyfin core replaces with a space when deriving a folder name, i.e. the name would
+        /// sanitize to nothing usable.
+        /// </summary>
+        private static bool SanitizesToBlank(string name)
+        {
+            foreach (var c in name)
+            {
+                if (!char.IsWhiteSpace(c) && Array.IndexOf(JellyfinSanitizedChars, c) < 0)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Utilities/InputValidator.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/InputValidator.cs
@@ -116,43 +116,52 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
                 return SmartListValidationResult.Failure("List name contains invalid control characters");
             }
 
-            // A name built only from characters core strips would sanitize to whitespace, leaving core
-            // to create a blank folder name - which fails outright on Windows, where a path segment
-            // cannot be blank or end in a space. Reject only that degenerate case; every other use of
-            // ": * ? < > | \" / \\" is a legitimate display name that core handles for us.
-            if (SanitizesToBlank(name))
+            // Everything below validates the name core will actually put on disk, not the raw input:
+            // checking the raw string misses names that only become degenerate after core rewrites
+            // them (e.g. "..:" sanitizes to ".." and escapes to the parent directory).
+            var folderName = SanitizedFolderName(name);
+
+            if (folderName.Length == 0)
             {
                 return SmartListValidationResult.Failure("List name must contain at least one character that is valid in a file name");
             }
 
             // "." and ".." are relative path segments rather than names: core concatenates the
-            // sanitized name straight into Path.Combine, so a playlist named ".." would resolve to the
-            // parent directory. The traversal patterns above are separator-anchored and miss this.
-            var trimmed = name.Trim();
-            if (string.Equals(trimmed, ".", StringComparison.Ordinal) || string.Equals(trimmed, "..", StringComparison.Ordinal))
+            // sanitized name straight into Path.Combine, so a playlist named ".." would resolve to
+            // the parent directory. The traversal patterns above are separator-anchored and miss the
+            // bare form.
+            if (string.Equals(folderName, ".", StringComparison.Ordinal) || string.Equals(folderName, "..", StringComparison.Ordinal))
             {
-                return SmartListValidationResult.Failure("List name contains invalid characters");
+                return SmartListValidationResult.Failure("List name cannot be '.' or '..'");
+            }
+
+            // Windows also drops trailing dots from a path segment, so a name like "...." would
+            // create nothing at all there.
+            if (folderName.TrimEnd('.').Trim().Length == 0)
+            {
+                return SmartListValidationResult.Failure("List name must contain at least one character that is valid in a file name");
             }
 
             return SmartListValidationResult.Success();
         }
 
         /// <summary>
-        /// Returns true when every character in <paramref name="name"/> is either whitespace or one
-        /// that Jellyfin core replaces with a space when deriving a folder name, i.e. the name would
-        /// sanitize to nothing usable.
+        /// Reproduces the folder name Jellyfin core derives from a list name: every character core
+        /// treats as invalid becomes a space (ManagedFileSystem.GetValidFilename), and the result is
+        /// trimmed because a path segment cannot begin or end in whitespace on Windows.
         /// </summary>
-        private static bool SanitizesToBlank(string name)
+        private static string SanitizedFolderName(string name)
         {
-            foreach (var c in name)
+            var chars = name.ToCharArray();
+            for (var i = 0; i < chars.Length; i++)
             {
-                if (!char.IsWhiteSpace(c) && Array.IndexOf(JellyfinSanitizedChars, c) < 0)
+                if (Array.IndexOf(JellyfinSanitizedChars, chars[i]) >= 0)
                 {
-                    return false;
+                    chars[i] = ' ';
                 }
             }
 
-            return true;
+            return new string(chars).Trim();
         }
 
         /// <summary>

--- a/docs/content/changelog/rc.md
+++ b/docs/content/changelog/rc.md
@@ -13,6 +13,19 @@ A non-zero final segment is the RC number — older entries instead number the R
 itself (`v10.10.10.0-rc3`), which is the scheme used before the number moved into the version.
 
 
+## v12.0.0.21-rc
+
+*2026-09-08 · [release notes](https://github.com/jyourstone/jellyfin-smartlists-plugin/releases/tag/v12.0.0.21-rc)*
+
+**Bug Fixes**
+
+- List names can contain `:`, `*`, `?`, `<`, `>`, `|`, `"`, `/` and `\` again. Names like *Marvel: Phase One* were rejected outright on the premise that a list name becomes a file name, which it never does here — the plugin stores lists by ID, and Jellyfin itself already rewrites the name when it builds the collection or playlist folder, keeping the original as the display name. Only two names are still refused: one made up entirely of characters Jellyfin strips (`***`), and a bare `.` or `..` ([#514](https://github.com/jyourstone/jellyfin-smartlists-plugin/issues/514)).
+- Lists whose names already contained one of those characters — created before the rule was applied to the admin page, or restored from a backup — could not be saved at all, even when only a rule was edited. They save normally again.
+- **Saving a list now reports why it failed.** A rejected update showed no message whatsoever: a bug in the error handler threw before the notification was reached, so the save simply appeared to do nothing. Converting lists between playlist and collection was similarly silent, in both the single and bulk actions, and now shows the server's reason.
+- A failed update no longer discards the edits in the form. The form was being reloaded from the saved copy, wiping out whatever had just been typed; it now stays as-is so the change can be corrected and resubmitted.
+- List names are escaped in the notifications that show them, so a name containing HTML can no longer affect the page.
+
+
 ## v12.0.0.20-rc
 
 *2026-08-26 · [release notes](https://github.com/jyourstone/jellyfin-smartlists-plugin/releases/tag/v12.0.0.20-rc)*


### PR DESCRIPTION
Fixes #514.

## Problem

Creating or updating a collection/playlist whose name contained `:`, `*`, or other special characters failed with no visible reason. `InputValidator` rejected a hardcoded `DangerousFileNameChars` set outright, even though Jellyfin core already handles those characters itself.

## What changed

**Validation (`InputValidator.cs`)** — stop rejecting characters core sanitizes. Core (`ManagedFileSystem.GetValidFilename`) replaces each of `" < > | : * ? \ /` with a space when deriving the *folder* name, while storing the raw name as the item's display name. Rejecting them here double-sanitized and hid a perfectly valid name from the user.

Instead, validate the name core will actually put on disk:

- Reproduce core's sanitization, then reject only names that become degenerate afterwards.
- Reject a sanitized result that is empty, `.`, or `..` — core concatenates the sanitized name straight into `Path.Combine`, so `"..:"` sanitizes to `".."` and escapes to the parent directory. The existing traversal checks are separator-anchored and miss the bare form.
- Reject names that are only dots/whitespace after trimming, since Windows drops trailing dots from a path segment.

Control characters are still rejected outright by the existing check.

**Error surfacing (`config-lists.js`, `config-bulk-actions.js`)** — the original report said the failure was silent. `apiClient.ajax` rejects with the `Response` on a 4xx, so validation failures landed in the `catch` branch and the server's reason was dropped. Both paths now extract the message; bulk convert reports the first server error alongside the failure count instead of a bare count.

**Build fix (`BasicDirectoryService.cs`)** — unrelated to #514, but `main` did not build on `net10.0`. The package reference floats `Jellyfin.Controller` on `12.0.*-*`, which now resolves to stable `12.0.0`; that release added `Invalidate` and `Move` to `IDirectoryService`, failing every net10.0 build with CS0535. Added no-op stubs inside the existing `NET10_0_OR_GREATER` guard, matching the null-implementation behaviour of the rest of the class.

## Verification

- `net10.0` (Jellyfin 12) — build succeeded, 0 warnings
- `net9.0` (Jellyfin 10.11) — build succeeded, 0 warnings
- `dotnet test` — 1628 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * List names can again include common filename characters such as `:`, `*`, `?`, `/`, and `\`.
  * Invalid names—including blank, control-character-only, `.`, and `..` names—remain rejected.
  * Saving and playlist conversion errors now display the server-provided reason.
  * Failed updates preserve entered form values so they can be corrected and retried.
  * Existing lists with previously restricted names can be saved successfully.
  * Names shown in notifications are safely escaped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->