### PR TITLE
Drop the net9.0 (Jellyfin 10.11) target from main

### DIFF
--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -7,7 +7,7 @@ description: Drive the SmartLists plugin against the local dev Jellyfin containe
 
 ## Build + deploy (from repo root; works from worktrees too)
 
-Before deploying, compile-check BOTH target frameworks (the container only runs net10.0, but the project must also build for net9.0 / Jellyfin 10.11):
+Before deploying, compile-check the plugin (net10.0 / Jellyfin 12):
 
 ```bash
 dotnet build Jellyfin.Plugin.SmartLists/Jellyfin.Plugin.SmartLists.csproj -c Release --no-incremental

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -7,7 +7,7 @@ description: Drive the SmartLists plugin against the local dev Jellyfin containe
 
 ## Build + deploy (from repo root; works from worktrees too)
 
-Before deploying, compile-check BOTH target frameworks (the container only runs net10.0, but the project must also build for net9.0 / Jellyfin 10.11):
+Before deploying, compile-check the plugin (net10.0 / Jellyfin 12):
 
 ```bash
 dotnet build Jellyfin.Plugin.SmartLists/Jellyfin.Plugin.SmartLists.csproj -c Release --no-incremental

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,22 +40,11 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore
 
-      # Both ABIs are built because the plugin ships both and the build treats all
-      # warnings as errors (AnalysisMode=Recommended) - an analyzer regression on
-      # either target should fail here, not at release-tag time.
-      # net9.0 compiles against reference packs, so no .NET 9 runtime is needed.
-      - name: Build plugin (net9.0 / Jellyfin 10.11)
+      - name: Build plugin
         run: >-
           dotnet build Jellyfin.Plugin.SmartLists/Jellyfin.Plugin.SmartLists.csproj
-          --framework net9.0 --configuration Release --no-restore
+          --configuration Release --no-restore
 
-      - name: Build plugin (net10.0 / Jellyfin 12)
-        run: >-
-          dotnet build Jellyfin.Plugin.SmartLists/Jellyfin.Plugin.SmartLists.csproj
-          --framework net10.0 --configuration Release --no-restore
-
-      # The test project targets net10.0 only - it needs a runtime to execute, and
-      # only .NET 10 is installed here. See the note in the test csproj.
       - name: Run tests
         run: >-
           dotnet test Jellyfin.Plugin.SmartLists.Tests/Jellyfin.Plugin.SmartLists.Tests.csproj

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,9 @@ env:
   # version published for them (v12.0.1.0) - Jellyfin offers every version whose targetAbi is at
   # or below the running server, so they keep a working build without being offered newer ones.
   # A 10.11 hotfix, if ever needed, is cut from the 10.11-release branch with this set to
-  # '[{"abi":"10.11.0.0","framework":"net9.0"}]'.
+  # '[{"abi":"10.11.0.0","framework":"net9.0"}]'. That branch sits at v12.0.1.0, the last
+  # commit that still carried the net9.0 target, so its hotfix workflow can build net9.0
+  # while main (net10.0-only) cannot.
   TARGETS: '[{"abi":"12.0.0.0","framework":"net10.0"}]'
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,7 @@ A Jellyfin plugin that creates dynamic playlists and collections based on user-d
 
 ```bash
 # Build + restart local Jellyfin Docker container (from /dev directory)
-./build-local.sh                        # defaults to Jellyfin 12.x (net10.0)
-JELLYFIN_ABI=10.11.0 ./build-local.sh   # build for Jellyfin 10.11 (net9.0)
+./build-local.sh                        # builds for Jellyfin 12 (net10.0)
 
 # View logs
 docker logs jellyfin 2>&1 | grep -i "Smart"
@@ -18,17 +17,17 @@ tail -f dev/jellyfin-data/config/log/log_*.log | grep "Smart"
 dotnet test Jellyfin.Plugin.SmartLists.Tests/Jellyfin.Plugin.SmartLists.Tests.csproj
 ```
 
-The project multi-targets `net9.0` (Jellyfin 10.11) and `net10.0` (Jellyfin 12.x). The build treats all warnings as errors with `AnalysisMode=Recommended` — CA analyzer warnings (e.g. CA1822 make-static, CA1305 locale) fail the build.
+The project targets `net10.0` (Jellyfin 12). The build treats all warnings as errors with `AnalysisMode=Recommended` — CA analyzer warnings (e.g. CA1822 make-static, CA1305 locale) fail the build.
 
 ### Tests
 
 Unit tests live in `Jellyfin.Plugin.SmartLists.Tests` (xunit, ~1,640 tests). They cover the pure-C# surface — the query engine (operators, prefilter resolvers, `FieldRegistry` invariants), the sort implementations in `Core/Orders/`, the external-list providers, and `Utilities/`. Every file under test is plain C# with no Jellyfin dependencies.
 
-The test project targets `net10.0` only, while the plugin multi-targets `net9.0;net10.0`. This is a runtime constraint, not a preference: no .NET 9 runtime is installed to run them on (`net9.0` compiles against reference packs, but the testhost aborts at launch). The upgrade path is documented in the test csproj. Warnings-as-errors and analyzers are deliberately relaxed in the test project, since tests do things production code must not.
+The test project targets `net10.0`, same as the plugin. Warnings-as-errors and analyzers are deliberately relaxed in the test project, since tests do things production code must not.
 
 Tests do **not** cover anything that touches Jellyfin at runtime — playlist and collection creation, refresh scheduling, or the config UI. Verify those by building and exercising the plugin against the local Jellyfin instance (<http://localhost:8096>); the `/verify` skill drives that flow.
 
-CI (`.github/workflows/ci.yml`) builds both ABIs and runs the tests on every pull request and on pushes to `main` and `10.11-release`.
+CI (`.github/workflows/ci.yml`) builds the plugin and runs the tests on every pull request and on pushes to `main` and `10.11-release`.
 
 ## Project Structure
 
@@ -142,7 +141,7 @@ Ordering always holds: `12.0.0.1 < 12.0.0.2 < 12.0.1.0` — so RC users auto-upd
 
 Releases now **ship forward to Jellyfin 12 only** — `TARGETS` in release.yml is `[{"abi":"12.0.0.0","framework":"net10.0"}]`, and each tag writes a single `targetAbi` entry to the manifest. The manifest branch (stable = main, unstable) is the release *channel*; git branches only anchor where tags are cut.
 
-**Jellyfin 10.11 servers are not broken by this, but they stop receiving new releases.** Jellyfin offers every version whose `targetAbi` is at or below the running server, so a 10.11 server simply stays on `v12.0.1.0` — the last version published with a 10.11 build — and keeps working. The csproj still deliberately multi-targets `net9.0;net10.0`, so a 10.11 hotfix cut from `10.11-release` remains possible if one is ever genuinely needed. This replaces the old dual-ABI-per-tag scheme, which had two problems: `targetAbi` is a *minimum* supported version with no maximum, so two entries sharing one version number showed as duplicate rows in the plugin UI; and worse, a server running the 10.11 build that upgraded to Jellyfin 12 was stranded — Jellyfin compares version numbers only, and since the version hadn't changed it offered no update, while the installed net9.0 build could not load on Jellyfin 12, leaving the plugin stuck showing "Not supported" with no way out but a manual reinstall.
+**Jellyfin 10.11 servers are not broken by this, but they stop receiving new releases.** Jellyfin offers every version whose `targetAbi` is at or below the running server, so a 10.11 server simply stays on `v12.0.1.0` — the last version published with a 10.11 build — and keeps working. `main` builds `net10.0` only; a 10.11 hotfix is still possible from `10.11-release`, which sits at `v12.0.1.0`, the last commit that carried the `net9.0` target. This replaces the old dual-ABI-per-tag scheme, which had two problems: `targetAbi` is a *minimum* supported version with no maximum, so two entries sharing one version number showed as duplicate rows in the plugin UI; and worse, a server running the 10.11 build that upgraded to Jellyfin 12 was stranded — Jellyfin compares version numbers only, and since the version hadn't changed it offered no update, while the installed net9.0 build could not load on Jellyfin 12, leaving the plugin stuck showing "Not supported" with no way out but a manual reinstall.
 
 #### Branches
 
@@ -150,7 +149,7 @@ Releases now **ship forward to Jellyfin 12 only** — `TARGETS` in release.yml i
 |---|---|
 | `main` | Trunk. All development lands here. **RCs are tagged here.** |
 | `12-release` | Tracks the **last stable release**. Fast-forwarded to `main` at each stable. **Stables are tagged here.** The mkdocs Cloudflare Worker publishes from this branch, so the docs site shows released state rather than unreleased trunk. |
-| `10.11-release` | Frozen just past `v10.11.30.2`. Outside the normal release flow — tag here **only** for a Jellyfin 10.11 hotfix, with `TARGETS` temporarily set to `[{"abi":"10.11.0.0","framework":"net9.0"}]` so the build targets `net9.0`. Never merge into. |
+| `10.11-release` | Pinned at `v12.0.1.0` — the last commit that still built `net9.0`, and the last version 10.11 servers were offered. Outside the normal release flow — tag here **only** for a Jellyfin 10.11 hotfix, with `TARGETS` temporarily set to `[{"abi":"10.11.0.0","framework":"net9.0"}]` so the build targets `net9.0`. Never merge into. |
 
 #### Cutting a release
 
@@ -169,7 +168,7 @@ Releases now **ship forward to Jellyfin 12 only** — `TARGETS` in release.yml i
 
 Bump the **Build** segment for stables; Revision is reserved exclusively for RC numbers. Ordering holds across the whole line, so RC users now roll straight into stables — the old trade-off where a `10.11.X.0` stable sorted *below* the `12.x` RCs and was never offered to RC users is gone with the split.
 
-Smoke testing the 10.11 ABI is no longer a routine pre-stable step, since 10.11 is no longer shipped by normal releases. Use it when preparing a 10.11 hotfix on `10.11-release`: `JELLYFIN_ABI=10.11.0 ./build-local.sh`.
+Smoke testing the 10.11 ABI is no longer a routine pre-stable step, since 10.11 is no longer shipped by normal releases. 10.11 can't be smoke-tested from `main` any more (no `net9.0` target); when preparing a 10.11 hotfix, check out `10.11-release` and use that branch's own `build-local.sh` with `JELLYFIN_ABI=10.11.0`.
 
 ## When Making Changes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,7 @@ A Jellyfin plugin that creates dynamic playlists and collections based on user-d
 
 ```bash
 # Build + restart local Jellyfin Docker container (from /dev directory)
-./build-local.sh                        # defaults to Jellyfin 12.x (net10.0)
-JELLYFIN_ABI=10.11.0 ./build-local.sh   # build for Jellyfin 10.11 (net9.0)
+./build-local.sh                        # builds for Jellyfin 12 (net10.0)
 
 # View logs
 docker logs jellyfin 2>&1 | grep -i "Smart"
@@ -18,17 +17,17 @@ tail -f dev/jellyfin-data/config/log/log_*.log | grep "Smart"
 dotnet test Jellyfin.Plugin.SmartLists.Tests/Jellyfin.Plugin.SmartLists.Tests.csproj
 ```
 
-The project multi-targets `net9.0` (Jellyfin 10.11) and `net10.0` (Jellyfin 12.x). The build treats all warnings as errors with `AnalysisMode=Recommended` — CA analyzer warnings (e.g. CA1822 make-static, CA1305 locale) fail the build.
+The project targets `net10.0` (Jellyfin 12). The build treats all warnings as errors with `AnalysisMode=Recommended` — CA analyzer warnings (e.g. CA1822 make-static, CA1305 locale) fail the build.
 
 ### Tests
 
 Unit tests live in `Jellyfin.Plugin.SmartLists.Tests` (xunit, ~1,640 tests). They cover the pure-C# surface — the query engine (operators, prefilter resolvers, `FieldRegistry` invariants), the sort implementations in `Core/Orders/`, the external-list providers, and `Utilities/`. Every file under test is plain C# with no Jellyfin dependencies.
 
-The test project targets `net10.0` only, while the plugin multi-targets `net9.0;net10.0`. This is a runtime constraint, not a preference: no .NET 9 runtime is installed to run them on (`net9.0` compiles against reference packs, but the testhost aborts at launch). The upgrade path is documented in the test csproj. Warnings-as-errors and analyzers are deliberately relaxed in the test project, since tests do things production code must not.
+The test project targets `net10.0`, same as the plugin. Warnings-as-errors and analyzers are deliberately relaxed in the test project, since tests do things production code must not.
 
 Tests do **not** cover anything that touches Jellyfin at runtime — playlist and collection creation, refresh scheduling, or the config UI. Verify those by building and exercising the plugin against the local Jellyfin instance (<http://localhost:8096>); the `/verify` skill drives that flow.
 
-CI (`.github/workflows/ci.yml`) builds both ABIs and runs the tests on every pull request and on pushes to `main` and `10.11-release`.
+CI (`.github/workflows/ci.yml`) builds the plugin and runs the tests on every pull request and on pushes to `main` and `10.11-release`.
 
 ## Project Structure
 
@@ -142,7 +141,7 @@ Ordering always holds: `12.0.0.1 < 12.0.0.2 < 12.0.1.0` — so RC users auto-upd
 
 Releases now **ship forward to Jellyfin 12 only** — `TARGETS` in release.yml is `[{"abi":"12.0.0.0","framework":"net10.0"}]`, and each tag writes a single `targetAbi` entry to the manifest. The manifest branch (stable = main, unstable) is the release *channel*; git branches only anchor where tags are cut.
 
-**Jellyfin 10.11 servers are not broken by this, but they stop receiving new releases.** Jellyfin offers every version whose `targetAbi` is at or below the running server, so a 10.11 server simply stays on `v12.0.1.0` — the last version published with a 10.11 build — and keeps working. The csproj still deliberately multi-targets `net9.0;net10.0`, so a 10.11 hotfix cut from `10.11-release` remains possible if one is ever genuinely needed. This replaces the old dual-ABI-per-tag scheme, which had two problems: `targetAbi` is a *minimum* supported version with no maximum, so two entries sharing one version number showed as duplicate rows in the plugin UI; and worse, a server running the 10.11 build that upgraded to Jellyfin 12 was stranded — Jellyfin compares version numbers only, and since the version hadn't changed it offered no update, while the installed net9.0 build could not load on Jellyfin 12, leaving the plugin stuck showing "Not supported" with no way out but a manual reinstall.
+**Jellyfin 10.11 servers are not broken by this, but they stop receiving new releases.** Jellyfin offers every version whose `targetAbi` is at or below the running server, so a 10.11 server simply stays on `v12.0.1.0` — the last version published with a 10.11 build — and keeps working. `main` builds `net10.0` only; a 10.11 hotfix is still possible from `10.11-release`, which sits at `v12.0.1.0`, the last commit that carried the `net9.0` target. This replaces the old dual-ABI-per-tag scheme, which had two problems: `targetAbi` is a *minimum* supported version with no maximum, so two entries sharing one version number showed as duplicate rows in the plugin UI; and worse, a server running the 10.11 build that upgraded to Jellyfin 12 was stranded — Jellyfin compares version numbers only, and since the version hadn't changed it offered no update, while the installed net9.0 build could not load on Jellyfin 12, leaving the plugin stuck showing "Not supported" with no way out but a manual reinstall.
 
 #### Branches
 
@@ -150,7 +149,7 @@ Releases now **ship forward to Jellyfin 12 only** — `TARGETS` in release.yml i
 |---|---|
 | `main` | Trunk. All development lands here. **RCs are tagged here.** |
 | `12-release` | Tracks the **last stable release**. Fast-forwarded to `main` at each stable. **Stables are tagged here.** The mkdocs Cloudflare Worker publishes from this branch, so the docs site shows released state rather than unreleased trunk. |
-| `10.11-release` | Frozen just past `v10.11.30.2`. Outside the normal release flow — tag here **only** for a Jellyfin 10.11 hotfix, with `TARGETS` temporarily set to `[{"abi":"10.11.0.0","framework":"net9.0"}]` so the build targets `net9.0`. Never merge into. |
+| `10.11-release` | Pinned at `v12.0.1.0` — the last commit that still built `net9.0`, and the last version 10.11 servers were offered. Outside the normal release flow — tag here **only** for a Jellyfin 10.11 hotfix, with `TARGETS` temporarily set to `[{"abi":"10.11.0.0","framework":"net9.0"}]` so the build targets `net9.0`. Never merge into. |
 
 #### Cutting a release
 
@@ -169,7 +168,7 @@ Releases now **ship forward to Jellyfin 12 only** — `TARGETS` in release.yml i
 
 Bump the **Build** segment for stables; Revision is reserved exclusively for RC numbers. Ordering holds across the whole line, so RC users now roll straight into stables — the old trade-off where a `10.11.X.0` stable sorted *below* the `12.x` RCs and was never offered to RC users is gone with the split.
 
-Smoke testing the 10.11 ABI is no longer a routine pre-stable step, since 10.11 is no longer shipped by normal releases. Use it when preparing a 10.11 hotfix on `10.11-release`: `JELLYFIN_ABI=10.11.0 ./build-local.sh`.
+Smoke testing the 10.11 ABI is no longer a routine pre-stable step, since 10.11 is no longer shipped by normal releases. 10.11 can't be smoke-tested from `main` any more (no `net9.0` target); when preparing a 10.11 hotfix, check out `10.11-release` and use that branch's own `build-local.sh` with `JELLYFIN_ABI=10.11.0`.
 
 ## When Making Changes
 

--- a/Jellyfin.Plugin.SmartLists.Tests/Jellyfin.Plugin.SmartLists.Tests.csproj
+++ b/Jellyfin.Plugin.SmartLists.Tests/Jellyfin.Plugin.SmartLists.Tests.csproj
@@ -1,20 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!--
-      ponytail: CEILING - tests run on net10.0 (Jellyfin 12 ABI) only, while the plugin
-      multi-targets net9.0;net10.0. Not a design preference: no .NET 9 *runtime* exists
-      to run them on. This machine has only Microsoft.NETCore.App 10.0.7, and CI
-      (.github/workflows/release.yml, DOTNET_VERSION: 10.0.x) installs only the 10 SDK.
-      net9.0 *compiles* via reference packs but the testhost aborts at launch:
-      "You must install or update .NET to run this application. Framework:
-      'Microsoft.NETCore.App', version '9.0.0'".
-      UPGRADE PATH: install the .NET 9 runtime locally (and add 9.0.x to setup-dotnet in
-      CI), then change this single line to <TargetFrameworks>net9.0;net10.0</TargetFrameworks>.
-      Nothing else here needs to change - the ProjectReference already TFM-matches.
-      Low urgency: every file under test is pure C# with zero Jellyfin dependencies, so
-      the two ABIs differ only in BCL, not in plugin surface.
-    -->
+    <!-- Tests run on net10.0 (Jellyfin 12 ABI), same as the plugin. -->
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.SmartLists.Tests</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
@@ -2471,9 +2471,9 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
         }
 
         /// <summary>
-        /// Cached reflection lookup for the ABI-shared ILibraryManager.GetPeople(InternalPeopleQuery)
-        /// overload. Shared by every per-item people extraction path and (on 10.11) the
-        /// prefilter's people name dump so all callers reuse the same MethodInfo cache.
+        /// Cached reflection lookup for the ILibraryManager.GetPeople(InternalPeopleQuery)
+        /// overload. Shared by every per-item people extraction path so all callers reuse
+        /// the same MethodInfo cache.
         /// </summary>
         /// <param name="libraryManager">The library manager whose concrete type carries the method.</param>
         /// <returns>The GetPeople method, or null when the lookup fails.</returns>

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/PeoplePrefilterResolver.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/PeoplePrefilterResolver.cs
@@ -3,9 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using MediaBrowser.Controller.Entities;
 using Microsoft.Extensions.Logging;
-#if !NET10_0_OR_GREATER
-using System.Reflection;
-#endif
 
 namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
 {
@@ -16,29 +13,23 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
     /// 1. Resolve which STORED person names the rule matches by evaluating the operator in
     ///    memory (via the same <see cref="Engine"/> helpers the compiled rules bind) against
     ///    a bulk name dump from the people table. This step is mandatory, not an
-    ///    optimization: the item query's Person clause is byte-exact case-sensitive on
-    ///    Jellyfin 10.11, so passing the user's raw rule value would silently under-match.
+    ///    optimization: the item query's Person clause is byte-exact, so passing the
+    ///    user's raw rule value would silently under-match.
     /// 2. One user-neutral GetItemIds(Person = exact stored name) query per matched name.
     ///    The union over matched names is a guaranteed superset of the items whose people
     ///    list satisfies the rule, because every name in an item's extracted people list
     ///    also exists as a people-table row reachable through the same dump.
     ///
-    /// Role handling differs per ABI:
-    /// - net10 (Jellyfin 12): names are dumped via GetPeopleNames, whose SQL is a plain
-    ///   ordinal Distinct over Name - unlike GetPeople, whose no-ItemId branch collapses to
-    ///   ONE arbitrary row per LOWERCASED name and would drop case-only duplicate spellings
-    ///   (each stored spelling needs its own byte-exact item query). Role-specific fields
-    ///   push the role into the people query itself (InternalPeopleQuery.PersonTypes is
-    ///   translated BEFORE the name projection) and into the item query (Person +
-    ///   PersonTypes compose). Never role-filter dump results in memory on 12.
-    /// - net9 (Jellyfin 10.11): the GetPeople dump has no collapse and returns one row per
-    ///   (Name, Type); it runs ONCE per filter run and each role's names are derived from
-    ///   it in memory with the same Type.ToString() comparison CategorizePeople uses.
-    ///   PersonTypes is a silent no-op on 10.11 item queries, so the per-name item query is
-    ///   any-role there - a valid superset; role verification stays per-item.
+    /// Names are dumped via GetPeopleNames, whose SQL is a plain ordinal Distinct over
+    /// Name - unlike GetPeople, whose no-ItemId branch collapses to ONE arbitrary row per
+    /// LOWERCASED name and would drop case-only duplicate spellings (each stored spelling
+    /// needs its own byte-exact item query). Role-specific fields push the role into the
+    /// people query itself (InternalPeopleQuery.PersonTypes is translated BEFORE the name
+    /// projection) and into the item query (Person + PersonTypes compose). Never
+    /// role-filter dump results in memory.
     ///
     /// ActorRoles never rides: role strings live on the people map row and are not
-    /// filterable in either ABI. Negative operators are rejected centrally by
+    /// filterable. Negative operators are rejected centrally by
     /// <see cref="CandidateSetBuilder"/> (SupportsNegativeOperators stays false).
     /// </summary>
     internal sealed class PeoplePrefilterResolver : IRulePrefilterResolver
@@ -133,15 +124,12 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
                     Person = name,
                     GroupByPresentationUniqueKey = false,
                 };
-#if NET10_0_OR_GREATER
                 // Jellyfin 12 composes Person + PersonTypes into an indexed role-specific
-                // lookup. On 10.11 PersonTypes is declared but never read by TranslateQuery,
-                // so the query stays any-role there (still a superset).
+                // lookup.
                 if (role != null)
                 {
                     query.PersonTypes = [role];
                 }
-#endif
                 result.UnionWith(context.LibraryManager.GetItemIds(query));
             }
 
@@ -218,7 +206,6 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
                 return cached;
             }
 
-#if NET10_0_OR_GREATER
             // Jellyfin 12: GetPeopleNames only - its SQL is an ordinal Distinct over Name,
             // so every distinct stored spelling survives and gets its own byte-exact item
             // query. GetPeople's no-ItemId branch instead collapses to one arbitrary row
@@ -232,103 +219,8 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
                 : new InternalPeopleQuery([role], []);
 
             IReadOnlyList<string>? names = context.LibraryManager.GetPeopleNames(query);
-#else
-            // Jellyfin 10.11 returns one GetPeople row per (Name, Type) with no collapse:
-            // dump the table once per filter run and derive each role's names in memory
-            // with the same Type.ToString() comparison the per-item CategorizePeople
-            // switch uses. (PersonTypes narrowing in the people query is 12-only behavior,
-            // and 10.11's GetPeopleNames cannot be used - it drops the Type column.)
-            var names = FilterNamesByRole(GetDumpRows(context), role);
-#endif
             _namesByRole[cacheKey] = names;
             return names;
         }
-
-#if !NET10_0_OR_GREATER
-        /// <summary>
-        /// The unrestricted (Name, Type) dump rows for this filter run, materialized at most
-        /// once; null when the dump is unavailable. See <see cref="_dumpAttempted"/>.
-        /// </summary>
-        private IReadOnlyList<(string Name, string? Type)>? _dumpRows;
-
-        /// <summary>
-        /// Whether the dump has been attempted, so a failed dump is not retried per role.
-        /// </summary>
-        private bool _dumpAttempted;
-
-        /// <summary>
-        /// Runs the unrestricted people dump through the reflected ABI-shared
-        /// ILibraryManager.GetPeople(InternalPeopleQuery), once per filter run.
-        /// </summary>
-        private IReadOnlyList<(string Name, string? Type)>? GetDumpRows(PrefilterContext context)
-        {
-            if (_dumpAttempted)
-            {
-                return _dumpRows;
-            }
-
-            _dumpAttempted = true;
-            var getPeopleMethod = OperandFactory.GetPeopleQueryMethod(context.LibraryManager);
-            if (getPeopleMethod == null)
-            {
-                return null;
-            }
-
-            var result = getPeopleMethod.Invoke(context.LibraryManager, [new InternalPeopleQuery()]);
-            if (result is not IEnumerable<object> rows)
-            {
-                return null;
-            }
-
-            var dump = new List<(string Name, string? Type)>();
-            PropertyInfo? nameProperty = null;
-            PropertyInfo? typeProperty = null;
-            foreach (var row in rows)
-            {
-                if (row == null)
-                {
-                    continue;
-                }
-
-                nameProperty ??= row.GetType().GetProperty("Name");
-                typeProperty ??= row.GetType().GetProperty("Type");
-                if (nameProperty?.GetValue(row) is not string name || name.Length == 0)
-                {
-                    continue;
-                }
-
-                dump.Add((name, typeProperty?.GetValue(row)?.ToString()));
-            }
-
-            _dumpRows = dump;
-            return _dumpRows;
-        }
-
-        /// <summary>
-        /// Derives the distinct names for a role (null = any role) from the dump rows.
-        /// Ordinal distinctness is deliberate: names differing only by case are distinct
-        /// stored rows and each needs its own byte-exact item query on 10.11.
-        /// </summary>
-        private static IReadOnlyList<string>? FilterNamesByRole(IReadOnlyList<(string Name, string? Type)>? rows, string? role)
-        {
-            if (rows == null)
-            {
-                return null;
-            }
-
-            var names = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var (name, type) in rows)
-            {
-                if (role != null && !string.Equals(type, role, StringComparison.Ordinal))
-                {
-                    continue;
-                }
-
-                names.Add(name);
-            }
-
-            return [.. names];
-        }
-#endif
     }
 }

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/StreamLanguagePrefilterResolver.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Prefilters/StreamLanguagePrefilterResolver.cs
@@ -2,10 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
-#if NET10_0_OR_GREATER
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Model.Entities;
-#endif
 
 namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
 {
@@ -40,13 +38,6 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
     /// are a subset of all audio-stream languages, so the any-stream candidate set is a
     /// superset and default-ness stays verified per-item.
     ///
-    /// Jellyfin 10.11 (net9.0) contributes no candidates: there is no positive language
-    /// filter there, and the double-negation route over HasNo*TrackWithLanguage has
-    /// verified false-negative traps (the server silently DROPS the filter when it cannot
-    /// resolve the code - collapsing pool-minus-result to an empty candidate set - and its
-    /// SQL IN over stored codes is case-sensitive where the plugin compare is not). Those
-    /// rules simply stay per-item on 10.11.
-    ///
     /// Negative operators are rejected centrally by <see cref="CandidateSetBuilder"/>
     /// (SupportsNegativeOperators stays false); MatchRegex patterns matching the empty
     /// string are rejected both centrally and here (empty stream lists test against "").
@@ -65,7 +56,6 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
         /// <inheritdoc />
         public HashSet<Guid>? Resolve(Expression expression, PrefilterContext context)
         {
-#if NET10_0_OR_GREATER
             var isAudio = string.Equals(expression.MemberName, "AudioLanguages", StringComparison.Ordinal);
             if ((!isAudio && !string.Equals(expression.MemberName, "SubtitleLanguages", StringComparison.Ordinal))
                 || context.LibraryManager == null)
@@ -133,11 +123,6 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
 
             // Fresh set per call - the caller owns and mutates the result.
             return [.. ids];
-#else
-            // Jellyfin 10.11: no positive language filter; the double-negation route has
-            // verified false-negative traps (see the class doc). Always per-item.
-            return null;
-#endif
         }
 
         /// <summary>
@@ -188,7 +173,6 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
             return matched;
         }
 
-#if NET10_0_OR_GREATER
         /// <summary>
         /// Per-stream-kind raw code dumps for this filter run (the resolver lives for one
         /// CandidateSetBuilder.Build call); null when the dump failed, so a failure is not
@@ -221,6 +205,5 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine.Prefilters
             _dumpByType[streamType] = codes;
             return codes;
         }
-#endif
     }
 }

--- a/Jellyfin.Plugin.SmartLists/Jellyfin.Plugin.SmartLists.csproj
+++ b/Jellyfin.Plugin.SmartLists/Jellyfin.Plugin.SmartLists.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.SmartLists</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn Condition="'$(TargetFramework)' == 'net10.0'">$(NoWarn);CA1873</NoWarn>
+    <NoWarn>$(NoWarn);CA1873</NoWarn>
     <Nullable>enable</Nullable>
     <AnalysisMode>Recommended</AnalysisMode>
     <!-- Version will be set dynamically during build from git tag -->
@@ -68,10 +68,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.11.0" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="Jellyfin.Model" Version="10.11.0" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="Jellyfin.Controller" Version="12.0.*-*" Condition="'$(TargetFramework)' == 'net10.0'" />
-    <PackageReference Include="Jellyfin.Model" Version="12.0.*-*" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Jellyfin.Controller" Version="12.0.*-*" />
+    <PackageReference Include="Jellyfin.Model" Version="12.0.*-*" />
     <!-- ImageSharp is bundled with the plugin as Jellyfin doesn't provide it -->
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12">
       <Private>true</Private>

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/BasicDirectoryService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/BasicDirectoryService.cs
@@ -17,7 +17,6 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
         public FileSystemMetadata? GetDirectory(string path) => null;
         public FileSystemMetadata? GetFileSystemEntry(string path) => null;
         public IReadOnlyList<string> GetFilePaths(string path) => [];
-#if NET10_0_OR_GREATER
         public IReadOnlyList<string> GetFilePaths(string path, bool clearCache) => GetFilePaths(path);
         public void Invalidate(string path)
         {
@@ -26,7 +25,6 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
         public void Move(string source, string destination)
         {
         }
-#endif
         public IReadOnlyList<string> GetFilePaths(string path, bool clearCache, bool sort) => GetFilePaths(path);
         public bool IsAccessible(string path) => false;
     }

--- a/Jellyfin.Plugin.SmartLists/Utilities/LinkedChildFactory.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/LinkedChildFactory.cs
@@ -5,7 +5,7 @@ using MediaBrowser.Model.Entities;
 namespace Jellyfin.Plugin.SmartLists.Utilities
 {
     /// <summary>
-    /// Creates LinkedChild instances with the correct shape for the target Jellyfin ABI.
+    /// Creates LinkedChild instances.
     /// </summary>
     public static class LinkedChildFactory
     {
@@ -13,11 +13,7 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
         {
             ArgumentNullException.ThrowIfNull(item);
 
-#if NET10_0_OR_GREATER
             return new LinkedChild { ItemId = itemId };
-#else
-            return new LinkedChild { ItemId = itemId, Path = item.Path };
-#endif
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <div align="center">
     <p>
         <img alt="Logo" src="https://raw.githubusercontent.com/jyourstone/jellyfin-smartlists-plugin/main/images/logo.jpg" height="350"/><br />
-        <a href="https://github.com/jyourstone/jellyfin-smartlists-plugin/releases"><img alt="Total GitHub Downloads" src="https://img.shields.io/github/downloads/jyourstone/jellyfin-smartlists-plugin/total"/></a> <a href="https://github.com/jyourstone/jellyfin-smartlists-plugin/issues"><img alt="GitHub Issues or Pull Requests" src="https://img.shields.io/github/issues/jyourstone/jellyfin-smartlists-plugin"/></a> <a href="https://github.com/jyourstone/jellyfin-smartlists-plugin/releases"><img alt="Build and Release" src="https://github.com/jyourstone/jellyfin-smartlists-plugin/actions/workflows/release.yml/badge.svg"/></a> <a href="https://jellyfin.org/"><img alt="Jellyfin Version" src="https://img.shields.io/badge/Jellyfin-10.11%20%7C%2012.x-blue.svg"/></a>
+        <a href="https://github.com/jyourstone/jellyfin-smartlists-plugin/releases"><img alt="Total GitHub Downloads" src="https://img.shields.io/github/downloads/jyourstone/jellyfin-smartlists-plugin/total"/></a> <a href="https://github.com/jyourstone/jellyfin-smartlists-plugin/issues"><img alt="GitHub Issues or Pull Requests" src="https://img.shields.io/github/issues/jyourstone/jellyfin-smartlists-plugin"/></a> <a href="https://github.com/jyourstone/jellyfin-smartlists-plugin/releases"><img alt="Build and Release" src="https://github.com/jyourstone/jellyfin-smartlists-plugin/actions/workflows/release.yml/badge.svg"/></a> <a href="https://jellyfin.org/"><img alt="Jellyfin Version" src="https://img.shields.io/badge/Jellyfin-12.x-blue.svg"/></a>
     </p>        
 </div>
 
@@ -10,7 +10,7 @@ Create smart, rule-based **playlists and collections** in Jellyfin — for movie
 
 A single genre rule takes seconds; stack rules into groups and you can express almost anything. Either way, they keep themselves up to date. The plugin features a modern web-based interface for easy list management - no technical knowledge required.
 
-**Requires Jellyfin version `10.11.0` and newer.**
+**Requires Jellyfin 12.** Jellyfin 10.11 servers stay on `v12.0.1.0`, the last release built for them.
 
 ## ✨ Features
 

--- a/dev/build-local.ps1
+++ b/dev/build-local.ps1
@@ -5,7 +5,7 @@
 
 $ErrorActionPreference = "Stop" # Exit immediately if a command fails
 
-# Set the Jellyfin ABI for local testing. Defaults to Jellyfin 12 RC/dev.
+# Set the Jellyfin ABI for local testing. Written into the dev manifest; build targets net10.0 only.
 $JellyfinAbi = $env:JELLYFIN_ABI
 if ([string]::IsNullOrWhiteSpace($JellyfinAbi)) {
     $JellyfinAbi = "12.0.0"
@@ -16,16 +16,7 @@ if ([string]::IsNullOrWhiteSpace($VERSION)) {
     $VERSION = "$JellyfinAbi.0"
 }
 
-$TargetFramework = $env:TARGET_FRAMEWORK
-if ([string]::IsNullOrWhiteSpace($TargetFramework)) {
-    if ($JellyfinAbi.StartsWith("10.11.")) {
-        $TargetFramework = "net9.0"
-    } elseif ($JellyfinAbi.StartsWith("12.")) {
-        $TargetFramework = "net10.0"
-    } else {
-        throw "Unsupported JELLYFIN_ABI '$JellyfinAbi'. Expected 10.11.x or 12.x."
-    }
-}
+$TargetFramework = "net10.0"
 
 $OUTPUT_DIR = "..\build_output"
 

--- a/dev/build-local.ps1
+++ b/dev/build-local.ps1
@@ -5,11 +5,8 @@
 
 $ErrorActionPreference = "Stop" # Exit immediately if a command fails
 
-# Set the Jellyfin ABI for local testing. Written into the dev manifest; build targets net10.0 only.
-$JellyfinAbi = $env:JELLYFIN_ABI
-if ([string]::IsNullOrWhiteSpace($JellyfinAbi)) {
-    $JellyfinAbi = "12.0.0"
-}
+# Jellyfin ABI written into the dev manifest. Fixed: the build is net10.0 / Jellyfin 12 only.
+$JellyfinAbi = "12.0.0"
 
 $VERSION = $env:VERSION
 if ([string]::IsNullOrWhiteSpace($VERSION)) {

--- a/dev/build-local.sh
+++ b/dev/build-local.sh
@@ -5,8 +5,8 @@
 
 set -e # Exit immediately if a command exits with a non-zero status.
 
-# Set the Jellyfin ABI for local testing. Written into the dev manifest; build targets net10.0 only.
-JELLYFIN_ABI="${JELLYFIN_ABI:-12.0.0}"
+# Jellyfin ABI written into the dev manifest. Fixed: the build is net10.0 / Jellyfin 12 only.
+JELLYFIN_ABI="12.0.0"
 VERSION="${VERSION:-${JELLYFIN_ABI}.0}"
 TARGET_FRAMEWORK="net10.0"
 OUTPUT_DIR="../build_output"

--- a/dev/build-local.sh
+++ b/dev/build-local.sh
@@ -5,21 +5,10 @@
 
 set -e # Exit immediately if a command exits with a non-zero status.
 
-# Set the Jellyfin ABI for local testing. Defaults to Jellyfin 12 RC/dev.
+# Set the Jellyfin ABI for local testing. Written into the dev manifest; build targets net10.0 only.
 JELLYFIN_ABI="${JELLYFIN_ABI:-12.0.0}"
 VERSION="${VERSION:-${JELLYFIN_ABI}.0}"
-case "$JELLYFIN_ABI" in
-    10.11.*)
-        TARGET_FRAMEWORK="${TARGET_FRAMEWORK:-net9.0}"
-        ;;
-    12.*)
-        TARGET_FRAMEWORK="${TARGET_FRAMEWORK:-net10.0}"
-        ;;
-    *)
-        echo "Unsupported JELLYFIN_ABI '$JELLYFIN_ABI'. Expected 10.11.x or 12.x."
-        exit 1
-        ;;
-esac
+TARGET_FRAMEWORK="net10.0"
 OUTPUT_DIR="../build_output"
 
 echo "Building SmartLists plugin for Jellyfin ABI $JELLYFIN_ABI ($TARGET_FRAMEWORK)..."

--- a/docs/content/development/building-locally.md
+++ b/docs/content/development/building-locally.md
@@ -48,18 +48,7 @@ The build scripts automatically:
 - Restart the Jellyfin Docker container
 - Make the plugin available in your local Jellyfin instance
 
-By default, the scripts build for Jellyfin ABI `12.0.0` using `net10.0`, which matches the Jellyfin 12 RC development container. To test against Jellyfin 10.11, set `JELLYFIN_ABI=10.11.0` before running the script:
-
-```bash
-cd dev
-JELLYFIN_ABI=10.11.0 ./build-local.sh
-```
-
-```powershell
-cd dev
-$env:JELLYFIN_ABI = "10.11.0"
-.\build-local.ps1
-```
+The scripts build for Jellyfin 12 (`net10.0`), which matches the development container. Jellyfin 10.11 is no longer a build target on `main`.
 
 ### 2. Access Jellyfin
 

--- a/docs/content/development/building-locally.md
+++ b/docs/content/development/building-locally.md
@@ -88,4 +88,4 @@ dev/jellyfin-data/config/log/
 
 ### Development Metadata
 
-**`meta-dev.json`** is a development-specific plugin manifest for the default Jellyfin 12 development setup. The build scripts generate `build_output/meta.json` from the selected `JELLYFIN_ABI` value during local builds.
+**`meta-dev.json`** is a development-specific plugin manifest for the default Jellyfin 12 development setup. The build scripts generate `build_output/meta.json` with the Jellyfin 12 ABI during local builds.

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -6,7 +6,7 @@
         <a href="https://github.com/jyourstone/jellyfin-smartlists-plugin/releases"><img alt="Total GitHub Downloads" src="https://img.shields.io/github/downloads/jyourstone/jellyfin-smartlists-plugin/total"/></a> 
         <a href="https://github.com/jyourstone/jellyfin-smartlists-plugin/issues"><img alt="GitHub Issues or Pull Requests" src="https://img.shields.io/github/issues/jyourstone/jellyfin-smartlists-plugin"/></a> 
         <a href="https://github.com/jyourstone/jellyfin-smartlists-plugin/releases"><img alt="Build and Release" src="https://github.com/jyourstone/jellyfin-smartlists-plugin/actions/workflows/release.yml/badge.svg"/></a> 
-        <a href="https://jellyfin.org/"><img alt="Jellyfin Version" src="https://img.shields.io/badge/Jellyfin-10.11%20%7C%2012.x-blue.svg"/></a>
+        <a href="https://jellyfin.org/"><img alt="Jellyfin Version" src="https://img.shields.io/badge/Jellyfin-12.x-blue.svg"/></a>
     </p>        
 </div>
 
@@ -16,7 +16,7 @@ Create smart, rule-based playlists and collections in Jellyfin — for movies, s
 
 The documentation is published twice — a [stable site](https://jellyfin-smartlists-plugin.dinsten.se/) tracking the current release, and a [preview site](https://jellyfin-smartlists-plugin-preview.dinsten.se/) tracking release candidates. If you installed from the [unstable manifest](getting-started/installation.md#try-rc-releases-unstable), use the preview site.
 
-**Requires Jellyfin version `10.11.0` and newer.**
+**Requires Jellyfin 12.** Jellyfin 10.11 servers stay on `v12.0.1.0`, the last release built for them.
 
 ## Project Links
 


### PR DESCRIPTION
Releases ship for Jellyfin 12 only (ship-forward decision, see CLAUDE.md "Release Line"), so `main` no longer needs to compile against the Jellyfin 10.11 ABI. This makes the plugin target `net10.0` alone.

## What changes

- **csproj**: `net9.0;net10.0` → `net10.0`; the 10.11.0 `Jellyfin.Controller`/`Jellyfin.Model` references and the framework conditions are gone.
- **Conditional code removed** (kept the NET10 path everywhere):
  - `PeoplePrefilterResolver` — the 10.11 `GetPeople` dump-based name lookup (`GetDumpRows`, `FilterNamesByRole`, ~85 lines) and its reflection using.
  - `StreamLanguagePrefilterResolver` — the 10.11 `return null` stub and the class-doc paragraph about it.
  - `LinkedChildFactory` — the 10.11 `Path = item.Path` branch.
  - `BasicDirectoryService` — the guard around `Invalidate`/`Move`/`GetFilePaths(path, clearCache)`.
  - A `Factory.cs` doc comment that referenced the dump path.
- **CI**: the net9.0 build step is gone; the remaining step is just "Build plugin".
- **Local build scripts** (`build-local.sh`, `build-local.ps1`): no `JELLYFIN_ABI` → framework switch; always `net10.0`.
- **Docs/agent docs**: CLAUDE.md/AGENTS.md, test-csproj note, README + docs index badge/"Requires Jellyfin 12", building-locally.md, verify skill.

## 10.11 hotfix escape hatch

Still exists, and is actually more usable now: `10.11-release` was sitting at `a5d2b63` (Aug 15), 269 commits behind `v12.0.1.0` — the last version shipped to 10.11 servers. It has been re-pointed to `v12.0.1.0` (`7aac4ff`), the last commit that still carried the `net9.0` target. A 10.11 hotfix is cut there with `TARGETS` overridden as documented in `release.yml`.

## Testing

- `dotnet build --no-incremental`: 0 warnings, 0 errors (warnings-as-errors, `AnalysisMode=Recommended`).
- `dotnet test`: 1678/1678 passing.
- Deployed to the local Jellyfin 12 container via the simplified `build-local.sh`; plugin loaded (18 playlists, 12 collections). Refreshed one Actors-rule collection and one SubtitleLanguages-rule collection to exercise both touched prefilters live — `People prefilter: Actors Contains matched 1 names -> 7 candidate items`, `Stream language prefilter: SubtitleLanguages Equal matched 1 raw codes -> 38 candidate items`, both refreshes completed with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Compatibility**
  - The plugin now supports Jellyfin 12 (net10.0) exclusively.
  - Jellyfin 10.11 users should remain on version 12.0.1.0.

- **Build and Release**
  - Local builds and CI now use the Jellyfin 12 target only.
  - Jellyfin 10.11 hotfix builds remain available from the dedicated release branch.

- **Documentation**
  - Requirements, build instructions, version badges, and testing guidance now reflect Jellyfin 12 support and the separate Jellyfin 10.11 maintenance path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->