### PR TITLE
Add a Min Items threshold, replacing HideWhenEmpty

### DIFF
--- a/Jellyfin.Plugin.SmartLists/Api/Controllers/SmartListController.cs
+++ b/Jellyfin.Plugin.SmartLists/Api/Controllers/SmartListController.cs
@@ -636,6 +636,11 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                 });
             }
 
+            // A caller on an older client version may still send a legacy field (e.g.
+            // HideWhenEmpty). Normalize it into its current equivalent before this DTO is used
+            // for anything, so a fresh save/refresh never sees the stale legacy value.
+            list.MigrateLegacyFields();
+
             // Route to appropriate handler based on type
             if (list.Type == Core.Enums.SmartListType.Collection)
             {
@@ -1142,6 +1147,11 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                     Status = StatusCodes.Status400BadRequest
                 });
             }
+
+            // A caller on an older client version may still send a legacy field (e.g.
+            // HideWhenEmpty). Normalize it into its current equivalent before this DTO is saved
+            // or used for a refresh, so a stale legacy value is never persisted or acted on.
+            list.MigrateLegacyFields();
 
             var stopwatch = Stopwatch.StartNew();
             try

--- a/Jellyfin.Plugin.SmartLists/Api/Controllers/UserSmartListController.cs
+++ b/Jellyfin.Plugin.SmartLists/Api/Controllers/UserSmartListController.cs
@@ -278,10 +278,14 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                 var validationResult = ValidateSmartList(list);
                 if (!validationResult.IsValid)
                 {
-                    _logger.LogWarning("Validation failed for user {UserId} creating list '{Name}': {Error}", 
+                    _logger.LogWarning("Validation failed for user {UserId} creating list '{Name}': {Error}",
                         userId, list.Name, validationResult.ErrorMessage);
                     return BadRequest(new { error = validationResult.ErrorMessage });
                 }
+
+                // A caller on an older client version may still send a legacy field (e.g.
+                // HideWhenEmpty). Normalize it before this DTO is saved or used for a refresh.
+                list.MigrateLegacyFields();
 
                 // Check if user can create collections
                 if (list.Type == Core.Enums.SmartListType.Collection && !CanUserManageCollections())
@@ -1112,6 +1116,12 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                     list.Id = id;
                 }
 
+                // A caller on an older client version may still send a legacy field (e.g.
+                // HideWhenEmpty). Normalize it before this DTO is used for anything below --
+                // including the playlist<->collection conversion paths, which bypass the
+                // per-branch update logic entirely.
+                list.MigrateLegacyFields();
+
                 // Determine if it's a playlist or collection and update accordingly
                 var playlistStore = _playlistStore;
                 var collectionStore = _collectionStore;
@@ -1166,7 +1176,7 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                     var validationResult = ValidateSmartList(playlistDto);
                     if (!validationResult.IsValid)
                     {
-                        _logger.LogWarning("Validation failed for user {UserId} updating playlist '{Name}': {Error}", 
+                        _logger.LogWarning("Validation failed for user {UserId} updating playlist '{Name}': {Error}",
                             userId, playlistDto.Name, validationResult.ErrorMessage);
                         return BadRequest(new { error = validationResult.ErrorMessage });
                     }
@@ -1254,7 +1264,7 @@ namespace Jellyfin.Plugin.SmartLists.Api.Controllers
                     var validationResult = ValidateSmartList(collectionDto);
                     if (!validationResult.IsValid)
                     {
-                        _logger.LogWarning("Validation failed for user {UserId} updating collection '{Name}': {Error}", 
+                        _logger.LogWarning("Validation failed for user {UserId} updating collection '{Name}': {Error}",
                             userId, collectionDto.Name, validationResult.ErrorMessage);
                         return BadRequest(new { error = validationResult.ErrorMessage });
                     }

--- a/Jellyfin.Plugin.SmartLists/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.SmartLists/Configuration/PluginConfiguration.cs
@@ -42,6 +42,15 @@ namespace Jellyfin.Plugin.SmartLists.Configuration
         public int? DefaultMinItems { get; set; } = 1;
 
         /// <summary>
+        /// Legacy input-only field, replaced by <see cref="DefaultMinItems"/>. An existing saved
+        /// XML config with this element set still deserializes into it (unlike a genuinely new
+        /// install, where it's simply absent); <see cref="Plugin"/> migrates it into
+        /// DefaultMinItems once at startup and saves the configuration back with this cleared, so
+        /// it is a one-time read, not a standing property to keep populating.
+        /// </summary>
+        public bool? DefaultHideWhenEmpty { get; set; }
+
+        /// <summary>
         /// Gets or sets whether to stamp a small smart list badge onto auto-generated
         /// and uploaded cover images so smart lists are recognizable at a glance.
         /// </summary>

--- a/Jellyfin.Plugin.SmartLists/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.SmartLists/Configuration/PluginConfiguration.cs
@@ -36,10 +36,10 @@ namespace Jellyfin.Plugin.SmartLists.Configuration
         public bool DefaultMakePublic { get; set; } = false;
 
         /// <summary>
-        /// Gets or sets whether new lists should hide when empty by default.
-        /// Keep the default in sync with SmartLists.getDefaultHideWhenEmpty in config-core.js.
+        /// Gets or sets the default minimum-items-to-show threshold for new lists (0/null = none).
+        /// Keep the default in sync with SmartLists.getDefaultMinItems in config-core.js.
         /// </summary>
-        public bool DefaultHideWhenEmpty { get; set; } = true;
+        public int? DefaultMinItems { get; set; } = 1;
 
         /// <summary>
         /// Gets or sets whether to stamp a small smart list badge onto auto-generated

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-core.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-core.js
@@ -490,13 +490,16 @@
     };
 
     /**
-     * Resolve the hide-when-empty default for new lists.
+     * Resolve the minimum-items-to-show default for new lists (0/empty = never hide).
      * Single JS source of truth — must stay in sync with the
-     * PluginConfiguration.DefaultHideWhenEmpty initializer (true) in C#.
+     * PluginConfiguration.DefaultMinItems initializer (1) in C#.
      * Pass null when no config is available (user page, config fetch failure).
      */
-    SmartLists.getDefaultHideWhenEmpty = function (config) {
-        return !config || config.DefaultHideWhenEmpty !== false;
+    SmartLists.getDefaultMinItems = function (config) {
+        if (!config || config.DefaultMinItems === undefined || config.DefaultMinItems === null) {
+            return 1;
+        }
+        return config.DefaultMinItems;
     };
 
     SmartLists.getPluginId = function () {

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-init.js
@@ -474,9 +474,9 @@
         SmartLists.setElementChecked(page, '#matchByMembers', false);
         SmartLists.setElementChecked(page, '#groupIntoCollections', false);
         // Cache the resolved default so template application can read it even
-        // after the checkbox has been toggled (e.g. by a previous template)
-        page._defaultHideWhenEmpty = SmartLists.getDefaultHideWhenEmpty(config);
-        SmartLists.setElementChecked(page, '#playlistHideWhenEmpty', page._defaultHideWhenEmpty);
+        // after the field has been edited (e.g. by a previous template)
+        page._defaultMinItems = SmartLists.getDefaultMinItems(config);
+        SmartLists.setElementValue(page, '#playlistMinItems', page._defaultMinItems);
         SmartLists.setElementChecked(page, '#playlistIsEnabled', true); // Default to enabled
 
         // Reinitialize schedule system
@@ -533,8 +533,8 @@
         SmartLists.setElementChecked(page, '#playlistIncludeExtras', false);
         SmartLists.setElementChecked(page, '#matchByMembers', false);
         SmartLists.setElementChecked(page, '#groupIntoCollections', false);
-        page._defaultHideWhenEmpty = SmartLists.getDefaultHideWhenEmpty(null);
-        SmartLists.setElementChecked(page, '#playlistHideWhenEmpty', page._defaultHideWhenEmpty);
+        page._defaultMinItems = SmartLists.getDefaultMinItems(null);
+        SmartLists.setElementValue(page, '#playlistMinItems', page._defaultMinItems);
         SmartLists.setElementChecked(page, '#playlistIsEnabled', true);
 
         // Reinitialize schedule system with fallback defaults
@@ -1953,7 +1953,7 @@
             const defaultIgnoreArticlesContainer = page.querySelector('#defaultIgnoreArticlesContainer');
             const defaultListTypeEl = page.querySelector('#defaultListType');
             const defaultMakePublicEl = page.querySelector('#defaultMakePublic');
-            const defaultHideWhenEmptyEl = page.querySelector('#defaultHideWhenEmpty');
+            const defaultMinItemsEl = page.querySelector('#defaultMinItems');
             const defaultMaxItemsEl = page.querySelector('#defaultMaxItems');
             const defaultMaxPlayTimeMinutesEl = page.querySelector('#defaultMaxPlayTimeMinutes');
             const defaultAutoRefreshEl = page.querySelector('#defaultAutoRefresh');
@@ -1991,7 +1991,7 @@
 
             if (defaultMakePublicEl) defaultMakePublicEl.checked = config.DefaultMakePublic || false;
 
-            if (defaultHideWhenEmptyEl) defaultHideWhenEmptyEl.checked = SmartLists.getDefaultHideWhenEmpty(config);
+            if (defaultMinItemsEl) defaultMinItemsEl.value = SmartLists.getDefaultMinItems(config);
 
             // Smart list badge defaults to enabled, so only an explicit false unchecks it
             const showSmartListBadgeEl = page.querySelector('#showSmartListBadge');
@@ -2178,7 +2178,8 @@
             config.DefaultMediaTypes = defaultMediaTypes && defaultMediaTypes.length > 0 ? defaultMediaTypes : null;
 
             config.DefaultMakePublic = page.querySelector('#defaultMakePublic').checked;
-            config.DefaultHideWhenEmpty = SmartLists.getElementChecked(page, '#defaultHideWhenEmpty', SmartLists.getDefaultHideWhenEmpty(config));
+            const defaultMinItemsInput = page.querySelector('#defaultMinItems') ? page.querySelector('#defaultMinItems').value : '';
+            config.DefaultMinItems = defaultMinItemsInput === '' ? null : parseInt(defaultMinItemsInput, 10);
             config.ShowSmartListBadge = page.querySelector('#showSmartListBadge').checked;
             const defaultMaxItemsInput = page.querySelector('#defaultMaxItems').value;
             if (defaultMaxItemsInput === '') {

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-lists.js
@@ -348,7 +348,8 @@
             // Only meaningful when a container media type is selected; the checkbox is
             // reset whenever the toggle is hidden, so reading it directly is safe
             const matchByMembers = SmartLists.getElementChecked(page, '#matchByMembers', false);
-            const hideWhenEmpty = SmartLists.getElementChecked(page, '#playlistHideWhenEmpty', false);
+            const minItemsInput = SmartLists.getElementValue(page, '#playlistMinItems', '');
+            const minItems = minItemsInput === '' ? null : parseInt(minItemsInput, 10);
             // Collection-only: the flag is never sent for a playlist regardless of UI state
             const groupIntoCollections = isCollection && SmartLists.getElementChecked(page, '#groupIntoCollections', false);
             const isEnabled = SmartLists.getElementChecked(page, '#playlistIsEnabled', true); // Default to true
@@ -451,7 +452,7 @@
                 IncludeExtras: includeExtras,
                 MatchByMembers: matchByMembers,
                 GroupIntoCollections: groupIntoCollections,
-                HideWhenEmpty: hideWhenEmpty,
+                MinItems: minItems,
                 MediaTypes: selectedMediaTypes,
                 MaxItems: maxItems,
                 MaxPlayTimeMinutes: maxPlayTimeMinutes,
@@ -746,7 +747,9 @@
         if (playlist.Enabled === false) {
             chips.push('Disabled');
         }
-        if (playlist.HideWhenEmpty) {
+        if (playlist.MinItems > 1) {
+            chips.push('Min ' + playlist.MinItems + ' items');
+        } else if (playlist.MinItems === 1) {
             chips.push('Hide when empty');
         }
         if (playlist.GroupIntoCollections) {
@@ -987,7 +990,7 @@
         SmartLists.setElementChecked(page, '#playlistIncludeExtras', playlist.IncludeExtras || false);
         SmartLists.setElementChecked(page, '#matchByMembers', playlist.MatchByMembers || false);
         SmartLists.setElementChecked(page, '#groupIntoCollections', playlist.GroupIntoCollections || false);
-        SmartLists.setElementChecked(page, '#playlistHideWhenEmpty', playlist.HideWhenEmpty || false);
+        SmartLists.setElementValue(page, '#playlistMinItems', playlist.MinItems !== undefined && playlist.MinItems !== null ? playlist.MinItems : '');
 
         // Handle AutoRefresh with backward compatibility
         const autoRefreshValue = playlist.AutoRefresh !== undefined ? playlist.AutoRefresh : 'Never';
@@ -2078,10 +2081,10 @@
                 '</tr>' :
                 ''
             ) +
-            (playlist.HideWhenEmpty ?
+            (playlist.MinItems > 0 ?
                 '<tr style="border-bottom: 1px solid var(--jf-palette-divider);">' +
-                '<td style="padding: 0.5em 0.75em; font-weight: bold; opacity: 0.8; width: 40%; border-right: 1px solid var(--jf-palette-divider);">Hide When Empty</td>' +
-                '<td style="padding: 0.5em 0.75em; ">Yes</td>' +
+                '<td style="padding: 0.5em 0.75em; font-weight: bold; opacity: 0.8; width: 40%; border-right: 1px solid var(--jf-palette-divider);">Min Items</td>' +
+                '<td style="padding: 0.5em 0.75em; ">' + playlist.MinItems + '</td>' +
                 '</tr>' :
                 ''
             ) +

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-templates.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-templates.js
@@ -183,7 +183,7 @@
                 }],
                 Order: { SortOptions: [{ SortBy: 'External List Order', SortOrder: 'Ascending' }] },
                 Schedules: [{ Trigger: 'Daily', Time: '06:00:00' }],
-                HideWhenEmpty: true,
+                MinItems: 1,
                 MaxItems: 50
             }
         },
@@ -331,13 +331,13 @@
         // Deep-copy so form population can never mutate the catalog
         const dto = JSON.parse(JSON.stringify(template.dto));
 
-        // Templates that don't specify HideWhenEmpty inherit the configured
+        // Templates that don't specify MinItems inherit the configured
         // default for new lists (cached by the form-defaults population; the
-        // live checkbox may have been toggled by a previously applied template)
-        if (dto.HideWhenEmpty === undefined) {
-            dto.HideWhenEmpty = page._defaultHideWhenEmpty !== undefined
-                ? page._defaultHideWhenEmpty
-                : SmartLists.getDefaultHideWhenEmpty(null);
+        // live field may have been edited by a previously applied template)
+        if (dto.MinItems === undefined) {
+            dto.MinItems = page._defaultMinItems !== undefined
+                ? page._defaultMinItems
+                : SmartLists.getDefaultMinItems(null);
         }
 
         try {

--- a/Jellyfin.Plugin.SmartLists/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config.html
@@ -270,6 +270,14 @@
                             </div>
                         </div>
 
+                        <div class="inputContainer" style="margin-bottom: 1em; margin-top: 1em;">
+                            <label class="inputLabel inputLabelUnfocused" for="playlistMinItems">Min Items</label>
+                            <input type="number" id="playlistMinItems" class="emby-input" min="0" step="1" value="1">
+                            <div class="fieldDescription">Hides the list while the number of items in the list is
+                                less than this. The list will be shown once the number of items is greater than
+                                this minimum. Leave blank or 0 to never hide.</div>
+                        </div>
+
                         <div class="inputContainer playlist-only-field" style="margin-bottom: 1em; margin-top: 1em;">
                             <label class="inputLabel" for="playlistMaxPlayTimeMinutes"
                                 style="display: flex; align-items: center;">
@@ -450,21 +458,6 @@
                         </div>
 
                             <h3 class="sectionTitle" style="margin-top: 1.5em;">Presentation</h3>
-                        <div class="checkboxList paperList"
-                            style="padding: 0.5em 1em; margin-bottom: 1em; margin-top: 0.5em;">
-                            <label class="emby-checkbox-label">
-                                <input type="checkbox" is="emby-checkbox" id="playlistHideWhenEmpty"
-                                    data-embycheckbox="true" class="emby-checkbox" checked>
-                                <span class="checkboxLabel">Hide when empty</span>
-                                <span class="checkboxOutline">
-                                    <span class="material-icons checkboxIcon checkboxIcon-checked check"
-                                        aria-hidden="true"></span>
-                                    <span class="material-icons checkboxIcon checkboxIcon-unchecked"
-                                        aria-hidden="true"></span>
-                                </span>
-                            </label>
-                            <div class="fieldDescription">Don't create the playlist or collection while it has no matching items. If a refresh finds no items, the existing Jellyfin playlist/collection is removed and recreated automatically once items match again.</div>
-                        </div>
                         <div id="groupIntoCollectionsContainer" class="checkboxList paperList collection-only-field"
                             style="padding: 0.5em 1em; margin-bottom: 1em; margin-top: 0.5em;">
                             <label class="emby-checkbox-label">
@@ -729,31 +722,20 @@
                             </div>
                         </div>
 
-                        <div class="checkboxList paperList"
-                            style="padding: 0.5em 1em; margin-bottom: 1em; margin-top: 1em;">
-                            <div class="sectioncheckbox">
-                                <label class="emby-checkbox-label">
-                                    <input type="checkbox" is="emby-checkbox" id="defaultHideWhenEmpty"
-                                        data-embycheckbox="true" class="emby-checkbox" checked>
-                                    <span class="checkboxLabel">Hide lists when empty by default</span>
-                                    <span class="checkboxOutline">
-                                        <span class="material-icons checkboxIcon checkboxIcon-checked check"
-                                            aria-hidden="true"></span>
-                                        <span class="material-icons checkboxIcon checkboxIcon-unchecked"
-                                            aria-hidden="true"></span>
-                                    </span>
-                                </label>
-                                <div class="fieldDescription">New smart lists will hide when empty by default: the
-                                    Jellyfin playlist/collection isn't created while no items match, and is removed
-                                    and recreated automatically once items match again.</div>
-                            </div>
-                        </div>
-
                         <div class="inputContainer" style="margin-bottom: 1em; margin-top: 1em;">
                             <label class="inputLabel" for="defaultMaxItems">Default Max Items</label>
                             <input type="number" id="defaultMaxItems" class="emby-input" min="0" step="1">
                             <div class="fieldDescription">Default maximum number of items for new smart lists. Set to 0
                                 for no limit.</div>
+                        </div>
+
+                        <div class="inputContainer" style="margin-bottom: 1em; margin-top: 1em;">
+                            <label class="inputLabel inputLabelUnfocused" for="defaultMinItems">Default Min Items</label>
+                            <input type="number" id="defaultMinItems" class="emby-input" min="0" step="1" value="1">
+                            <div class="fieldDescription">Hides the list while the number of items in the list is
+                                less than this. The list will be shown once the number of items is greater than
+                                this minimum. Leave blank or 0 to never hide. Applied to new lists that don't set
+                                their own value.</div>
                         </div>
 
                         <div class="inputContainer" style="margin-bottom: 1em; margin-top: 1em;">

--- a/Jellyfin.Plugin.SmartLists/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config.html
@@ -274,7 +274,7 @@
                             <label class="inputLabel inputLabelUnfocused" for="playlistMinItems">Min Items</label>
                             <input type="number" id="playlistMinItems" class="emby-input" min="0" step="1" value="1">
                             <div class="fieldDescription">Hides the list while the number of items in the list is
-                                less than this. The list will be shown once the number of items is greater than
+                                less than this minimum. The list will be shown once the number of items is at least
                                 this minimum. Leave blank or 0 to never hide.</div>
                         </div>
 
@@ -733,7 +733,7 @@
                             <label class="inputLabel inputLabelUnfocused" for="defaultMinItems">Default Min Items</label>
                             <input type="number" id="defaultMinItems" class="emby-input" min="0" step="1" value="1">
                             <div class="fieldDescription">Hides the list while the number of items in the list is
-                                less than this. The list will be shown once the number of items is greater than
+                                less than this minimum. The list will be shown once the number of items is at least
                                 this minimum. Leave blank or 0 to never hide. Applied to new lists that don't set
                                 their own value.</div>
                         </div>

--- a/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
@@ -211,7 +211,7 @@
                             <label class="inputLabel inputLabelUnfocused" for="playlistMinItems">Min Items</label>
                             <input type="number" id="playlistMinItems" class="emby-input" min="0" step="1" value="1">
                             <div class="fieldDescription">Hides the list while the number of items in the list is
-                                less than this. The list will be shown once the number of items is greater than
+                                less than this minimum. The list will be shown once the number of items is at least
                                 this minimum. Leave blank or 0 to never hide.</div>
                         </div>
 

--- a/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
@@ -207,6 +207,14 @@
                             </div>
                         </div>
 
+                        <div class="inputContainer" style="margin-bottom: 1em; margin-top: 1em;">
+                            <label class="inputLabel inputLabelUnfocused" for="playlistMinItems">Min Items</label>
+                            <input type="number" id="playlistMinItems" class="emby-input" min="0" step="1" value="1">
+                            <div class="fieldDescription">Hides the list while the number of items in the list is
+                                less than this. The list will be shown once the number of items is greater than
+                                this minimum. Leave blank or 0 to never hide.</div>
+                        </div>
+
                         <div class="inputContainer playlist-only-field" style="margin-bottom: 1em; margin-top: 1em;">
                             <label class="inputLabel" for="playlistMaxPlayTimeMinutes"
                                 style="display: flex; align-items: center;">
@@ -387,21 +395,6 @@
                         </div>
 
                             <h3 class="sectionTitle" style="margin-top: 1.5em;">Presentation</h3>
-                        <div class="checkboxList paperList"
-                            style="padding: 0.5em 1em; margin-bottom: 1em; margin-top: 0.5em;">
-                            <label class="emby-checkbox-label">
-                                <input type="checkbox" is="emby-checkbox" id="playlistHideWhenEmpty"
-                                    data-embycheckbox="true" class="emby-checkbox" checked>
-                                <span class="checkboxLabel">Hide when empty</span>
-                                <span class="checkboxOutline">
-                                    <span class="material-icons checkboxIcon checkboxIcon-checked check"
-                                        aria-hidden="true"></span>
-                                    <span class="material-icons checkboxIcon checkboxIcon-unchecked"
-                                        aria-hidden="true"></span>
-                                </span>
-                            </label>
-                            <div class="fieldDescription">Don't create the playlist or collection while it has no matching items. If a refresh finds no items, the existing Jellyfin playlist/collection is removed and recreated automatically once items match again.</div>
-                        </div>
                         <div id="groupIntoCollectionsContainer" class="checkboxList paperList collection-only-field"
                             style="padding: 0.5em 1em; margin-bottom: 1em; margin-top: 0.5em;">
                             <label class="emby-checkbox-label">

--- a/Jellyfin.Plugin.SmartLists/Core/Models/SmartListDto.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Models/SmartListDto.cs
@@ -93,11 +93,23 @@ namespace Jellyfin.Plugin.SmartLists.Core.Models
         public bool GroupIntoCollections { get; set; } = false;
 
         /// <summary>
-        /// When true, the Jellyfin playlist/collection is not created (and an existing one is
-        /// removed) while the list's rules match zero items. It is recreated automatically
-        /// once items match again. The smart list configuration itself is never deleted.
+        /// Minimum number of matched items required for the Jellyfin playlist/collection to
+        /// exist. While the count is below this, the Jellyfin playlist/collection is not
+        /// created (and an existing one is removed) -- it is recreated automatically once the
+        /// count reaches the threshold again. The smart list configuration itself is never
+        /// deleted. Null or 0 means no minimum (always shown, even with zero items) --
+        /// this is the legacy behaviour and the current default. 1 reproduces the old
+        /// "hide when empty" checkbox exactly; see MigrateLegacyFields.
         /// </summary>
-        public bool HideWhenEmpty { get; set; } = false;
+        public int? MinItems { get; set; }
+
+        /// <summary>
+        /// Legacy input-only field, replaced by <see cref="MinItems"/>. Kept so existing saved
+        /// lists (which serialized this as a bool) still deserialize; migrated to MinItems and
+        /// cleared by MigrateLegacyFields, so it is never written back out.
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? HideWhenEmpty { get; set; }
 
         // State and limits
         public bool Enabled { get; set; } = true; // Default to enabled
@@ -173,11 +185,21 @@ namespace Jellyfin.Plugin.SmartLists.Core.Models
         public bool? Favorite { get; set; }
 
         /// <summary>
-        /// Migrates legacy IsPlayed rules to PlaybackStatus.
-        /// Called after deserialization.
+        /// Migrates legacy IsPlayed rules to PlaybackStatus, and the legacy HideWhenEmpty bool
+        /// to MinItems. Called after deserialization.
         /// </summary>
         public void MigrateLegacyFields()
         {
+            if (HideWhenEmpty.HasValue)
+            {
+                if (MinItems is null)
+                {
+                    MinItems = HideWhenEmpty.Value ? 1 : null;
+                }
+
+                HideWhenEmpty = null;
+            }
+
             if (ExpressionSets != null)
             {
                 foreach (var expressionSet in ExpressionSets)

--- a/Jellyfin.Plugin.SmartLists/Plugin.cs
+++ b/Jellyfin.Plugin.SmartLists/Plugin.cs
@@ -16,9 +16,35 @@ namespace Jellyfin.Plugin.SmartLists
             : base(applicationPaths, xmlSerializer)
         {
             Instance = this;
-            
+
             // Register assembly resolver to help .NET find ImageSharp DLL
             AppDomain.CurrentDomain.AssemblyResolve += OnAssemblyResolve;
+
+            MigrateLegacyConfiguration();
+        }
+
+        /// <summary>
+        /// Migrates the legacy DefaultHideWhenEmpty bool to DefaultMinItems, once. Jellyfin's XML
+        /// configuration loader silently drops elements with no matching property, so an existing
+        /// installation's saved DefaultHideWhenEmpty is otherwise lost on upgrade and every new
+        /// list would silently fall back to DefaultMinItems' class initializer (1) regardless of
+        /// what the admin had configured. Only a genuinely pre-existing config has this field set
+        /// at all -- a fresh install never serializes it -- so there's no ambiguity here between
+        /// "never configured" and "admin set it back to the default" the way there can be for a
+        /// value with its own default. Saves the configuration back immediately with the legacy
+        /// field cleared, so this only ever runs its migration branch once.
+        /// </summary>
+        private void MigrateLegacyConfiguration()
+        {
+            var config = Configuration;
+            if (!config.DefaultHideWhenEmpty.HasValue)
+            {
+                return;
+            }
+
+            config.DefaultMinItems = config.DefaultHideWhenEmpty.Value ? 1 : null;
+            config.DefaultHideWhenEmpty = null;
+            SaveConfiguration(config);
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
@@ -343,7 +343,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                 // Recovery: if the stored Jellyfin collection ID is stale (e.g. lost after a DB
                 // migration or restore), re-find the collection via the SmartLists provider ID
                 // stamped on it at creation. Never match by name - duplicate names are legal.
-                // Runs before the hide-when-empty check so that an empty refresh deletes the
+                // Runs before the minimum-items check so that a below-threshold refresh deletes the
                 // recovered collection instead of leaving it orphaned.
                 if (existingCollectionItem == null && !string.IsNullOrEmpty(dto.Id))
                 {
@@ -364,12 +364,12 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                     }
                 }
 
-                // Hide when empty: don't keep a Jellyfin collection around while no items match
-                if (dto.HideWhenEmpty && newLinkedChildren.Length == 0)
+                // Minimum items: don't keep a Jellyfin collection around while it's below the floor
+                if (dto.MinItems.GetValueOrDefault() > 0 && newLinkedChildren.Length < dto.MinItems)
                 {
                     if (existingCollectionItem != null)
                     {
-                        _logger.LogInformation("Smart collection '{CollectionName}' matched no items - deleting Jellyfin collection (hide when empty)", dto.Name);
+                        _logger.LogInformation("Smart collection '{CollectionName}' matched {Count} item(s), below its minimum of {MinItems} - deleting Jellyfin collection", dto.Name, newLinkedChildren.Length, dto.MinItems);
                         _libraryManager.DeleteItem(existingCollectionItem, new DeleteOptions { DeleteFileLocation = true }, true);
 
                         // Drop it from this drain's snapshot too, so lists refreshed after this one
@@ -380,7 +380,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
                     // Clear the stored Jellyfin collection ID so a later refresh with items recreates it
                     dto.JellyfinCollectionId = null;
 
-                    return (true, $"Collection '{NameFormatter.FormatPlaylistName(dto.Name)}' has no items - hidden (hide when empty)", string.Empty);
+                    return (true, $"Collection '{NameFormatter.FormatPlaylistName(dto.Name)}' has {newLinkedChildren.Length} item(s), below its minimum of {dto.MinItems} - hidden", string.Empty);
                 }
 
                 var collectionName = dto.Name;

--- a/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
@@ -291,12 +291,12 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                 // Now that we've found the existing playlist (or not), apply the new naming format
                 var smartPlaylistName = NameFormatter.FormatPlaylistName(dto.Name);
 
-                // Hide when empty: don't keep a Jellyfin playlist around while no items match
-                if (dto.HideWhenEmpty && newLinkedChildren.Length == 0)
+                // Minimum items: don't keep a Jellyfin playlist around while it's below the floor
+                if (dto.MinItems.GetValueOrDefault() > 0 && newLinkedChildren.Length < dto.MinItems)
                 {
                     if (existingPlaylist != null)
                     {
-                        logger.LogInformation("Smart playlist '{PlaylistName}' matched no items - deleting Jellyfin playlist (hide when empty)", dto.Name);
+                        logger.LogInformation("Smart playlist '{PlaylistName}' matched {Count} item(s), below its minimum of {MinItems} - deleting Jellyfin playlist", dto.Name, newLinkedChildren.Length, dto.MinItems);
                         _libraryManager.DeleteItem(existingPlaylist, new DeleteOptions { DeleteFileLocation = true }, true);
 
                         // Drop it from this drain's snapshot too, so lists refreshed after this one
@@ -333,7 +333,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                         }
                     }
 
-                    return (true, $"Playlist '{smartPlaylistName}' has no items - hidden (hide when empty)", string.Empty);
+                    return (true, $"Playlist '{smartPlaylistName}' has {newLinkedChildren.Length} item(s), below its minimum of {dto.MinItems} - hidden", string.Empty);
                 }
 
                 if (existingPlaylist != null)

--- a/Jellyfin.Plugin.SmartLists/Utilities/DtoMapper.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/DtoMapper.cs
@@ -42,7 +42,7 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
                 Order = source.Order,
                 MediaTypes = source.MediaTypes,
                 IncludeExtras = source.IncludeExtras,
-                HideWhenEmpty = source.HideWhenEmpty,
+                MinItems = source.MinItems,
                 
                 // State and limits
                 Enabled = source.Enabled,
@@ -119,7 +119,7 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
                 IncludeExtras = source.IncludeExtras,
                 MatchByMembers = source.MatchByMembers,
                 GroupIntoCollections = source.GroupIntoCollections,
-                HideWhenEmpty = source.HideWhenEmpty,
+                MinItems = source.MinItems,
 
                 // State and limits
                 Enabled = source.Enabled,

--- a/docs/content/user-guide/configuration.md
+++ b/docs/content/user-guide/configuration.md
@@ -203,6 +203,7 @@ The remaining fields live inside the collapsed **More options** section, grouped
 - **Limits**
   - Set the maximum number of items
   - Set the maximum playtime for the list (playlists only)
+  - Hide the list while its item count is below a minimum you set (see [Min Items](#min-items))
   - Configure random group selection (see [Random Group Selection](sorting-and-limits.md#random-group-selection))
 - **Bumpers** — weave short interstitial items between the playlist's main items (playlists only, see [Bumpers](bumpers.md))
 - **Automation**
@@ -214,7 +215,6 @@ The remaining fields live inside the collapsed **More options** section, grouped
   - Decide if the list should be public or private (playlists only - collections are always server-wide)
 - **Presentation**
   - Upload custom images and set metadata such as sort title, overview, tags and favorite (see [Custom Images](#custom-images) and [Metadata](#metadata) above)
-  - Hide the Jellyfin playlist/collection while the list matches no items (see [Hide When Empty](#hide-when-empty))
   - Replace matched items with the collections that contain them (collections only, see [Group results into collections](media-types.md#group-into-collections))
 
 !!! info "User Page Differences"
@@ -272,7 +272,7 @@ Configure global settings for the plugin:
 - Set the default sort order for new lists
 - Set the default media types pre-selected for new lists (types only available for collections are skipped when creating a playlist)
 - Set the default max items and max playtime for new lists
-- Set whether new lists hide when empty by default
+- Set the default minimum items to show for new lists
 - Configure custom prefix and suffix for list names
 - Set the default auto-refresh mode for new lists
 - Set the default custom schedule settings for new lists
@@ -322,17 +322,20 @@ Disabling lists can be useful for:
 !!! tip "Use Visibility Scheduling Instead"
     For seasonal or time-based list visibility, consider using [Visibility Scheduling](auto-refresh.md#visibility-scheduling) instead of manually enabling/disabling lists. This automates the process and ensures lists appear and disappear exactly when you want them to.
 
-## Hide When Empty
+## Min Items
 
-With **Hide when empty** (in the **Presentation** group under **More options** when creating or editing a list), a smart list's Jellyfin playlist or collection is hidden while its rules match no items:
+With **Min Items** (in the **Limits** group under **More options** when creating or editing a list, next to Max Items), a smart list's Jellyfin playlist or collection is hidden while its matched item count is below a threshold you set:
 
-- If a refresh finds **no matching items**, the Jellyfin playlist/collection is removed (or never created in the first place).
-- As soon as a later refresh finds matching items again, it is recreated automatically — including any custom images and metadata you configured.
+- If a refresh finds **fewer matching items than the minimum**, the Jellyfin playlist/collection is removed (or never created in the first place).
+- As soon as a later refresh's count reaches the minimum again, it is recreated automatically — including any custom images and metadata you configured.
 - The smart list configuration itself is never deleted; it stays visible in the Smart Lists interface.
+- Leave the field blank or set it to `0` to always show the list, even with zero items — this is the default for existing lists.
+- Setting it to `1` reproduces the old **Hide when empty** behaviour exactly: the list is only hidden when it matches nothing at all.
+- Any value above `1` also hides thinly-populated lists — useful for e.g. a tag-based collection you only want visible once it has a handful of items, not just one.
 
-This is useful for seasonal or rotating lists (e.g. "Halloween movies" driven by a schedule or an external list) that would otherwise linger as empty entries in your library. For multi-user playlists, hiding applies per user: a user with no matching items has their playlist hidden while other users keep theirs.
+This is useful for seasonal or rotating lists (e.g. "Halloween movies" driven by a schedule or an external list) that would otherwise linger as near-empty entries in your library. For multi-user playlists, hiding applies per user: a user below the minimum has their playlist hidden while other users keep theirs.
 
-New lists have this enabled by default. Admins can change the default for new lists with **Hide lists when empty by default** in the Settings tab; the per-list checkbox always takes precedence, and changing the global setting does not affect existing lists. The Settings-tab default applies to lists created from the admin configuration page — the user page always starts new lists with **Hide when empty** enabled.
+New lists default to a minimum of `1` (equivalent to the old **Hide when empty** default). Admins can change the default for new lists with **Default Min Items** in the Settings tab; the per-list field always takes precedence, and changing the global setting does not affect existing lists. The Settings-tab default applies to lists created from the admin configuration page — the user page always starts new lists with a minimum of `1`.
 
 ## Custom List Naming
 


### PR DESCRIPTION
Replaces the boolean "hide when empty" toggle with a nullable MinItems count on SmartListDto, shared by playlists and collections. A list's Jellyfin playlist/collection is deleted (and recreated automatically on a later refresh) while its matched item count is below MinItems, the same delete/recreate mechanism HideWhenEmpty already used at count == 0, generalised to any threshold.

- MinItems: null/0 = always show (new default, matches old off-state). 1 reproduces old HideWhenEmpty exactly. >1 also hides thinly-populated lists, not just empty ones.
- Legacy HideWhenEmpty bool kept as a write-suppressed input-only field and migrated to MinItems in MigrateLegacyFields(), so existing saved lists behave identically after upgrading -- no manual reconfiguration.
- PluginConfiguration.DefaultHideWhenEmpty -> DefaultMinItems (int?, default 1, same effective default as before).
- Field renamed "Min Items", placed next to Max Items under Limits (not Presentation, where the old checkbox lived -- both are count-based caps on the same list).
- Config UI: config.html, user-playlists.html, config-core.js, config-init.js, config-lists.js, config-templates.js updated, including the Manage Lists advanced-summary chip and read-only details table row.
- docs/content/user-guide/configuration.md updated: section renamed, moved into the Limits bullet list, anchor updated.

Testing:
- dotnet build (net9.0 and net10.0, --no-incremental): 0 warnings, 0 errors.
- dotnet test: 1,678/1,678 passing.
- Live-verified against a throwaway Jellyfin container running a ZFS clone of a real production config/library (not synthetic test data): all 110 existing collections loaded with no errors, confirming the migration path. Set an existing collection's MinItems above its current item count, refreshed, confirmed the Jellyfin BoxSet was deleted; reset to null, refreshed, confirmed it was recreated.

Note: saving a MinItems edit in the UI does not itself trigger a refresh -- the new threshold only takes effect on the list's next refresh (manual, scheduled, or AutoRefresh), same as every other field. Left consistent with existing behaviour rather than special-cased.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable **Min Items** setting for lists and defaults.
  * Lists can remain hidden until they reach a specified item count; blank or 0 keeps them visible.
  * Added minimum-item indicators and details throughout list configuration screens.
  * New lists and templates inherit the configured minimum-item default when applicable.

* **Bug Fixes**
  * Existing lists using the former hide-when-empty setting are migrated automatically while preserving behavior.

* **Documentation**
  * Updated the user guide with the new minimum-items behavior and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->