### PR TITLE
Add Aspect Ratio rule field

### DIFF
--- a/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/AspectRatioTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/AspectRatioTests.cs
@@ -1,0 +1,82 @@
+using Jellyfin.Plugin.SmartLists.Core.Constants;
+using Jellyfin.Plugin.SmartLists.Core.QueryEngine;
+
+namespace Jellyfin.Plugin.SmartLists.Tests.Core.QueryEngine;
+
+public class AspectRatioTests
+{
+    private static Func<Operand, bool> Compile(string op, string target)
+        => Engine.CompileRule<Operand>(new Expression("AspectRatio", op, target), string.Empty);
+
+    private static Operand Item(string aspectRatio) => new("item") { AspectRatio = aspectRatio };
+
+    [Theory]
+    [InlineData("16:9", true)]
+    [InlineData("2.35:1", true)]
+    [InlineData("80:29", true)]
+    [InlineData(" 9 : 16 ", true)]
+    [InlineData("", false)]
+    [InlineData("16", false)]
+    [InlineData("16:0", false)]
+    [InlineData("-16:9", false)]
+    public void IsValid_RequiresTwoPositiveComponents(string value, bool expected)
+    {
+        Assert.Equal(expected, AspectRatioTypes.IsValid(value));
+    }
+
+    [Theory]
+    [InlineData("Equal", "160:58", "80:29", true)]
+    [InlineData("NotEqual", "16:9", "4:3", true)]
+    [InlineData("LessThan", "9:16", "1:1", true)]
+    [InlineData("GreaterThan", "80:29", "2.40:1", true)]
+    [InlineData("GreaterThanOrEqual", "16:9", "32:18", true)]
+    [InlineData("LessThanOrEqual", "1:1", "1:1", true)]
+    public void CompileRule_RatioComparisonsUseNumericProportions(string op, string actual, string target, bool expected)
+    {
+        Assert.Equal(expected, Compile(op, target)(Item(actual)));
+    }
+
+    [Theory]
+    [InlineData("IsIn", "16:9", "4:3;32:18", true)]
+    [InlineData("IsIn", "2.35:1", "2.3:1;16:9", false)]
+    [InlineData("IsNotIn", "80:29", "16:9;4:3", true)]
+    [InlineData("IsNotIn", "80:29", "160:58;4:3", false)]
+    public void CompileRule_MembershipUsesExactNumericRatios(string op, string actual, string targets, bool expected)
+    {
+        Assert.Equal(expected, Compile(op, targets)(Item(actual)));
+    }
+
+    [Theory]
+    [InlineData("NotEqual", "16:9")]
+    [InlineData("IsNotIn", "16:9;4:3")]
+    [InlineData("LessThan", "1:1")]
+    [InlineData("MatchRegex", "^$")]
+    public void CompileRule_MissingRatioNeverMatches(string op, string target)
+    {
+        Assert.False(Compile(op, target)(Item(string.Empty)));
+    }
+
+    [Fact]
+    public void CompileRule_RegexTargetsJellyfinRawValue()
+    {
+        Assert.True(Compile("MatchRegex", "^[0-9]+:29$")(Item("80:29")));
+        Assert.False(Compile("MatchRegex", "^2\\.76:1$")(Item("80:29")));
+    }
+
+    [Theory]
+    [InlineData("Contains")]
+    [InlineData("NotContains")]
+    public void CompileRule_SubstringOperatorsAreRejected(string op)
+    {
+        Assert.Throws<ArgumentException>(() => Compile(op, "2.3"));
+    }
+
+    [Theory]
+    [InlineData("Equal", "not-a-ratio")]
+    [InlineData("IsIn", "16:9;invalid")]
+    [InlineData("IsNotIn", "")]
+    public void CompileRule_InvalidTargetsAreRejected(string op, string target)
+    {
+        Assert.Throws<ArgumentException>(() => Compile(op, target));
+    }
+}

--- a/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/AspectRatioTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/AspectRatioTests.cs
@@ -25,6 +25,40 @@ public class AspectRatioTests
     }
 
     [Theory]
+    [InlineData("100000:1", true)]
+    [InlineData("1:100000", true)]
+    [InlineData("0.0001:1", true)]
+    [InlineData("100001:1", false)]
+    [InlineData("1:100001", false)]
+    [InlineData("0.00009:1", false)]
+    [InlineData("99999999999999999999:1", false)]
+    public void IsValid_RejectsComponentsOutsideSupportedRange(string value, bool expected)
+    {
+        Assert.Equal(expected, AspectRatioTypes.IsValid(value));
+    }
+
+    [Fact]
+    public void CompileRule_ExtremeTargetIsRejectedInsteadOfOverflowing()
+    {
+        Assert.Throws<ArgumentException>(() => Compile("GreaterThan", "99999999999999999999:1"));
+    }
+
+    [Fact]
+    public void CompileRule_ExtremeItemRatioNeverMatches()
+    {
+        var isWide = Compile("GreaterThan", "1:1");
+        Assert.False(isWide(Item("99999999999999999999:0.0000000001")));
+    }
+
+    [Fact]
+    public void Evaluate_NearOverflowComponentsStayOrdered()
+    {
+        // Both cross-products land at 1e10, the arithmetic worst case the bounds allow.
+        Assert.True(AspectRatioTypes.Evaluate("100000:0.0001", "99999:0.0001", "GreaterThan"));
+        Assert.True(AspectRatioTypes.Evaluate("0.0001:100000", "0.0001:99999", "LessThan"));
+    }
+
+    [Theory]
     [InlineData("Equal", "160:58", "80:29", true)]
     [InlineData("NotEqual", "16:9", "4:3", true)]
     [InlineData("LessThan", "9:16", "1:1", true)]

--- a/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/AspectRatioTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/AspectRatioTests.cs
@@ -51,6 +51,31 @@ public class AspectRatioTests
     }
 
     [Fact]
+    public void Evaluate_RatiosDifferingBeyondSupportedPrecisionCompareEqual()
+    {
+        // Both sides round to 1:1 at the supported precision. Treating them as equal is the
+        // deliberate trade for exact comparison; ordering them would mean ordering by digits
+        // no display format carries.
+        const string overSpecified = "1.0000000000000000000000000001:1.0000000000000000000000000002";
+        const string target = "1:1.0000000000000000000000000001";
+
+        Assert.True(AspectRatioTypes.Evaluate(overSpecified, target, "Equal"));
+        Assert.False(AspectRatioTypes.Evaluate(overSpecified, target, "GreaterThan"));
+        Assert.False(AspectRatioTypes.Evaluate(overSpecified, target, "LessThan"));
+    }
+
+    [Fact]
+    public void Evaluate_DifferencesWithinSupportedPrecisionStayExact()
+    {
+        Assert.True(AspectRatioTypes.Evaluate("1.00000001:1", "1:1", "GreaterThan"));
+        Assert.True(AspectRatioTypes.Evaluate("1:1.00000001", "1:1", "LessThan"));
+        Assert.True(AspectRatioTypes.Evaluate("1.00000001:1", "1.00000002:1", "LessThan"));
+
+        // Worst case the bounds allow: full magnitude and full precision on both operands.
+        Assert.True(AspectRatioTypes.Evaluate("99999.99999999:0.0001", "99999.99999998:0.0001", "GreaterThan"));
+    }
+
+    [Fact]
     public void Evaluate_NearOverflowComponentsStayOrdered()
     {
         // Both cross-products land at 1e10, the arithmetic worst case the bounds allow.

--- a/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/FieldRegistryInvariantTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/QueryEngine/FieldRegistryInvariantTests.cs
@@ -59,6 +59,7 @@ public class FieldRegistryInvariantTests
         FieldType.Simple => clr == typeof(string),
         FieldType.UserData => clr == typeof(string),
         FieldType.Resolution => clr == typeof(string),
+        FieldType.AspectRatio => clr == typeof(string),
         FieldType.Framerate => clr == typeof(float?),
         FieldType.Boolean => clr == typeof(bool),
         FieldType.Date => clr == typeof(double),
@@ -70,7 +71,7 @@ public class FieldRegistryInvariantTests
 
     private static string ExpectedClrDescription(FieldType type) => type switch
     {
-        FieldType.Text or FieldType.Simple or FieldType.UserData or FieldType.Resolution => "string",
+        FieldType.Text or FieldType.Simple or FieldType.UserData or FieldType.Resolution or FieldType.AspectRatio => "string",
         FieldType.Framerate => "float?",
         FieldType.Boolean => "bool",
         FieldType.Date => "double (unix seconds)",
@@ -372,6 +373,7 @@ public class FieldRegistryInvariantTests
             ("IsBooleanField", FieldType.Boolean, FieldRegistry.IsBooleanField),
             ("IsSimpleField", FieldType.Simple, FieldRegistry.IsSimpleField),
             ("IsResolutionField", FieldType.Resolution, FieldRegistry.IsResolutionField),
+            ("IsAspectRatioField", FieldType.AspectRatio, FieldRegistry.IsAspectRatioField),
             ("IsFramerateField", FieldType.Framerate, FieldRegistry.IsFramerateField),
             ("IsSimilarityField", FieldType.Similarity, FieldRegistry.IsSimilarityField),
         };

--- a/Jellyfin.Plugin.SmartLists.Tests/Utilities/MediaStreamHelperAspectRatioTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Utilities/MediaStreamHelperAspectRatioTests.cs
@@ -1,0 +1,39 @@
+using Jellyfin.Plugin.SmartLists.Services.Shared;
+using Jellyfin.Plugin.SmartLists.Utilities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Model.Entities;
+
+namespace Jellyfin.Plugin.SmartLists.Tests.Utilities;
+
+public class MediaStreamHelperAspectRatioTests
+{
+    [Fact]
+    public void GetAspectRatio_ReturnsFirstValidVideoRatioVerbatim()
+    {
+        var cache = new RefreshQueueService.RefreshCache();
+        var movie = new Movie { Id = Guid.NewGuid(), Name = "Kung Fu Panda" };
+        cache.MediaStreamsCache[movie.Id] = new object[]
+        {
+            new MediaStream { Type = MediaStreamType.Audio, AspectRatio = "16:9" },
+            new MediaStream { Type = MediaStreamType.Video, AspectRatio = "invalid" },
+            new MediaStream { Type = MediaStreamType.Video, AspectRatio = "2.35:1" },
+            new MediaStream { Type = MediaStreamType.Video, AspectRatio = "16:9" },
+        };
+
+        Assert.Equal("2.35:1", MediaStreamHelper.GetAspectRatio(movie, cache, null));
+    }
+
+    [Fact]
+    public void GetAspectRatio_ReturnsEmptyWhenNoVideoHasAValidRatio()
+    {
+        var cache = new RefreshQueueService.RefreshCache();
+        var movie = new Movie { Id = Guid.NewGuid(), Name = "Unknown" };
+        cache.MediaStreamsCache[movie.Id] = new object[]
+        {
+            new MediaStream { Type = MediaStreamType.Audio },
+            new MediaStream { Type = MediaStreamType.Video, AspectRatio = null },
+        };
+
+        Assert.Empty(MediaStreamHelper.GetAspectRatio(movie, cache, null));
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-core.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-core.js
@@ -46,6 +46,7 @@
         BOOLEAN_FIELDS: ['IsFavorite', 'NextUnwatched'],
         SIMPLE_FIELDS: ['ItemType', 'SeriesStatus'],
         RESOLUTION_FIELDS: ['Resolution'],
+        ASPECT_RATIO_FIELDS: ['AspectRatio'],
         STRING_FIELDS: ['SimilarTo', 'Name', 'Album', 'SeriesName', 'OfficialRating', 'Overview', 'FileName', 'FolderPath', 'AudioCodec', 'AudioProfile', 'VideoCodec', 'VideoProfile', 'VideoRange', 'VideoRangeType', 'PlaybackStatus', 'CustomRating', 'ImdbId', 'TmdbId', 'TvdbId'],
         USER_DATA_FIELDS: ['PlaybackStatus', 'IsFavorite', 'PlayCount', 'Rating', 'NextUnwatched', 'LastPlayedDate']
     };
@@ -68,7 +69,7 @@
 
     // Audio and video field lists for visibility gating
     SmartLists.AUDIO_FIELD_NAMES = ['AudioBitrate', 'AudioSampleRate', 'AudioBitDepth', 'AudioCodec', 'AudioProfile', 'AudioChannels', 'AudioLanguages', 'SubtitleLanguages'];
-    SmartLists.VIDEO_FIELD_NAMES = ['Resolution', 'Framerate', 'VideoCodec', 'VideoProfile', 'VideoRange', 'VideoRangeType'];
+    SmartLists.VIDEO_FIELD_NAMES = ['Resolution', 'AspectRatio', 'Framerate', 'VideoCodec', 'VideoProfile', 'VideoRange', 'VideoRangeType'];
 
     // Debounce delay for media type change updates (milliseconds)
     SmartLists.MEDIA_TYPE_UPDATE_DEBOUNCE_MS = 200;

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-rules.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-rules.js
@@ -39,6 +39,7 @@
         if (SmartLists.FIELD_TYPES.BOOLEAN_FIELDS.indexOf(fieldValue) !== -1) return 'boolean';
         if (SmartLists.FIELD_TYPES.SIMPLE_FIELDS.indexOf(fieldValue) !== -1) return 'simple';
         if (SmartLists.FIELD_TYPES.RESOLUTION_FIELDS.indexOf(fieldValue) !== -1) return 'resolution';
+        if (SmartLists.FIELD_TYPES.ASPECT_RATIO_FIELDS.indexOf(fieldValue) !== -1) return 'aspectratio';
         if (fieldValue === 'PlaybackStatus') return 'playback';
         if (fieldValue === 'ExtraType') return 'extratype';
         if (fieldValue === 'SeriesStatus') return 'seriesstatus';
@@ -200,6 +201,8 @@
             SmartLists.handleDateFieldInput(valueContainer, currentOperator, currentValue);
         } else if (SmartLists.FIELD_TYPES.RESOLUTION_FIELDS.indexOf(fieldValue) !== -1) {
             SmartLists.handleResolutionFieldInput(valueContainer, currentValue);
+        } else if (SmartLists.FIELD_TYPES.ASPECT_RATIO_FIELDS.indexOf(fieldValue) !== -1) {
+            SmartLists.handleAspectRatioFieldInput(valueContainer, currentValue);
         } else {
             SmartLists.handleTextFieldInput(valueContainer, currentValue);
         }
@@ -500,6 +503,14 @@
             input.value = currentValue;
         }
         valueContainer.appendChild(input);
+    };
+
+    SmartLists.handleAspectRatioFieldInput = function (valueContainer, currentValue) {
+        SmartLists.handleTextFieldInput(valueContainer, currentValue);
+        const input = valueContainer.querySelector('.rule-value-input');
+        if (input) {
+            input.placeholder = 'Width:height (e.g., 16:9 or 2.35:1)';
+        }
     };
 
     // ===== VALUE RESTORATION =====

--- a/Jellyfin.Plugin.SmartLists/Core/Constants/AspectRatioTypes.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Constants/AspectRatioTypes.cs
@@ -11,10 +11,26 @@ namespace Jellyfin.Plugin.SmartLists.Core.Constants
     public static class AspectRatioTypes
     {
         /// <summary>
-        /// Determines whether a value is a positive width-to-height ratio.
+        /// Smallest and largest accepted ratio component. Real display ratios sit far inside this
+        /// range - the widest cinema formats are near 2.76:1, and ratios written as pixel
+        /// dimensions top out around 7680:4320 - so the bounds only exclude values that could
+        /// never describe a picture. Rejecting the rest at parse time is what keeps
+        /// <see cref="Compare"/> arithmetic safe: the largest possible cross-product is 1e10,
+        /// against a decimal ceiling of roughly 7.9e28.
+        /// </summary>
+        private const decimal MinComponent = 0.0001m;
+
+        /// <summary>
+        /// Upper bound for a ratio component. See <see cref="MinComponent"/>.
+        /// </summary>
+        private const decimal MaxComponent = 100000m;
+
+        /// <summary>
+        /// Determines whether a value is a width-to-height ratio whose components both fall
+        /// inside the supported range.
         /// </summary>
         /// <param name="value">Ratio in <c>width:height</c> form.</param>
-        /// <returns><c>true</c> when both components are valid and positive.</returns>
+        /// <returns><c>true</c> when both components parse and are in range.</returns>
         public static bool IsValid(string? value)
         {
             return TryParse(value, out _, out _);
@@ -114,20 +130,24 @@ namespace Jellyfin.Plugin.SmartLists.Core.Constants
             return parts.Length == 2
                 && decimal.TryParse(parts[0].Trim(), NumberStyles.Number, CultureInfo.InvariantCulture, out width)
                 && decimal.TryParse(parts[1].Trim(), NumberStyles.Number, CultureInfo.InvariantCulture, out height)
-                && width > 0
-                && height > 0;
+                && IsInRange(width)
+                && IsInRange(height);
         }
 
+        private static bool IsInRange(decimal component)
+        {
+            return component >= MinComponent && component <= MaxComponent;
+        }
+
+        /// <summary>
+        /// Orders two ratios by cross-multiplication. Components are bounded by
+        /// <see cref="MinComponent"/> and <see cref="MaxComponent"/>, so neither cross-product can
+        /// overflow or underflow to zero. That removes the need to fall back on division, which
+        /// rounds distinct proportions together at the extremes.
+        /// </summary>
         private static int Compare(decimal leftWidth, decimal leftHeight, decimal rightWidth, decimal rightHeight)
         {
-            try
-            {
-                return decimal.Compare(leftWidth * rightHeight, rightWidth * leftHeight);
-            }
-            catch (OverflowException)
-            {
-                return decimal.Compare(leftWidth / leftHeight, rightWidth / rightHeight);
-            }
+            return decimal.Compare(leftWidth * rightHeight, rightWidth * leftHeight);
         }
     }
 }

--- a/Jellyfin.Plugin.SmartLists/Core/Constants/AspectRatioTypes.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Constants/AspectRatioTypes.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Globalization;
+using System.Linq;
+
+namespace Jellyfin.Plugin.SmartLists.Core.Constants
+{
+    /// <summary>
+    /// Parses and compares Jellyfin display-aspect-ratio values such as <c>16:9</c>,
+    /// <c>2.35:1</c>, and <c>80:29</c>.
+    /// </summary>
+    public static class AspectRatioTypes
+    {
+        /// <summary>
+        /// Determines whether a value is a positive width-to-height ratio.
+        /// </summary>
+        /// <param name="value">Ratio in <c>width:height</c> form.</param>
+        /// <returns><c>true</c> when both components are valid and positive.</returns>
+        public static bool IsValid(string? value)
+        {
+            return TryParse(value, out _, out _);
+        }
+
+        /// <summary>
+        /// Determines whether a semicolon-separated list contains only valid ratios.
+        /// </summary>
+        /// <param name="values">Semicolon-separated ratios.</param>
+        /// <returns><c>true</c> when the list is non-empty and every entry is valid.</returns>
+        public static bool IsValidList(string? values)
+        {
+            if (string.IsNullOrWhiteSpace(values))
+            {
+                return false;
+            }
+
+            var entries = values.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            return entries.Length > 0 && entries.All(IsValid);
+        }
+
+        /// <summary>
+        /// Evaluates a ratio comparison. Invalid or missing item values never match, including
+        /// negative operators, so non-video items do not leak into aspect-ratio rules.
+        /// </summary>
+        /// <param name="fieldValue">Jellyfin's stored aspect ratio.</param>
+        /// <param name="targetValue">One ratio, or a semicolon-separated list for IsIn/IsNotIn.</param>
+        /// <param name="operatorName">The SmartLists operator name.</param>
+        /// <returns>Whether the comparison matches.</returns>
+        public static bool Evaluate(string? fieldValue, string? targetValue, string operatorName)
+        {
+            if (!TryParse(fieldValue, out var fieldWidth, out var fieldHeight))
+            {
+                return false;
+            }
+
+            if (operatorName is "IsIn" or "IsNotIn")
+            {
+                if (string.IsNullOrWhiteSpace(targetValue))
+                {
+                    return false;
+                }
+
+                var entries = targetValue.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                if (entries.Length == 0)
+                {
+                    return false;
+                }
+
+                var isIn = false;
+                foreach (var entry in entries)
+                {
+                    if (!TryParse(entry, out var targetWidth, out var targetHeight))
+                    {
+                        return false;
+                    }
+
+                    if (Compare(fieldWidth, fieldHeight, targetWidth, targetHeight) == 0)
+                    {
+                        isIn = true;
+                        break;
+                    }
+                }
+
+                return operatorName == "IsIn" ? isIn : !isIn;
+            }
+
+            if (!TryParse(targetValue, out var singleTargetWidth, out var singleTargetHeight))
+            {
+                return false;
+            }
+
+            var comparison = Compare(fieldWidth, fieldHeight, singleTargetWidth, singleTargetHeight);
+            return operatorName switch
+            {
+                "Equal" => comparison == 0,
+                "NotEqual" => comparison != 0,
+                "GreaterThan" => comparison > 0,
+                "LessThan" => comparison < 0,
+                "GreaterThanOrEqual" => comparison >= 0,
+                "LessThanOrEqual" => comparison <= 0,
+                _ => false,
+            };
+        }
+
+        private static bool TryParse(string? value, out decimal width, out decimal height)
+        {
+            width = 0;
+            height = 0;
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return false;
+            }
+
+            var parts = value.Split(':');
+            return parts.Length == 2
+                && decimal.TryParse(parts[0].Trim(), NumberStyles.Number, CultureInfo.InvariantCulture, out width)
+                && decimal.TryParse(parts[1].Trim(), NumberStyles.Number, CultureInfo.InvariantCulture, out height)
+                && width > 0
+                && height > 0;
+        }
+
+        private static int Compare(decimal leftWidth, decimal leftHeight, decimal rightWidth, decimal rightHeight)
+        {
+            try
+            {
+                return decimal.Compare(leftWidth * rightHeight, rightWidth * leftHeight);
+            }
+            catch (OverflowException)
+            {
+                return decimal.Compare(leftWidth / leftHeight, rightWidth / rightHeight);
+            }
+        }
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Core/Constants/AspectRatioTypes.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Constants/AspectRatioTypes.cs
@@ -26,6 +26,16 @@ namespace Jellyfin.Plugin.SmartLists.Core.Constants
         private const decimal MaxComponent = 100000m;
 
         /// <summary>
+        /// Decimal places kept when parsing a component. 16:9 needs none and 2.35:1 needs two, so
+        /// eight is far past any real display format. Bounding precision is what makes
+        /// <see cref="Compare"/> exact rather than merely overflow-free: with at most six integer
+        /// digits each component carries at most 14 significant digits, so a cross-product carries
+        /// at most 28 and always fits a decimal without rounding. The trade is deliberate - two
+        /// ratios that differ only past the eighth decimal compare equal.
+        /// </summary>
+        private const int MaxScale = 8;
+
+        /// <summary>
         /// Determines whether a value is a width-to-height ratio whose components both fall
         /// inside the supported range.
         /// </summary>
@@ -127,11 +137,21 @@ namespace Jellyfin.Plugin.SmartLists.Core.Constants
             }
 
             var parts = value.Split(':');
-            return parts.Length == 2
-                && decimal.TryParse(parts[0].Trim(), NumberStyles.Number, CultureInfo.InvariantCulture, out width)
-                && decimal.TryParse(parts[1].Trim(), NumberStyles.Number, CultureInfo.InvariantCulture, out height)
-                && IsInRange(width)
-                && IsInRange(height);
+            if (parts.Length != 2
+                || !decimal.TryParse(parts[0].Trim(), NumberStyles.Number, CultureInfo.InvariantCulture, out width)
+                || !decimal.TryParse(parts[1].Trim(), NumberStyles.Number, CultureInfo.InvariantCulture, out height)
+                || !IsInRange(width)
+                || !IsInRange(height))
+            {
+                return false;
+            }
+
+            // Excess precision is dropped rather than rejected: a ratio written to more places
+            // than MaxScale is still a legitimate ratio, only an over-specified one. Rounding
+            // cannot leave the range, since MinComponent is itself larger than half an ulp here.
+            width = decimal.Round(width, MaxScale);
+            height = decimal.Round(height, MaxScale);
+            return true;
         }
 
         private static bool IsInRange(decimal component)
@@ -140,10 +160,11 @@ namespace Jellyfin.Plugin.SmartLists.Core.Constants
         }
 
         /// <summary>
-        /// Orders two ratios by cross-multiplication. Components are bounded by
-        /// <see cref="MinComponent"/> and <see cref="MaxComponent"/>, so neither cross-product can
-        /// overflow or underflow to zero. That removes the need to fall back on division, which
-        /// rounds distinct proportions together at the extremes.
+        /// Orders two ratios by cross-multiplication. Components are bounded in magnitude by
+        /// <see cref="MinComponent"/> and <see cref="MaxComponent"/> and in precision by
+        /// <see cref="MaxScale"/>, so every cross-product is exact: it can neither overflow nor
+        /// round two distinct proportions onto the same value. That is what removes the need for
+        /// a division fallback, which would do both at the extremes.
         /// </summary>
         private static int Compare(decimal leftWidth, decimal leftHeight, decimal rightWidth, decimal rightHeight)
         {

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
@@ -1099,7 +1099,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             {
                 var expected = r.Operator is "IsIn" or "IsNotIn"
                     ? "a non-empty list of width:height ratios"
-                    : "a positive width:height ratio";
+                    : "a width:height ratio";
                 throw new ArgumentException(
                     $"Invalid aspect ratio value '{r.TargetValue}' for field '{r.MemberName}'. Expected {expected}, for example 16:9 or 2.35:1.");
             }

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Engine.cs
@@ -223,6 +223,11 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                 return BuildResolutionExpression(r, left, logger);
             }
 
+            if (tProp == typeof(string) && FieldRegistry.IsAspectRatioField(r.MemberName))
+            {
+                return BuildAspectRatioExpression(r, left, logger);
+            }
+
             // Check framerate fields (nullable float type)
             if (tProp == typeof(float?) && IsFramerateField(r.MemberName))
             {
@@ -1043,6 +1048,75 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
 
             // Combine: resolution must be valid AND meet the comparison criteria
             return System.Linq.Expressions.Expression.AndAlso(isValidResolution, comparisonExpression);
+        }
+
+        /// <summary>
+        /// Builds expressions for aspect ratios. Equality and ordering compare the numeric
+        /// width-to-height proportion, while regex intentionally targets Jellyfin's raw string.
+        /// </summary>
+        private static System.Linq.Expressions.Expression BuildAspectRatioExpression(Expression r, MemberExpression left, ILogger? logger)
+        {
+            var allowedOps = Operators.GetOperatorsForField(r.MemberName);
+            if (!allowedOps.Contains(r.Operator))
+            {
+                logger?.LogError(
+                    "SmartLists unsupported operator '{Operator}' for aspect-ratio field '{Field}'. Allowed: {Allowed}",
+                    r.Operator,
+                    r.MemberName,
+                    string.Join(", ", allowedOps));
+                throw new ArgumentException(
+                    $"Operator '{r.Operator}' is not supported for aspect-ratio field '{r.MemberName}'. Supported operators: {string.Join(", ", allowedOps)}");
+            }
+
+            var isValidMethod = typeof(AspectRatioTypes).GetMethod(nameof(AspectRatioTypes.IsValid), [typeof(string)]);
+            if (isValidMethod == null)
+            {
+                throw new InvalidOperationException("AspectRatioTypes.IsValid method not found");
+            }
+
+            var hasValidAspectRatio = System.Linq.Expressions.Expression.Call(isValidMethod, left);
+
+            if (r.Operator == "MatchRegex")
+            {
+                var regex = GetOrCreateRegex(r.TargetValue, logger);
+                var regexMethod = typeof(Engine).GetMethod(nameof(RegexIsMatch), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+                if (regexMethod == null)
+                {
+                    throw new InvalidOperationException("Engine.RegexIsMatch method not found");
+                }
+
+                var regexCall = System.Linq.Expressions.Expression.Call(
+                    regexMethod,
+                    System.Linq.Expressions.Expression.Constant(regex),
+                    left);
+                return System.Linq.Expressions.Expression.AndAlso(hasValidAspectRatio, regexCall);
+            }
+
+            var targetIsValid = r.Operator is "IsIn" or "IsNotIn"
+                ? AspectRatioTypes.IsValidList(r.TargetValue)
+                : AspectRatioTypes.IsValid(r.TargetValue);
+            if (!targetIsValid)
+            {
+                var expected = r.Operator is "IsIn" or "IsNotIn"
+                    ? "a non-empty list of width:height ratios"
+                    : "a positive width:height ratio";
+                throw new ArgumentException(
+                    $"Invalid aspect ratio value '{r.TargetValue}' for field '{r.MemberName}'. Expected {expected}, for example 16:9 or 2.35:1.");
+            }
+
+            var evaluateMethod = typeof(AspectRatioTypes).GetMethod(
+                nameof(AspectRatioTypes.Evaluate),
+                [typeof(string), typeof(string), typeof(string)]);
+            if (evaluateMethod == null)
+            {
+                throw new InvalidOperationException("AspectRatioTypes.Evaluate method not found");
+            }
+
+            return System.Linq.Expressions.Expression.Call(
+                evaluateMethod,
+                left,
+                System.Linq.Expressions.Expression.Constant(r.TargetValue, typeof(string)),
+                System.Linq.Expressions.Expression.Constant(r.Operator, typeof(string)));
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
@@ -1696,6 +1696,14 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         }
 
         /// <summary>
+        /// Extracts Jellyfin's display aspect ratio from the item's video streams.
+        /// </summary>
+        private static void ExtractAspectRatio(Operand operand, BaseItem baseItem, RefreshQueueServiceRefreshCache cache, ILogger? logger)
+        {
+            operand.AspectRatio = Utilities.MediaStreamHelper.GetAspectRatio(baseItem, cache, logger);
+        }
+
+        /// <summary>
         /// Extracts framerate from media streams.
         /// </summary>
         private static void ExtractFramerate(Operand operand, BaseItem baseItem, RefreshQueueServiceRefreshCache cache, ILogger? logger)
@@ -2977,6 +2985,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                 if (MediaTypes.VideoStreamCapableSet.Contains(operand.ItemType))
                 {
                     ExtractResolution(operand, baseItem, cache, logger);
+                    ExtractAspectRatio(operand, baseItem, cache, logger);
                     ExtractFramerate(operand, baseItem, cache, logger);
                     ExtractVideoQuality(operand, baseItem, cache, logger);
                 }
@@ -2984,6 +2993,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                 {
                     // Clear video quality fields for non-video items
                     operand.Resolution = string.Empty;
+                    operand.AspectRatio = string.Empty;
                     operand.Framerate = null;
                     operand.VideoCodec = string.Empty;
                     operand.VideoProfile = string.Empty;
@@ -2995,6 +3005,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             else
             {
                 operand.Resolution = string.Empty;
+                operand.AspectRatio = string.Empty;
                 operand.Framerate = null;
                 operand.VideoCodec = string.Empty;
                 operand.VideoProfile = string.Empty;

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/FieldRegistry.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/FieldRegistry.cs
@@ -62,7 +62,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         // These trigger two-phase filtering for optimization
         AudioLanguages = 1 << 0,      // Fields: AudioLanguages, SubtitleLanguages | Cache: MediaStreamsCache
         AudioQuality = 1 << 1,        // Fields: AudioBitrate, AudioSampleRate, AudioBitDepth, AudioCodec, AudioProfile, AudioChannels | Cache: MediaStreamsCache
-        VideoQuality = 1 << 2,        // Fields: Resolution, Framerate, VideoCodec, VideoProfile, VideoRange, VideoRangeType | Cache: MediaStreamsCache
+        VideoQuality = 1 << 2,        // Fields: Resolution, AspectRatio, Framerate, VideoCodec, VideoProfile, VideoRange, VideoRangeType | Cache: MediaStreamsCache
         People = 1 << 3,              // Fields: All people roles (Actors, Directors, etc.) | Cache: ItemPeople
         Collections = 1 << 4,         // Fields: Collections | Cache: ItemCollectionsWithDepth, CollectionMembershipCache
         Playlists = 1 << 5,           // Fields: Playlists | Cache: ItemPlaylists, PlaylistMembershipCache
@@ -100,6 +100,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         Boolean,
         List,           // IEnumerable&lt;string&gt;
         Resolution,
+        AspectRatio,
         Framerate,
         UserData,       // User-specific fields (PlaybackStatus, IsFavorite, etc.)
         Similarity,
@@ -173,6 +174,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         private static readonly string[] BooleanOperators = ["Equal", "NotEqual"];
         private static readonly string[] SimpleOperators = ["Equal", "NotEqual"];
         private static readonly string[] SimilarityOperators = ["Equal", "Contains", "IsIn", "MatchRegex"];
+        private static readonly string[] AspectRatioOperators = ["Equal", "NotEqual", "IsIn", "IsNotIn", "GreaterThan", "LessThan", "GreaterThanOrEqual", "LessThanOrEqual", "MatchRegex"];
 
         // The canonical registry - all field metadata in one place
         private static readonly Dictionary<string, FieldMetadata> _fields;
@@ -187,6 +189,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         private static readonly HashSet<string> _userDataFields;
         private static readonly HashSet<string> _simpleFields;
         private static readonly HashSet<string> _resolutionFields;
+        private static readonly HashSet<string> _aspectRatioFields;
         private static readonly HashSet<string> _framerateFields;
         private static readonly HashSet<string> _similarityFields;
         private static readonly Dictionary<string, string[]> _fieldOperators;
@@ -207,6 +210,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
             _userDataFields = BuildFieldSet(f => f.IsUserSpecific);
             _simpleFields = BuildFieldSet(f => f.Type == FieldType.Simple);
             _resolutionFields = BuildFieldSet(f => f.Type == FieldType.Resolution);
+            _aspectRatioFields = BuildFieldSet(f => f.Type == FieldType.AspectRatio);
             _framerateFields = BuildFieldSet(f => f.Type == FieldType.Framerate);
             _similarityFields = BuildFieldSet(f => f.Type == FieldType.Similarity);
             _fieldOperators = _fields.ToDictionary(kv => kv.Key, kv => kv.Value.AllowedOperators, StringComparer.OrdinalIgnoreCase);
@@ -233,6 +237,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
 
             // Video Fields
             AddField(fields, "Resolution", "Resolution", FieldType.Resolution, FieldCategory.Video, NumericOperators, ExtractionGroup.VideoQuality);
+            AddField(fields, "AspectRatio", "Aspect Ratio", FieldType.AspectRatio, FieldCategory.Video, AspectRatioOperators, ExtractionGroup.VideoQuality);
             AddField(fields, "Framerate", "Framerate", FieldType.Framerate, FieldCategory.Video, NumericOperators, ExtractionGroup.VideoQuality);
             AddField(fields, "VideoCodec", "Video Codec", FieldType.Text, FieldCategory.Video, StringOperators, ExtractionGroup.VideoQuality);
             AddField(fields, "VideoProfile", "Video Profile", FieldType.Text, FieldCategory.Video, StringOperators, ExtractionGroup.VideoQuality);
@@ -423,6 +428,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         public static bool IsUserDataField(string fieldName) => _userDataFields.Contains(fieldName);
         public static bool IsSimpleField(string fieldName) => _simpleFields.Contains(fieldName);
         public static bool IsResolutionField(string fieldName) => _resolutionFields.Contains(fieldName);
+        public static bool IsAspectRatioField(string fieldName) => _aspectRatioFields.Contains(fieldName);
         public static bool IsFramerateField(string fieldName) => _framerateFields.Contains(fieldName);
         public static bool IsSimilarityField(string fieldName) => _similarityFields.Contains(fieldName);
 
@@ -471,6 +477,11 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         public static HashSet<string> GetResolutionFields()
         {
             return new HashSet<string>(_resolutionFields, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public static HashSet<string> GetAspectRatioFields()
+        {
+            return new HashSet<string>(_aspectRatioFields, StringComparer.OrdinalIgnoreCase);
         }
 
         public static HashSet<string> GetFramerateFields()

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Operand.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Operand.cs
@@ -83,6 +83,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
 
         // Video quality fields (from media streams)
         public string Resolution { get; set; } = string.Empty;  // e.g., 480p, 720p, 1080p, 4K, 8K
+        public string AspectRatio { get; set; } = string.Empty;  // Jellyfin display ratio, e.g., 16:9, 2.35:1, 80:29
         public float? Framerate { get; set; } = null;  // e.g., 23.976, 29.97, 59.94
         public string VideoCodec { get; set; } = string.Empty;  // e.g., HEVC, H264, AV1, VP9
         public string VideoProfile { get; set; } = string.Empty;  // e.g., Main 10, High

--- a/Jellyfin.Plugin.SmartLists/Utilities/MediaStreamHelper.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/MediaStreamHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Jellyfin.Plugin.SmartLists.Core.Constants;
 using Jellyfin.Plugin.SmartLists.Core.QueryEngine;
 using Jellyfin.Plugin.SmartLists.Services.Shared;
 using MediaBrowser.Controller.Entities;
@@ -96,6 +97,43 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
             }
 
             return maxHeight;
+        }
+
+        /// <summary>
+        /// Gets Jellyfin's stored display aspect ratio from the first video stream that has a
+        /// valid ratio. The stored value is authoritative because it accounts for anamorphic
+        /// display metadata that cannot be reconstructed from encoded width and height alone.
+        /// </summary>
+        /// <param name="item">The item whose video streams should be inspected.</param>
+        /// <param name="cache">Optional per-refresh media-stream cache.</param>
+        /// <param name="logger">Optional logger for stream-read failures.</param>
+        /// <returns>The original Jellyfin ratio string, or an empty string when unavailable.</returns>
+        public static string GetAspectRatio(BaseItem item, RefreshQueueService.RefreshCache? cache, ILogger? logger)
+        {
+            foreach (var stream in GetMediaStreams(item, cache, logger))
+            {
+                try
+                {
+                    var typeProperty = stream.GetType().GetProperty("Type");
+                    var aspectRatioProperty = stream.GetType().GetProperty("AspectRatio");
+                    if (typeProperty?.GetValue(stream)?.ToString() != "Video" || aspectRatioProperty == null)
+                    {
+                        continue;
+                    }
+
+                    var aspectRatio = aspectRatioProperty.GetValue(stream)?.ToString();
+                    if (AspectRatioTypes.IsValid(aspectRatio))
+                    {
+                        return aspectRatio!;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger?.LogDebug(ex, "Failed to read an aspect ratio for item {Name}", item.Name);
+                }
+            }
+
+            return string.Empty;
         }
     }
 }

--- a/docs/content/examples/common-use-cases.md
+++ b/docs/content/examples/common-use-cases.md
@@ -20,6 +20,14 @@ Here are some popular playlist and collection types you can create:
 ### Unwatched Action Movies
 - **Playback Status** = Unplayed AND **Genre** contains "Action"
 
+### Portrait Videos for Phones
+- **Media Types**: Movie, Episode, Music Video, or Video
+- **Aspect Ratio** less than `1:1`
+- Matches every portrait display ratio, including `9:16` and uncommon phone-specific ratios
+
+To target particular formats instead, use **Aspect Ratio is in** with values such as `9:16` and
+`4:5`. Aspect ratios are entered as `width:height`.
+
 ### Continue Watching (In Progress)
 - **Playback Status** = In Progress
 - Shows all movies and episodes that have been started but not finished
@@ -399,4 +407,3 @@ Use **matches regex** with .NET syntax for advanced matching:
 
 - **Audio Languages** matches regex `(?i)fra?` with "Must be default language" enabled
 - Matches "fr" or "fra" as default audio, excluding English films with French dubs
-

--- a/docs/content/user-guide/fields-and-operators.md
+++ b/docs/content/user-guide/fields-and-operators.md
@@ -56,11 +56,30 @@ The more fields selected, the more comprehensive but potentially stricter the ma
 | Field | JSON name | Description |
 |-------|-----------|-------------|
 | **Resolution** | `Resolution` | Video resolution (480p, 720p, 1080p, 1440p, 4K, 8K) |
+| **Aspect Ratio** | `AspectRatio` | Jellyfin's display aspect ratio (for example, `16:9`, `2.35:1`, `9:16`, or `80:29`) |
 | **Framerate** | `Framerate` | Video framerate in fps (e.g., 23.976, 29.97, 59.94) |
 | **Video Codec** | `VideoCodec` | Codec format (e.g., HEVC, H264, AV1, VP9) |
 | **Video Profile** | `VideoProfile` | Codec profile (e.g., Main 10, High) |
 | **Video Range** | `VideoRange` | Dynamic range (e.g., SDR, HDR) |
 | **Video Range Type** | `VideoRangeType` | Specific HDR format (e.g., HDR10, DOVIWithHDR10, HDR10Plus, HLG) |
+
+#### Aspect Ratio
+
+Aspect Ratio uses the display ratio reported by Jellyfin for the video's first stream with valid
+ratio metadata. Enter ratios as `width:height`; both whole-number and decimal components work.
+There is no fixed list of possible values, so the field uses a text input.
+
+Equality and comparison operators compare the proportions rather than the text. For example,
+`160:58` equals `80:29`. This also makes orientation rules possible without listing every phone
+format:
+
+- **less than `1:1`** — portrait video
+- **greater than `1:1`** — landscape video
+- **equals `1:1`** — square video
+
+**is in** and **is not in** compare against multiple exact ratios. **matches regex** is the one
+operator that works against Jellyfin's original ratio text. Items without a valid video aspect
+ratio never match an Aspect Ratio rule, including negative rules.
 
 ### Audio
 
@@ -349,6 +368,9 @@ For list fields (Genres, Studios, Tags, Actors, Directors, Collections, Playlist
 | **equals** / **not equals** | `Equal` / `NotEqual` | Exact match |
 | **greater than** / **less than** | `GreaterThan` / `LessThan` | Comparison |
 | **greater than or equal** / **less than or equal** | `GreaterThanOrEqual` / `LessThanOrEqual` | Comparison |
+
+Aspect Ratio supports these numeric operators using `width:height` values. It additionally supports
+**is in**, **is not in**, and **matches regex**, as described in the Aspect Ratio section above.
 
 ### Date Operators
 


### PR DESCRIPTION
## What

Adds an `AspectRatio` rule field under the **Video** category, so lists can filter on a video's display aspect ratio.

## Why

There was no way to target aspect ratio at all. `Resolution` only exposes stream height, so portrait content (phone videos), ultra-wide/scope films, and square video were unreachable as rule criteria.

## How

**Extraction** — the value is Jellyfin's stored display aspect ratio, taken from the first video stream that reports a valid one. Read via reflection through the existing `MediaStreamHelper` / `MediaStreamsCache` path, matching how `GetMaxVideoHeight` already works: ABI-portable across Jellyfin versions and no extra stream reads per refresh. Jellyfin's stored ratio is authoritative rather than deriving one from width/height, because it accounts for anamorphic display metadata that encoded dimensions don't capture.

**Comparison** — new `Core/Constants/AspectRatioTypes.cs` parses `width:height` (whole or decimal components, invariant culture) and compares by cross-multiplication, so comparisons are on the proportion, not the text:

- `160:58` equals `80:29`
- **less than `1:1`** → all portrait video, no need to enumerate `9:16`, `4:5`, etc.
- **greater than `1:1`** → landscape; **equals `1:1`** → square

**Operators** — `Equal`, `NotEqual`, `IsIn`, `IsNotIn`, `GreaterThan`, `LessThan`, `GreaterThanOrEqual`, `LessThanOrEqual` all compare numerically. `MatchRegex` is the deliberate exception: it runs against Jellyfin's original ratio string, since regex on a proportion would be meaningless.

**Non-matching items** — items with no valid video aspect ratio never match, *including under negative operators* (`NotEqual`, `IsNotIn`). This keeps audio, books, and streamless items from leaking into aspect-ratio rules the way a naive "not equal" would.

**Registry / UI** — registered with `ExtractionGroup.VideoQuality`, so it participates in two-phase filtering alongside the other video fields, and it's gated by the same video-field visibility rules in the UI. Because there is no fixed set of valid ratios, the value control is a text input with a `Width:height (e.g., 16:9 or 2.35:1)` placeholder rather than a dropdown.

## Reviewer notes

- Invalid target values fail fast at expression-build time with a message naming the expected form, rather than silently matching nothing.
- `Compare` falls back to division on `OverflowException` — cross-multiplication of two `decimal`s can overflow on pathological input.
- Docs updated: a dedicated Aspect Ratio subsection in `fields-and-operators.md` (including the orientation trick) and a "Portrait Videos for Phones" entry in `common-use-cases.md`.

## Testing

`dotnet test` — **1666 passed, 0 failed**. New coverage in `AspectRatioTests.cs` (parsing, proportional equality, operator semantics, invalid input) and `MediaStreamHelperAspectRatioTests.cs` (stream selection, missing/invalid metadata). `FieldRegistryInvariantTests` extended so the new `FieldType.AspectRatio` is covered by the existing registry invariants.

Note: `.agents/` and `AGENTS.md` were left uncommitted in the working tree — agent tooling, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added **Aspect Ratio** as a video field for smart list rules.
  - Supports proportional comparisons, exact values, value lists, and regular-expression matching.
  - Enables portrait and landscape filtering for ratios such as `9:16`, `4:5`, and `2.35:1`.
  - Added `width:height` input guidance and validation.
  - Missing or invalid aspect ratios are excluded from matches.

- **Documentation**
  - Updated operator guidance and expanded the portrait-video example with ratio-based rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->