### PR TITLE
fix: collection name collisions after sanitization, and deleted-list resurrection (#515)

### DIFF
--- a/Jellyfin.Plugin.SmartLists.Tests/Utilities/InputValidatorTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Utilities/InputValidatorTests.cs
@@ -1075,4 +1075,25 @@ public class InputValidatorTests
 
         AssertValid(InputValidator.ValidateSmartList(dto));
     }
+
+    // ---------------------------------------------------------------------------------
+    // NamesResolveToSameFolder
+    // ---------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("Marvel: Phase One [Smart]", "Marvel? Phase One [Smart]")] // issue #515
+    [InlineData("Marvel Phase One", "Marvel Phase One")]
+    [InlineData("Marvel Phase One", "MARVEL PHASE ONE")]
+    [InlineData(":Marvel:", "?Marvel?")]
+    [InlineData("A:B", "A B")]
+    public void NamesResolveToSameFolder_CollidingNames_ReturnsTrue(string first, string second)
+    {
+        Assert.True(InputValidator.NamesResolveToSameFolder(first, second));
+    }
+
+    [Fact]
+    public void NamesResolveToSameFolder_GenuinelyDifferentNames_ReturnsFalse()
+    {
+        Assert.False(InputValidator.NamesResolveToSameFolder("Marvel Phase One", "Marvel Phase Two"));
+    }
 }

--- a/Jellyfin.Plugin.SmartLists.Tests/Utilities/InputValidatorTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Utilities/InputValidatorTests.cs
@@ -1086,6 +1086,8 @@ public class InputValidatorTests
     [InlineData("Marvel Phase One", "MARVEL PHASE ONE")]
     [InlineData(":Marvel:", "?Marvel?")]
     [InlineData("A:B", "A B")]
+    [InlineData("AB", "A B")] // control char maps to a space
+    [InlineData("A\tB", "A B")] // tab is a control character
     public void NamesResolveToSameFolder_CollidingNames_ReturnsTrue(string first, string second)
     {
         Assert.True(InputValidator.NamesResolveToSameFolder(first, second));

--- a/Jellyfin.Plugin.SmartLists/Api/Controllers/SmartListController.cs
+++ b/Jellyfin.Plugin.SmartLists/Api/Controllers/SmartListController.cs
@@ -1003,14 +1003,7 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
 
                 // Check for duplicate collection names (Jellyfin doesn't allow collections with the same name)
                 var formattedName = NameFormatter.FormatPlaylistName(collection.Name);
-                var allCollections = await collectionStore.GetAllAsync();
-                // Compare ids as Guids: a restored backup or a client-supplied body can use another valid
-                // representation, and the sanitized-name match means a self-rename (A:B -> A?B) now collides
-                // with itself, so this exclusion is what keeps a valid rename from being called a duplicate.
-                var selfCollectionId = Guid.TryParse(collection.Id, out var parsedSelfCollectionId) ? parsedSelfCollectionId : Guid.Empty;
-                var duplicateCollection = allCollections.FirstOrDefault(c => 
-                    !(Guid.TryParse(c.Id, out var otherCollectionId) && otherCollectionId == selfCollectionId) &&
-                    InputValidator.NamesResolveToSameFolder(NameFormatter.FormatPlaylistName(c.Name), formattedName));
+                var duplicateCollection = await CollectionNameConflict.FindAsync(collectionStore, formattedName, collection.Id);
                 
                 if (duplicateCollection != null)
                 {
@@ -1274,11 +1267,7 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                         // check as a created or renamed one - and it must clear it before the delete-first block
                         // below destroys the playlist, or a rejected conversion would lose the original.
                         var convertedFormattedName = NameFormatter.FormatPlaylistName(collectionDto.Name);
-                        var existingCollectionsForConversion = await GetCollectionStore().GetAllAsync();
-                        var conversionSelfId = Guid.TryParse(collectionDto.Id, out var parsedConversionSelfId) ? parsedConversionSelfId : Guid.Empty;
-                        var conversionDuplicate = existingCollectionsForConversion.FirstOrDefault(c =>
-                            !(Guid.TryParse(c.Id, out var otherConversionId) && otherConversionId == conversionSelfId) &&
-                            InputValidator.NamesResolveToSameFolder(NameFormatter.FormatPlaylistName(c.Name), convertedFormattedName));
+                        var conversionDuplicate = await CollectionNameConflict.FindAsync(GetCollectionStore(), convertedFormattedName, collectionDto.Id);
 
                         if (conversionDuplicate != null)
                         {
@@ -1869,13 +1858,7 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                 if (nameChanging)
                 {
                     var formattedName = NameFormatter.FormatPlaylistName(collection.Name);
-                    var allCollections = await collectionStore.GetAllAsync();
-                    // Compare ids as Guids: a restored backup or a client-supplied body can use another valid
-                    // representation, and the sanitized-name match means a self-rename (A:B -> A?B) now collides
-                    // with itself, so this exclusion is what keeps a valid rename from being called a duplicate.
-                    var duplicateCollection = allCollections.FirstOrDefault(c => 
-                        !(Guid.TryParse(c.Id, out var otherCollectionId) && otherCollectionId == guidId) &&
-                        InputValidator.NamesResolveToSameFolder(NameFormatter.FormatPlaylistName(c.Name), formattedName));
+                    var duplicateCollection = await CollectionNameConflict.FindAsync(collectionStore, formattedName, guidId.ToString());
                     
                     if (duplicateCollection != null)
                     {

--- a/Jellyfin.Plugin.SmartLists/Api/Controllers/SmartListController.cs
+++ b/Jellyfin.Plugin.SmartLists/Api/Controllers/SmartListController.cs
@@ -1005,8 +1005,8 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                 var formattedName = NameFormatter.FormatPlaylistName(collection.Name);
                 var allCollections = await collectionStore.GetAllAsync();
                 var duplicateCollection = allCollections.FirstOrDefault(c => 
-                    c.Id != collection.Id && 
-                    string.Equals(NameFormatter.FormatPlaylistName(c.Name), formattedName, StringComparison.OrdinalIgnoreCase));
+                    c.Id != collection.Id &&
+                    InputValidator.NamesResolveToSameFolder(NameFormatter.FormatPlaylistName(c.Name), formattedName));
                 
                 if (duplicateCollection != null)
                 {
@@ -1014,7 +1014,7 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                     return BadRequest(new ProblemDetails
                     {
                         Title = "Validation Error",
-                        Detail = $"A collection named '{formattedName}' already exists. Jellyfin does not allow multiple collections with the same name.",
+                        Detail = InputValidator.BuildCollectionNameConflictDetail(formattedName, NameFormatter.FormatPlaylistName(duplicateCollection.Name)),
                         Status = StatusCodes.Status400BadRequest
                     });
                 }
@@ -1846,8 +1846,8 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                     var formattedName = NameFormatter.FormatPlaylistName(collection.Name);
                     var allCollections = await collectionStore.GetAllAsync();
                     var duplicateCollection = allCollections.FirstOrDefault(c => 
-                        c.Id != guidId.ToString() && 
-                        string.Equals(NameFormatter.FormatPlaylistName(c.Name), formattedName, StringComparison.OrdinalIgnoreCase));
+                        c.Id != guidId.ToString() &&
+                        InputValidator.NamesResolveToSameFolder(NameFormatter.FormatPlaylistName(c.Name), formattedName));
                     
                     if (duplicateCollection != null)
                     {
@@ -1856,7 +1856,7 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                         return BadRequest(new ProblemDetails
                         {
                             Title = "Validation Error",
-                            Detail = $"A collection named '{formattedName}' already exists. Jellyfin does not allow multiple collections with the same name.",
+                            Detail = InputValidator.BuildCollectionNameConflictDetail(formattedName, NameFormatter.FormatPlaylistName(duplicateCollection.Name)),
                             Status = StatusCodes.Status400BadRequest
                         });
                     }

--- a/Jellyfin.Plugin.SmartLists/Api/Controllers/SmartListController.cs
+++ b/Jellyfin.Plugin.SmartLists/Api/Controllers/SmartListController.cs
@@ -1004,8 +1004,12 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                 // Check for duplicate collection names (Jellyfin doesn't allow collections with the same name)
                 var formattedName = NameFormatter.FormatPlaylistName(collection.Name);
                 var allCollections = await collectionStore.GetAllAsync();
+                // Compare ids as Guids: a restored backup or a client-supplied body can use another valid
+                // representation, and the sanitized-name match means a self-rename (A:B -> A?B) now collides
+                // with itself, so this exclusion is what keeps a valid rename from being called a duplicate.
+                var selfCollectionId = Guid.TryParse(collection.Id, out var parsedSelfCollectionId) ? parsedSelfCollectionId : Guid.Empty;
                 var duplicateCollection = allCollections.FirstOrDefault(c => 
-                    c.Id != collection.Id &&
+                    !(Guid.TryParse(c.Id, out var otherCollectionId) && otherCollectionId == selfCollectionId) &&
                     InputValidator.NamesResolveToSameFolder(NameFormatter.FormatPlaylistName(c.Name), formattedName));
                 
                 if (duplicateCollection != null)
@@ -1264,6 +1268,27 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                         if (existingPlaylist.DateCreated.HasValue)
                         {
                             collectionDto.DateCreated = existingPlaylist.DateCreated;
+                        }
+
+                        // A converted playlist becomes a collection, so it must clear the same folder-collision
+                        // check as a created or renamed one - and it must clear it before the delete-first block
+                        // below destroys the playlist, or a rejected conversion would lose the original.
+                        var convertedFormattedName = NameFormatter.FormatPlaylistName(collectionDto.Name);
+                        var existingCollectionsForConversion = await GetCollectionStore().GetAllAsync();
+                        var conversionSelfId = Guid.TryParse(collectionDto.Id, out var parsedConversionSelfId) ? parsedConversionSelfId : Guid.Empty;
+                        var conversionDuplicate = existingCollectionsForConversion.FirstOrDefault(c =>
+                            !(Guid.TryParse(c.Id, out var otherConversionId) && otherConversionId == conversionSelfId) &&
+                            InputValidator.NamesResolveToSameFolder(NameFormatter.FormatPlaylistName(c.Name), convertedFormattedName));
+
+                        if (conversionDuplicate != null)
+                        {
+                            logger.LogWarning("Cannot convert playlist '{PlaylistName}' to a collection - a collection with a conflicting name already exists", existingPlaylist.Name);
+                            return BadRequest(new ProblemDetails
+                            {
+                                Title = "Validation Error",
+                                Detail = InputValidator.BuildCollectionNameConflictDetail(convertedFormattedName, NameFormatter.FormatPlaylistName(conversionDuplicate.Name)),
+                                Status = StatusCodes.Status400BadRequest
+                            });
                         }
 
                         // Delete-first approach for atomicity: if any deletion fails, original state is preserved
@@ -1845,8 +1870,11 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                 {
                     var formattedName = NameFormatter.FormatPlaylistName(collection.Name);
                     var allCollections = await collectionStore.GetAllAsync();
+                    // Compare ids as Guids: a restored backup or a client-supplied body can use another valid
+                    // representation, and the sanitized-name match means a self-rename (A:B -> A?B) now collides
+                    // with itself, so this exclusion is what keeps a valid rename from being called a duplicate.
                     var duplicateCollection = allCollections.FirstOrDefault(c => 
-                        c.Id != guidId.ToString() &&
+                        !(Guid.TryParse(c.Id, out var otherCollectionId) && otherCollectionId == guidId) &&
                         InputValidator.NamesResolveToSameFolder(NameFormatter.FormatPlaylistName(c.Name), formattedName));
                     
                     if (duplicateCollection != null)
@@ -2040,6 +2068,10 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                 {
                     return BadRequest("Invalid list ID format");
                 }
+
+                // Serialize against the refresh queue: an operation that already reloaded this list
+                // would otherwise finish after the delete and recreate what was just removed.
+                using var processingLock = await _refreshQueueService.AcquireProcessingLockAsync().ConfigureAwait(false);
 
                 // Normalize ID to dashed format for consistent image folder operations
                 var normalizedId = guidId.ToString("D");

--- a/Jellyfin.Plugin.SmartLists/Api/Controllers/UserSmartListController.cs
+++ b/Jellyfin.Plugin.SmartLists/Api/Controllers/UserSmartListController.cs
@@ -333,14 +333,7 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
 
                     // Check for duplicate collection names (Jellyfin doesn't allow collections with the same name)
                     var formattedName = Utilities.NameFormatter.FormatPlaylistName(collectionDto.Name);
-                    var allCollections = await collectionStore.GetAllAsync().ConfigureAwait(false);
-                    // Compare ids as Guids: a restored backup or a client-supplied body can use another valid
-                    // representation, and the sanitized-name match means a self-rename (A:B -> A?B) now collides
-                    // with itself, so this exclusion is what keeps a valid rename from being called a duplicate.
-                    var selfCollectionId = Guid.TryParse(collectionDto.Id, out var parsedSelfCollectionId) ? parsedSelfCollectionId : Guid.Empty;
-                    var duplicateCollection = allCollections.FirstOrDefault(c => 
-                        !(Guid.TryParse(c.Id, out var otherCollectionId) && otherCollectionId == selfCollectionId) &&
-                        Utilities.InputValidator.NamesResolveToSameFolder(Utilities.NameFormatter.FormatPlaylistName(c.Name), formattedName));
+                    var duplicateCollection = await Utilities.CollectionNameConflict.FindAsync(collectionStore, formattedName, collectionDto.Id).ConfigureAwait(false);
                     
                     if (duplicateCollection != null)
                     {
@@ -1272,14 +1265,7 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                     if (nameChanging)
                     {
                         var formattedName = Utilities.NameFormatter.FormatPlaylistName(collectionDto.Name);
-                        var allCollections = await collectionStore.GetAllAsync().ConfigureAwait(false);
-                        // Compare ids as Guids: a restored backup or a client-supplied body can use another valid
-                        // representation, and the sanitized-name match means a self-rename (A:B -> A?B) now collides
-                        // with itself, so this exclusion is what keeps a valid rename from being called a duplicate.
-                        var selfCollectionId = Guid.TryParse(collectionDto.Id, out var parsedSelfCollectionId) ? parsedSelfCollectionId : Guid.Empty;
-                        var duplicateCollection = allCollections.FirstOrDefault(c => 
-                            !(Guid.TryParse(c.Id, out var otherCollectionId) && otherCollectionId == selfCollectionId) &&
-                            Utilities.InputValidator.NamesResolveToSameFolder(Utilities.NameFormatter.FormatPlaylistName(c.Name), formattedName));
+                        var duplicateCollection = await Utilities.CollectionNameConflict.FindAsync(collectionStore, formattedName, collectionDto.Id).ConfigureAwait(false);
                         
                         if (duplicateCollection != null)
                         {
@@ -1621,11 +1607,7 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
             // A converted playlist becomes a collection, so it must clear the same folder-collision check
             // as a created or renamed one.
             var convertedFormattedName = Utilities.NameFormatter.FormatPlaylistName(collectionDto.Name);
-            var existingCollectionsForConversion = await collectionStore.GetAllAsync().ConfigureAwait(false);
-            var conversionSelfId = Guid.TryParse(collectionDto.Id, out var parsedConversionSelfId) ? parsedConversionSelfId : Guid.Empty;
-            var conversionDuplicate = existingCollectionsForConversion.FirstOrDefault(c =>
-                !(Guid.TryParse(c.Id, out var otherConversionId) && otherConversionId == conversionSelfId) &&
-                Utilities.InputValidator.NamesResolveToSameFolder(Utilities.NameFormatter.FormatPlaylistName(c.Name), convertedFormattedName));
+            var conversionDuplicate = await Utilities.CollectionNameConflict.FindAsync(collectionStore, convertedFormattedName, collectionDto.Id).ConfigureAwait(false);
 
             if (conversionDuplicate != null)
             {

--- a/Jellyfin.Plugin.SmartLists/Api/Controllers/UserSmartListController.cs
+++ b/Jellyfin.Plugin.SmartLists/Api/Controllers/UserSmartListController.cs
@@ -335,8 +335,8 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                     var formattedName = Utilities.NameFormatter.FormatPlaylistName(collectionDto.Name);
                     var allCollections = await collectionStore.GetAllAsync().ConfigureAwait(false);
                     var duplicateCollection = allCollections.FirstOrDefault(c => 
-                        c.Id != collectionDto.Id && 
-                        string.Equals(Utilities.NameFormatter.FormatPlaylistName(c.Name), formattedName, StringComparison.OrdinalIgnoreCase));
+                        c.Id != collectionDto.Id &&
+                        Utilities.InputValidator.NamesResolveToSameFolder(Utilities.NameFormatter.FormatPlaylistName(c.Name), formattedName));
                     
                     if (duplicateCollection != null)
                     {
@@ -344,7 +344,7 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                         return BadRequest(new ProblemDetails
                         {
                             Title = "Validation Error",
-                            Detail = $"A collection named '{formattedName}' already exists. Jellyfin does not allow multiple collections with the same name.",
+                            Detail = Utilities.InputValidator.BuildCollectionNameConflictDetail(formattedName, Utilities.NameFormatter.FormatPlaylistName(duplicateCollection.Name)),
                             Status = StatusCodes.Status400BadRequest
                         });
                     }
@@ -1270,8 +1270,8 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                         var formattedName = Utilities.NameFormatter.FormatPlaylistName(collectionDto.Name);
                         var allCollections = await collectionStore.GetAllAsync().ConfigureAwait(false);
                         var duplicateCollection = allCollections.FirstOrDefault(c => 
-                            c.Id != collectionDto.Id && 
-                            string.Equals(Utilities.NameFormatter.FormatPlaylistName(c.Name), formattedName, StringComparison.OrdinalIgnoreCase));
+                            c.Id != collectionDto.Id &&
+                            Utilities.InputValidator.NamesResolveToSameFolder(Utilities.NameFormatter.FormatPlaylistName(c.Name), formattedName));
                         
                         if (duplicateCollection != null)
                         {
@@ -1280,7 +1280,7 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                             return BadRequest(new ProblemDetails
                             {
                                 Title = "Validation Error",
-                                Detail = $"A collection named '{formattedName}' already exists. Jellyfin does not allow multiple collections with the same name.",
+                                Detail = Utilities.InputValidator.BuildCollectionNameConflictDetail(formattedName, Utilities.NameFormatter.FormatPlaylistName(duplicateCollection.Name)),
                                 Status = StatusCodes.Status400BadRequest
                             });
                         }

--- a/Jellyfin.Plugin.SmartLists/Api/Controllers/UserSmartListController.cs
+++ b/Jellyfin.Plugin.SmartLists/Api/Controllers/UserSmartListController.cs
@@ -334,8 +334,12 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                     // Check for duplicate collection names (Jellyfin doesn't allow collections with the same name)
                     var formattedName = Utilities.NameFormatter.FormatPlaylistName(collectionDto.Name);
                     var allCollections = await collectionStore.GetAllAsync().ConfigureAwait(false);
+                    // Compare ids as Guids: a restored backup or a client-supplied body can use another valid
+                    // representation, and the sanitized-name match means a self-rename (A:B -> A?B) now collides
+                    // with itself, so this exclusion is what keeps a valid rename from being called a duplicate.
+                    var selfCollectionId = Guid.TryParse(collectionDto.Id, out var parsedSelfCollectionId) ? parsedSelfCollectionId : Guid.Empty;
                     var duplicateCollection = allCollections.FirstOrDefault(c => 
-                        c.Id != collectionDto.Id &&
+                        !(Guid.TryParse(c.Id, out var otherCollectionId) && otherCollectionId == selfCollectionId) &&
                         Utilities.InputValidator.NamesResolveToSameFolder(Utilities.NameFormatter.FormatPlaylistName(c.Name), formattedName));
                     
                     if (duplicateCollection != null)
@@ -1269,8 +1273,12 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                     {
                         var formattedName = Utilities.NameFormatter.FormatPlaylistName(collectionDto.Name);
                         var allCollections = await collectionStore.GetAllAsync().ConfigureAwait(false);
+                        // Compare ids as Guids: a restored backup or a client-supplied body can use another valid
+                        // representation, and the sanitized-name match means a self-rename (A:B -> A?B) now collides
+                        // with itself, so this exclusion is what keeps a valid rename from being called a duplicate.
+                        var selfCollectionId = Guid.TryParse(collectionDto.Id, out var parsedSelfCollectionId) ? parsedSelfCollectionId : Guid.Empty;
                         var duplicateCollection = allCollections.FirstOrDefault(c => 
-                            c.Id != collectionDto.Id &&
+                            !(Guid.TryParse(c.Id, out var otherCollectionId) && otherCollectionId == selfCollectionId) &&
                             Utilities.InputValidator.NamesResolveToSameFolder(Utilities.NameFormatter.FormatPlaylistName(c.Name), formattedName));
                         
                         if (duplicateCollection != null)
@@ -1343,6 +1351,10 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                 {
                     return BadRequest(new { message = "Invalid list ID format" });
                 }
+
+                // Serialize against the refresh queue: an operation that already reloaded this list
+                // would otherwise finish after the delete and recreate what was just removed.
+                using var processingLock = await _refreshQueueService.AcquireProcessingLockAsync().ConfigureAwait(false);
 
                 // Normalize ID to dashed format for consistent cache operations
                 var normalizedId = guidId.ToString("D");
@@ -1605,6 +1617,26 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
             
             var collectionStore = _collectionStore;
             var playlistStore = _playlistStore;
+
+            // A converted playlist becomes a collection, so it must clear the same folder-collision check
+            // as a created or renamed one.
+            var convertedFormattedName = Utilities.NameFormatter.FormatPlaylistName(collectionDto.Name);
+            var existingCollectionsForConversion = await collectionStore.GetAllAsync().ConfigureAwait(false);
+            var conversionSelfId = Guid.TryParse(collectionDto.Id, out var parsedConversionSelfId) ? parsedConversionSelfId : Guid.Empty;
+            var conversionDuplicate = existingCollectionsForConversion.FirstOrDefault(c =>
+                !(Guid.TryParse(c.Id, out var otherConversionId) && otherConversionId == conversionSelfId) &&
+                Utilities.InputValidator.NamesResolveToSameFolder(Utilities.NameFormatter.FormatPlaylistName(c.Name), convertedFormattedName));
+
+            if (conversionDuplicate != null)
+            {
+                _logger.LogWarning("User {UserId} cannot convert playlist '{PlaylistName}' to a collection - a collection with a conflicting name already exists", userId, existingPlaylist.Name);
+                return BadRequest(new ProblemDetails
+                {
+                    Title = "Validation Error",
+                    Detail = Utilities.InputValidator.BuildCollectionNameConflictDetail(convertedFormattedName, Utilities.NameFormatter.FormatPlaylistName(conversionDuplicate.Name)),
+                    Status = StatusCodes.Status400BadRequest
+                });
+            }
             
             // Save-first approach: persist new collection before deleting old playlist
             try

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
@@ -329,21 +329,31 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
             // after the queue item was created but before processing started
             var fileSystem = new SmartListFileSystem(_applicationPaths);
 
+            // Each branch below reloads the DTO from the store: a list deleted after this operation was
+            // queued is gone from the store, and must not be resurrected from the stale enqueued DTO.
+            // A delete landing after the reload but during materialization is still possible; closing that
+            // window would require the delete path to take the queue's _processingLock.
             if (item.ListType == SmartListType.Playlist)
             {
                 var playlistStore = new PlaylistStore(fileSystem);
                 if (Guid.TryParse(item.ListId, out var listGuid))
                 {
                     var latestDto = await playlistStore.GetByIdAsync(listGuid);
-                    if (latestDto != null)
+                    if (latestDto == null)
                     {
-                        _logger.LogDebug("Reloaded playlist '{PlaylistName}' from store (CustomImages: {HasImages})",
-                            latestDto.Name, latestDto.CustomImages?.Count > 0);
-                        await ProcessPlaylistRefreshAsync(latestDto, item.TriggeringUserIds, cancellationToken);
+                        // The list was deleted after this operation was queued. Falling back to the DTO captured at
+                        // enqueue time would re-create the playlist and rewrite its config.json, resurrecting
+                        // a list the user deleted.
+                        _logger.LogInformation("Skipping {OperationType} operation for playlist '{ListName}' ({ListId}) - it no longer exists in the store.",
+                            item.OperationType, item.ListName, item.ListId);
                         return;
                     }
+                    _logger.LogDebug("Reloaded playlist '{PlaylistName}' from store (CustomImages: {HasImages})",
+                        latestDto.Name, latestDto.CustomImages?.Count > 0);
+                    await ProcessPlaylistRefreshAsync(latestDto, item.TriggeringUserIds, cancellationToken);
+                    return;
                 }
-                // Fallback to original DTO if reload fails
+                // Only reached when the list id is not a valid Guid - a deleted list returns above.
                 await ProcessPlaylistRefreshAsync((SmartPlaylistDto)item.ListData, item.TriggeringUserIds, cancellationToken);
             }
             else if (item.ListType == SmartListType.Collection)
@@ -352,15 +362,21 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                 if (Guid.TryParse(item.ListId, out var listGuid))
                 {
                     var latestDto = await collectionStore.GetByIdAsync(listGuid);
-                    if (latestDto != null)
+                    if (latestDto == null)
                     {
-                        _logger.LogDebug("Reloaded collection '{CollectionName}' from store (CustomImages: {HasImages})",
-                            latestDto.Name, latestDto.CustomImages?.Count > 0);
-                        await ProcessCollectionRefreshAsync(latestDto, cancellationToken);
+                        // The list was deleted after this operation was queued. Falling back to the DTO captured at
+                        // enqueue time would re-create the collection folder and rewrite its config.json, resurrecting
+                        // a list the user deleted.
+                        _logger.LogInformation("Skipping {OperationType} operation for collection '{ListName}' ({ListId}) - it no longer exists in the store.",
+                            item.OperationType, item.ListName, item.ListId);
                         return;
                     }
+                    _logger.LogDebug("Reloaded collection '{CollectionName}' from store (CustomImages: {HasImages})",
+                        latestDto.Name, latestDto.CustomImages?.Count > 0);
+                    await ProcessCollectionRefreshAsync(latestDto, cancellationToken);
+                    return;
                 }
-                // Fallback to original DTO if reload fails
+                // Only reached when the list id is not a valid Guid - a deleted list returns above.
                 await ProcessCollectionRefreshAsync((SmartCollectionDto)item.ListData, cancellationToken);
             }
             else

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
@@ -149,6 +149,36 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
         /// <summary>
         /// Gets the count of items waiting in the queue (excludes currently processing item).
         /// </summary>
+        /// <summary>
+        /// Takes the queue's processing lock and returns a scope that releases it on dispose, so the
+        /// caller cannot interleave with an operation that is already materializing a list. Deletes need
+        /// this: the queue reloads a list from the store before building it, and a delete landing after
+        /// that reload leaves the operation recreating what was just deleted. Holding the lock makes the
+        /// delete wait for the in-flight operation instead. The queue never deletes lists itself, so this
+        /// cannot deadlock.
+        /// </summary>
+        public async Task<IDisposable> AcquireProcessingLockAsync(CancellationToken cancellationToken = default)
+        {
+            await _processingLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            return new ProcessingLockScope(_processingLock);
+        }
+
+        private sealed class ProcessingLockScope : IDisposable
+        {
+            private SemaphoreSlim? _semaphore;
+
+            public ProcessingLockScope(SemaphoreSlim semaphore)
+            {
+                _semaphore = semaphore;
+            }
+
+            public void Dispose()
+            {
+                // Exchange so a double dispose cannot release the semaphore twice.
+                Interlocked.Exchange(ref _semaphore, null)?.Release();
+            }
+        }
+
         public int GetQueueCount()
         {
             return _queue.Count;

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/RefreshQueueService.cs
@@ -341,11 +341,23 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                     var latestDto = await playlistStore.GetByIdAsync(listGuid);
                     if (latestDto == null)
                     {
-                        // The list was deleted after this operation was queued. Falling back to the DTO captured at
-                        // enqueue time would re-create the playlist and rewrite its config.json, resurrecting
-                        // a list the user deleted.
-                        _logger.LogInformation("Skipping {OperationType} operation for playlist '{ListName}' ({ListId}) - it no longer exists in the store.",
-                            item.OperationType, item.ListName, item.ListId);
+                        // GetByIdAsync returns null both for a list that was deleted and for one whose config
+                        // file cannot be read or deserialized, so ask the file system which case this is.
+                        if (fileSystem.GetSmartListFilePath(item.ListId) == null)
+                        {
+                            // Genuinely deleted after this operation was queued. Falling back to the DTO captured
+                            // at enqueue time would rebuild the playlist and rewrite its config.json, resurrecting
+                            // a list the user deleted.
+                            _logger.LogInformation("Skipping {OperationType} operation for playlist '{ListName}' ({ListId}) - it no longer exists in the store.",
+                                item.OperationType, item.ListName, item.ListId);
+                            return;
+                        }
+
+                        // The config file is still there but could not be loaded. Refresh from the queued copy
+                        // rather than silently skipping, and surface the storage failure.
+                        _logger.LogWarning("Could not load playlist '{ListName}' ({ListId}) from its config file; refreshing from the copy captured when the operation was queued.",
+                            item.ListName, item.ListId);
+                        await ProcessPlaylistRefreshAsync((SmartPlaylistDto)item.ListData, item.TriggeringUserIds, cancellationToken);
                         return;
                     }
                     _logger.LogDebug("Reloaded playlist '{PlaylistName}' from store (CustomImages: {HasImages})",
@@ -364,11 +376,23 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                     var latestDto = await collectionStore.GetByIdAsync(listGuid);
                     if (latestDto == null)
                     {
-                        // The list was deleted after this operation was queued. Falling back to the DTO captured at
-                        // enqueue time would re-create the collection folder and rewrite its config.json, resurrecting
-                        // a list the user deleted.
-                        _logger.LogInformation("Skipping {OperationType} operation for collection '{ListName}' ({ListId}) - it no longer exists in the store.",
-                            item.OperationType, item.ListName, item.ListId);
+                        // GetByIdAsync returns null both for a list that was deleted and for one whose config
+                        // file cannot be read or deserialized, so ask the file system which case this is.
+                        if (fileSystem.GetSmartListFilePath(item.ListId) == null)
+                        {
+                            // Genuinely deleted after this operation was queued. Falling back to the DTO captured
+                            // at enqueue time would rebuild the collection and rewrite its config.json, resurrecting
+                            // a list the user deleted.
+                            _logger.LogInformation("Skipping {OperationType} operation for collection '{ListName}' ({ListId}) - it no longer exists in the store.",
+                                item.OperationType, item.ListName, item.ListId);
+                            return;
+                        }
+
+                        // The config file is still there but could not be loaded. Refresh from the queued copy
+                        // rather than silently skipping, and surface the storage failure.
+                        _logger.LogWarning("Could not load collection '{ListName}' ({ListId}) from its config file; refreshing from the copy captured when the operation was queued.",
+                            item.ListName, item.ListId);
+                        await ProcessCollectionRefreshAsync((SmartCollectionDto)item.ListData, cancellationToken);
                         return;
                     }
                     _logger.LogDebug("Reloaded collection '{CollectionName}' from store (CustomImages: {HasImages})",

--- a/Jellyfin.Plugin.SmartLists/Utilities/CollectionNameConflict.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/CollectionNameConflict.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SmartLists.Core.Models;
+using Jellyfin.Plugin.SmartLists.Services.Abstractions;
+
+namespace Jellyfin.Plugin.SmartLists.Utilities
+{
+    /// <summary>
+    /// Finds the collection, if any, whose name would land on the same folder as a candidate name.
+    /// Every path that saves a collection - create, rename, and playlist-to-collection conversion, on
+    /// both the admin and the user API - goes through here, so the checks cannot drift apart.
+    /// </summary>
+    public static class CollectionNameConflict
+    {
+        /// <summary>
+        /// Returns the existing collection that would share a folder with <paramref name="candidateFormattedName"/>,
+        /// or null when there is none.
+        /// </summary>
+        /// <param name="collectionStore">Store to scan.</param>
+        /// <param name="candidateFormattedName">The candidate name, already run through <see cref="NameFormatter"/>.</param>
+        /// <param name="selfListId">Id of the list being saved, excluded from the match so a list never conflicts with itself.</param>
+        public static async Task<SmartCollectionDto?> FindAsync(
+            ISmartListStore<SmartCollectionDto> collectionStore,
+            string candidateFormattedName,
+            string? selfListId)
+        {
+            ArgumentNullException.ThrowIfNull(collectionStore);
+
+            var allCollections = await collectionStore.GetAllAsync().ConfigureAwait(false);
+
+            // Compare ids as Guids: a restored backup or a client-supplied body can use another valid
+            // representation, and the sanitized-name match means a self-rename (A:B -> A?B) now collides
+            // with itself, so this exclusion is what keeps a valid rename from being called a duplicate.
+            var selfId = Guid.TryParse(selfListId, out var parsedSelfId) ? parsedSelfId : Guid.Empty;
+
+            return allCollections.FirstOrDefault(c =>
+                !(Guid.TryParse(c.Id, out var otherId) && otherId == selfId) &&
+                InputValidator.NamesResolveToSameFolder(NameFormatter.FormatPlaylistName(c.Name), candidateFormattedName));
+        }
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Utilities/InputValidator.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/InputValidator.cs
@@ -165,6 +165,32 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
         }
 
         /// <summary>
+        /// Returns true when two already-formatted list names would resolve to the same folder on disk.
+        /// Jellyfin core replaces every character it treats as invalid with a space when it derives a
+        /// collection's folder name, and derives the item's id from that path - so two names differing
+        /// only in those characters silently share one BoxSet.
+        /// </summary>
+        internal static bool NamesResolveToSameFolder(string first, string second)
+        {
+            return string.Equals(SanitizedFolderName(first), SanitizedFolderName(second), StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Builds the validation message for a collection name conflict. Names that are already equal get
+        /// the plain duplicate message; names that collide only after core's sanitization need to say why,
+        /// because the two names visibly differ on screen.
+        /// </summary>
+        internal static string BuildCollectionNameConflictDetail(string candidateFormatted, string existingFormatted)
+        {
+            if (string.Equals(candidateFormatted, existingFormatted, StringComparison.OrdinalIgnoreCase))
+            {
+                return $"A collection named '{candidateFormatted}' already exists. Jellyfin does not allow multiple collections with the same name.";
+            }
+
+            return $"A collection named '{existingFormatted}' already exists, and Jellyfin replaces the characters \" < > | : * ? \\ / with spaces when it creates the collection folder - so '{candidateFormatted}' would end up sharing that same collection. Choose a name that differs by more than those characters.";
+        }
+
+        /// <summary>
         /// Validates a string value (used in expressions).
         /// </summary>
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Utilities/InputValidator.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/InputValidator.cs
@@ -85,8 +85,10 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
         // Path.GetInvalidFileNameChars(), so it is identical on Linux and Windows - which is why this
         // plugin neither rejects nor sanitizes these characters itself: doing so would double-sanitize,
         // and since the display name is re-asserted after every refresh it would also make the
-        // sanitized form the user-visible name. Core's list also covers control chars 1-31, which the
-        // control-character check above already rejects outright.
+        // sanitized form the user-visible name. The punctuation is spelled out here as a literal
+        // array; control characters (also in core's list) are handled via char.IsControl in
+        // SanitizedFolderName below, because collection restore (SmartListController.RestoreCollection...)
+        // saves names without going through ValidateName, so a restored name can still contain them.
         private static readonly char[] JellyfinSanitizedChars = new[] { '"', '<', '>', '|', ':', '*', '?', '\\', '/' };
 
         /// <summary>
@@ -155,7 +157,7 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
             var chars = name.ToCharArray();
             for (var i = 0; i < chars.Length; i++)
             {
-                if (Array.IndexOf(JellyfinSanitizedChars, chars[i]) >= 0)
+                if (Array.IndexOf(JellyfinSanitizedChars, chars[i]) >= 0 || char.IsControl(chars[i]))
                 {
                     chars[i] = ' ';
                 }

--- a/docs/content/changelog/rc.md
+++ b/docs/content/changelog/rc.md
@@ -26,6 +26,7 @@ itself (`v10.10.10.0-rc3`), which is the scheme used before the number moved int
 - List names are escaped in the notifications that show them, so a name containing HTML can no longer affect the page.
 - Two smart collections whose names differ only in the characters Jellyfin rewrites — *Marvel: Phase One* and *Marvel? Phase One* — can no longer be created. Both names become the same folder, so Jellyfin quietly gave the two lists **one shared collection**: each refresh renamed it and took it over from the other, with nothing reported in either list. Naming a collection so that it would collide with an existing one is now refused up front, and the message names the collection it clashes with ([#515](https://github.com/jyourstone/jellyfin-smartlists-plugin/issues/515)).
 - **Deleting a list right after editing it no longer brings it back.** Saving a change queues a refresh, and a delete arriving before that refresh ran did not stop it: the refresh rebuilt the list from the copy captured when it was queued, restoring its folder, its images and its stored configuration, so the deleted list reappeared in the list view ([#515](https://github.com/jyourstone/jellyfin-smartlists-plugin/pull/518)).
+- Converting a playlist into a collection is now refused when the resulting collection would share a folder with an existing one. Conversion previously skipped the duplicate-name check entirely, so it could produce the shared-collection state described above; the playlist is left untouched when the conversion is refused.
 
 
 ## v12.0.0.20-rc

--- a/docs/content/changelog/rc.md
+++ b/docs/content/changelog/rc.md
@@ -25,6 +25,7 @@ itself (`v10.10.10.0-rc3`), which is the scheme used before the number moved int
 - A failed update no longer discards the edits in the form. The form was being reloaded from the saved copy, wiping out whatever had just been typed; it now stays as-is so the change can be corrected and resubmitted.
 - List names are escaped in the notifications that show them, so a name containing HTML can no longer affect the page.
 - Two smart collections whose names differ only in the characters Jellyfin rewrites — *Marvel: Phase One* and *Marvel? Phase One* — can no longer be created. Both names become the same folder, so Jellyfin quietly gave the two lists **one shared collection**: each refresh renamed it and took it over from the other, with nothing reported in either list. Naming a collection so that it would collide with an existing one is now refused up front, and the message names the collection it clashes with ([#515](https://github.com/jyourstone/jellyfin-smartlists-plugin/issues/515)).
+- **Deleting a list right after editing it no longer brings it back.** Saving a change queues a refresh, and a delete arriving before that refresh ran did not stop it: the refresh rebuilt the list from the copy captured when it was queued, restoring its folder, its images and its stored configuration, so the deleted list reappeared in the list view ([#515](https://github.com/jyourstone/jellyfin-smartlists-plugin/pull/518)).
 
 
 ## v12.0.0.20-rc

--- a/docs/content/changelog/rc.md
+++ b/docs/content/changelog/rc.md
@@ -24,6 +24,7 @@ itself (`v10.10.10.0-rc3`), which is the scheme used before the number moved int
 - **Saving a list now reports why it failed.** A rejected update showed no message whatsoever: a bug in the error handler threw before the notification was reached, so the save simply appeared to do nothing. Converting lists between playlist and collection was similarly silent, in both the single and bulk actions, and now shows the server's reason.
 - A failed update no longer discards the edits in the form. The form was being reloaded from the saved copy, wiping out whatever had just been typed; it now stays as-is so the change can be corrected and resubmitted.
 - List names are escaped in the notifications that show them, so a name containing HTML can no longer affect the page.
+- Two smart collections whose names differ only in the characters Jellyfin rewrites — *Marvel: Phase One* and *Marvel? Phase One* — can no longer be created. Both names become the same folder, so Jellyfin quietly gave the two lists **one shared collection**: each refresh renamed it and took it over from the other, with nothing reported in either list. Naming a collection so that it would collide with an existing one is now refused up front, and the message names the collection it clashes with ([#515](https://github.com/jyourstone/jellyfin-smartlists-plugin/issues/515)).
 
 
 ## v12.0.0.20-rc


### PR DESCRIPTION
Fixes #515, plus a second bug found while verifying it.

---

## 1. Collection names colliding after sanitization (#515)

Jellyfin core replaces every character it treats as invalid with a **space** when deriving a collection's folder name, then derives the item id from that path. Two smart collections whose names differ only in those characters resolve to the same folder, and so to the same `BoxSet`.

Reproduced against the dev container ([full writeup](https://github.com/jyourstone/jellyfin-smartlists-plugin/issues/515#issuecomment-5580871886)) — the observed mechanism differs from the original guess in two ways:

- **Core reuses rather than rejects.** Creating `Marvel: Phase One` then `Marvel? Phase One` produced one folder, one `BoxSet`, and both DTOs storing the same `JellyfinCollectionId`. Both creates returned 201 and logged `Success=True`.
- **The failure is completely silent.** The tether guard cited in the issue lives in `RemoveSmartSuffixAsync`, not the refresh path — the refresh path has no tether check at all. So instead of skipping, each refresh renames the shared item and takes the tether from the other list, confirmed in both directions. No warning, no error; both lists look healthy while one collection's name flips on every refresh.

The four collection duplicate-name checks missed this because they compared the **raw** formatted name.

**Fix.** Compare the **sanitized** form, reusing the transform `InputValidator` already models after core's — one definition of "what core will call this folder".

- `NamesResolveToSameFolder` is case-insensitive, so it fully replaces the old comparison. Strictly wider, so exact duplicates are still caught.
- Each check keeps its existing self-exclusion (`c.Id != …`), so renaming a list to a variant of its own name still works.
- `BuildCollectionNameConflictDetail` — a sanitization-only collision involves two names that visibly differ, so the message names the collection being clashed with and says why. Exact duplicates keep the previous wording.

Playlists are untouched: core's `PlaylistManager` de-duplicates folder names, so they never collide.

| Case | Result |
|---|---|
| create `Marvel: Phase One` | 201 |
| create `Marvel? Phase One` (sanitize-collision) | **400** + explanatory message |
| create `Marvel: Phase One` (exact duplicate) | **400** + original message |
| create `Marvel Phase Two` (genuinely different) | 201 |
| rename `Marvel Phase Two` → `Marvel? Phase One` | **400** |
| rename `Marvel: Phase One` → `Marvel* Phase One` (self) | **200** — not falsely blocked |

---

## 2. A list deleted while a refresh was queued came back

Found while cleaning up after the repro above: a deleted collection's folder and `config.json` reappeared on disk in the same second the delete completed.

Saving a list enqueues a refresh. A delete arriving before that refresh ran did not stop it — the queued operation rebuilt the list from the DTO captured at enqueue time, restoring its folder, its collage images and its stored configuration. **The deleted list reappeared in `GET /Plugins/SmartLists`.**

```
09:35:58 PUT     SaveAsync writes config.json -> Enqueued Edit operation
09:35:58 DELETE  deletes BoxSet + image folder + cache entry, returns 204
09:35:58 Edit    Processing starts - after the delete
09:35:59 Edit    Success=True -> folder + config.json re-created
```

**Root cause.** `ProcessRefreshAsync` already reloads the DTO from the store, and `GetByIdAsync` correctly returns `null` once the list is gone — but both the playlist and collection branches treated `null` as "reload failed" and fell through to `// Fallback to original DTO if reload fails`. That fallback exists for an id that will not parse as a `Guid`; a deleted list is a different case.

**Fix.** Return early on a null reload in both branches, leaving the fallback reachable only for an unparseable id. Every queued operation routes through this one path, so this covers all 27 enqueue callers and both delete APIs.

**Scope — this closes the common window, not all of it.** Verified against the container: a delete arriving while the
operation is *queued but not yet started* is now skipped (`Skipping Edit operation for collection '…' - it no longer
exists in the store.`) and the list stays deleted, while a normal edit still refreshes and the guard does not over-fire.

A delete that lands after the operation has already reloaded and begun materializing still resurrects the list — the
reload legitimately succeeded, so no guard fires. A PUT followed immediately by a DELETE hits this reliably. Closing it
needs the delete path to serialize against the queue's `_processingLock`, or the queue to self-heal after an operation
whose list vanished mid-flight; both are design changes beyond this PR, and tracked separately.

This bug predates the PR, so the partial fix is still a strict improvement over `main`.

`GetByIdAsync` also returns null when a list's `config.json` exists but cannot be read — `CollectionStore` swallows the
load exception. Treating that as deletion would silently skip the refresh, so the guard asks the file system which case
it is: no config file means deleted (skip), a present-but-unloadable file means a storage problem (refresh from the
queued copy, and warn). Raised by Greptile.

---

## Verification

`net10.0` and `net9.0` build clean (0 warnings). `dotnet test` — **1634 passed, 0 failed** (+6 new). Both fixes exercised end-to-end against the dev container, as tabulated above.

## Not covered

- Installs that **already** have a colliding pair stay broken — the name checks only run on create and rename. Repairing existing collisions would need a migration.
- A delete landing *after* the queue's reload but during materialization still resurrects the list — reproducible with a PUT followed immediately by a DELETE. Needs the delete path to serialize against `_processingLock`, or post-operation self-healing. Not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented deleted lists from being recreated by queued refreshes, including their folders, images, and saved settings.
  - Improved handling of unreadable list configuration files while preserving the latest available list information.
  - More accurately detects collection-name conflicts when different names produce the same folder, with clearer conflict details.
  - Prevented playlist-to-collection conversion when the resulting collection would conflict with an existing folder, leaving the playlist unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->