### PR TITLE
Fix MDBList official list URLs returning zero items

### DIFF
--- a/Jellyfin.Plugin.SmartLists.Tests/Services/ExternalList/MdbListProviderTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Services/ExternalList/MdbListProviderTests.cs
@@ -1,0 +1,41 @@
+using Jellyfin.Plugin.SmartLists.Services.ExternalList;
+
+namespace Jellyfin.Plugin.SmartLists.Tests.Services.ExternalList;
+
+/// <summary>
+/// ParseMdbListUrl is internal, reached through the InternalsVisibleTo wiring in
+/// Jellyfin.Plugin.SmartLists.csproj. Official lists (issue #525) use a three-segment web URL
+/// whose middle segment is a media type, not part of the list slug.
+/// </summary>
+public class MdbListProviderTests
+{
+    [Theory]
+    [InlineData("https://mdblist.com/lists/jxduffy/star-wars-chronological-order", "jxduffy", "star-wars-chronological-order", null)]
+    [InlineData("https://mdblist.com/lists/jxduffy/star-wars-chronological-order/", "jxduffy", "star-wars-chronological-order", null)]  // trailing slash
+    [InlineData("https://mdblist.com/lists/jxduffy/star-wars-chronological-order?foo=bar", "jxduffy", "star-wars-chronological-order", null)]
+    [InlineData("https://mdblist.com/lists/official/shows/popular", "official", "popular", "show")]
+    [InlineData("https://mdblist.com/lists/official/movies/justwatch-streaming-charts", "official", "justwatch-streaming-charts", "movie")]
+    [InlineData("https://mdblist.com/lists/official/movies/justwatch-streaming-charts?locale=en_US&rank=1&provider=&genre=", "official", "justwatch-streaming-charts", "movie")]  // web-only filters ignored
+    [InlineData("https://MDBLIST.COM/lists/official/SHOWS/popular", "official", "popular", "show")]  // case-insensitive
+    [InlineData("https://mdblist.com/lists/official/popular", "official", "popular", null)]  // no media segment: combined list
+    [InlineData("https://mdblist.com/lists/jxduffy", null, null, null)]  // missing list name
+    [InlineData("https://mdblist.com/lists/", null, null, null)]
+    [InlineData("not-a-url", null, null, null)]
+    public void ParseMdbListUrl_ExtractsUserListAndOfficialForms(string url, string? username, string? listname, string? mediaType)
+    {
+        Assert.Equal((username, listname, mediaType), MdbListProvider.ParseMdbListUrl(url));
+    }
+
+    // The JustWatch official page is a live chart; its website filters share names with the chart API.
+    [Theory]
+    [InlineData("https://mdblist.com/lists/official/movies/justwatch-streaming-charts", "")]
+    [InlineData("https://mdblist.com/lists/official/movies/justwatch-streaming-charts?locale=en_US&rank=1&provider=&genre=", "&locale=en_US&rank=1")]  // empty values dropped
+    [InlineData("https://mdblist.com/lists/official/movies/justwatch-streaming-charts?locale=de_DE&rank=7&provider=nfx&genre=act", "&locale=de_DE&rank=7&provider=nfx&genre=act")]
+    [InlineData("https://mdblist.com/lists/official/movies/justwatch-streaming-charts?LOCALE=en_GB&apikey=x&foo=bar", "&locale=en_GB")]  // unknown keys dropped, key case-insensitive
+    [InlineData("https://mdblist.com/lists/official/movies/justwatch-streaming-charts?provider=a%26b", "&provider=a%26b")]  // value re-escaped
+    [InlineData("not-a-url", "")]
+    public void BuildJustWatchChartQuery_ForwardsOnlyKnownNonEmptyFilters(string url, string expected)
+    {
+        Assert.Equal(expected, MdbListProvider.BuildJustWatchChartQuery(url));
+    }
+}

--- a/Jellyfin.Plugin.SmartLists/Services/ExternalList/MdbListModels.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/ExternalList/MdbListModels.cs
@@ -62,4 +62,14 @@ namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
         [JsonPropertyName("mdblist")]
         public string? MdbList { get; set; }
     }
+
+    /// <summary>
+    /// Response wrapper for the MDBList JustWatch streaming chart endpoint
+    /// (/justwatch/streaming-charts/{movie|show}). Items carry the same "ids" object as list items.
+    /// </summary>
+    public class MdbListJustWatchChartResponse
+    {
+        [JsonPropertyName("results")]
+        public MdbListItem[]? Results { get; set; }
+    }
 }

--- a/Jellyfin.Plugin.SmartLists/Services/ExternalList/MdbListProvider.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/ExternalList/MdbListProvider.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -12,11 +13,17 @@ namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
     /// <summary>
     /// Fetches list items from the MDBList API (api.mdblist.com).
     /// Supports URLs like https://mdblist.com/lists/{username}/{listname}
+    /// and official lists like https://mdblist.com/lists/official/{movies|shows}/{listname}
     /// </summary>
     public partial class MdbListProvider : IExternalListProvider
     {
         private const string ApiBaseUrl = "https://api.mdblist.com";
         private const int PageSize = 1000;
+
+        private const string JustWatchChartSlug = "justwatch-streaming-charts";
+
+        // Website chart filters share their names with the chart API's query parameters.
+        private static readonly string[] JustWatchChartParams = ["locale", "country", "rank", "period", "provider", "genre", "subgenre"];
 
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILogger<MdbListProvider> _logger;
@@ -48,14 +55,21 @@ namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
                 throw new InvalidOperationException("MDBList API key is not configured. Set the API key in Settings > External Lists.");
             }
 
-            var (username, listname) = ParseMdbListUrl(url);
+            var (username, listname, mediaType) = ParseMdbListUrl(url);
             if (username == null || listname == null)
             {
-                _logger.LogWarning("Could not parse MDBList URL: {Url}. Expected format: https://mdblist.com/lists/{{username}}/{{listname}}", url);
+                _logger.LogWarning("Could not parse MDBList URL: {Url}. Expected format: https://mdblist.com/lists/{{username}}/{{listname}} or https://mdblist.com/lists/official/{{movies|shows}}/{{listname}}", url);
                 return result;
             }
 
-            _logger.LogInformation("Fetching external list from MDBList: {Username}/{ListName}", username, listname);
+            _logger.LogInformation("Fetching external list from MDBList: {Username}/{ListName} (mediatype: {MediaType})", username, listname, mediaType ?? "all");
+
+            if (username == "official" && mediaType != null && string.Equals(listname, JustWatchChartSlug, StringComparison.OrdinalIgnoreCase))
+            {
+                return await FetchJustWatchChartAsync(url, mediaType, apiKey, cancellationToken).ConfigureAwait(false);
+            }
+
+            var mediaTypeFilter = mediaType == null ? string.Empty : "&mediatype=" + mediaType;
 
             var httpClient = _httpClientFactory.CreateClient("MdbList");
             int offset = 0;
@@ -68,7 +82,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    var apiUrl = $"{ApiBaseUrl}/lists/{Uri.EscapeDataString(username)}/{Uri.EscapeDataString(listname)}/items?apikey={Uri.EscapeDataString(apiKey)}&limit={PageSize}&offset={offset}";
+                    var apiUrl = $"{ApiBaseUrl}/lists/{Uri.EscapeDataString(username)}/{Uri.EscapeDataString(listname)}/items?apikey={Uri.EscapeDataString(apiKey)}&limit={PageSize}&offset={offset}{mediaTypeFilter}";
 
                     using var response = await httpClient.GetAsync(apiUrl, cancellationToken).ConfigureAwait(false);
 
@@ -166,6 +180,80 @@ namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
             return result;
         }
 
+        /// <summary>
+        /// The official JustWatch page on mdblist.com is a live chart (top 20 for a country/period/provider/genre)
+        /// served by a dedicated endpoint. /lists/official/justwatch-streaming-charts/items is an aggregate across
+        /// every chart and does not match what the page shows, so the web URL's filters are forwarded instead.
+        /// </summary>
+        private async Task<ExternalListResult> FetchJustWatchChartAsync(string url, string mediaType, string apiKey, CancellationToken cancellationToken)
+        {
+            var result = new ExternalListResult();
+            var apiUrl = $"{ApiBaseUrl}/justwatch/streaming-charts/{mediaType}?apikey={Uri.EscapeDataString(apiKey)}{BuildJustWatchChartQuery(url)}";
+            var httpClient = _httpClientFactory.CreateClient("MdbList");
+            int position = 0;
+
+            try
+            {
+                using var response = await httpClient.GetAsync(apiUrl, cancellationToken).ConfigureAwait(false);
+                if (!response.IsSuccessStatusCode)
+                {
+                    _logger.LogWarning("MDBList API returned {StatusCode} for JustWatch {MediaType} chart", response.StatusCode, mediaType);
+                    return result;
+                }
+
+                var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                var chart = JsonSerializer.Deserialize<MdbListJustWatchChartResponse>(json);
+                foreach (var item in chart?.Results ?? [])
+                {
+                    AddItemIds(item, result, ref position, GetItemKind(item.MediaType ?? mediaType));
+                }
+            }
+            catch (Exception ex) when (ex is HttpRequestException or JsonException)
+            {
+                _logger.LogWarning(ex, "Error fetching MDBList JustWatch {MediaType} chart", mediaType);
+            }
+
+            result.TotalItems = position;
+            result.IsComplete = true;
+            _logger.LogInformation("Fetched {Count} items from MDBList JustWatch {MediaType} chart (IMDb: {ImdbCount}, TMDB: {TmdbCount}, TVDB: {TvdbCount})",
+                position, mediaType, result.ImdbIds.Count, result.TmdbIds.Count, result.TvdbIds.Count);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Forwards the chart filters from the web URL query string (locale, rank, provider, genre, ...)
+        /// as "&amp;key=value" pairs. Unknown and empty parameters are dropped.
+        /// </summary>
+        internal static string BuildJustWatchChartQuery(string url)
+        {
+            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) || string.IsNullOrEmpty(uri.Query))
+            {
+                return string.Empty;
+            }
+
+            var query = new StringBuilder();
+            foreach (var pair in uri.Query.TrimStart('?').Split('&', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var separatorIndex = pair.IndexOf('=', StringComparison.Ordinal);
+                if (separatorIndex <= 0)
+                {
+                    continue;
+                }
+
+                var key = Uri.UnescapeDataString(pair[..separatorIndex]).ToLowerInvariant();
+                var value = Uri.UnescapeDataString(pair[(separatorIndex + 1)..]);
+                if (string.IsNullOrWhiteSpace(value) || Array.IndexOf(JustWatchChartParams, key) < 0)
+                {
+                    continue;
+                }
+
+                query.Append('&').Append(key).Append('=').Append(Uri.EscapeDataString(value));
+            }
+
+            return query.ToString();
+        }
+
         private static void AddItemIds(MdbListItem item, ExternalListResult result, ref int position, ExternalListItemKind kind)
         {
             // Add IMDb ID from top-level or nested ids (TryAdd keeps first/lowest position for duplicates)
@@ -187,19 +275,32 @@ namespace Jellyfin.Plugin.SmartLists.Services.ExternalList
         }
 
         /// <summary>
-        /// Parses a MDBList URL into username and list name components.
+        /// Parses a MDBList URL into username, list name and optional media type filter.
         /// Supports: https://mdblist.com/lists/{username}/{listname}
+        ///           https://mdblist.com/lists/official/{movies|shows}/{listname}
+        /// Official lists live under the reserved "official" username and combine movies and shows;
+        /// the web URL's media segment maps to the API's mediatype query filter.
         /// </summary>
-        private static (string? Username, string? ListName) ParseMdbListUrl(string url)
+        internal static (string? Username, string? ListName, string? MediaType) ParseMdbListUrl(string url)
         {
+            var official = MdbListOfficialUrlPattern().Match(url);
+            if (official.Success)
+            {
+                var mediaType = official.Groups[1].Value.Equals("movies", StringComparison.OrdinalIgnoreCase) ? "movie" : "show";
+                return ("official", official.Groups[2].Value, mediaType);
+            }
+
             var match = MdbListUrlPattern().Match(url);
             if (match.Success)
             {
-                return (match.Groups[1].Value, match.Groups[2].Value);
+                return (match.Groups[1].Value, match.Groups[2].Value, null);
             }
 
-            return (null, null);
+            return (null, null, null);
         }
+
+        [GeneratedRegex(@"mdblist\.com/lists/official/(movies|shows)/([^/?#]+)", RegexOptions.IgnoreCase)]
+        private static partial Regex MdbListOfficialUrlPattern();
 
         [GeneratedRegex(@"mdblist\.com/lists/([^/]+)/([^/?#]+)", RegexOptions.IgnoreCase)]
         private static partial Regex MdbListUrlPattern();

--- a/docs/content/user-guide/external-lists.md
+++ b/docs/content/user-guide/external-lists.md
@@ -43,6 +43,9 @@ Items are matched by comparing provider IDs between the external list and your l
 | Type | URL format |
 |------|-----------|
 | User list | `https://mdblist.com/lists/{username}/{listname}` |
+| Official list | `https://mdblist.com/lists/official/{movies\|shows}/{listname}` |
+
+The official **JustWatch Streaming Charts** list is a live top-20 chart. The country, period, provider and genre filters you pick on the MDBList website end up in the URL (e.g. `?locale=en_US&rank=7&provider=nfx`) and are applied by the plugin, so copy the URL after choosing your filters. Some official lists shown on the website are not exposed by the MDBList API and return no items.
 
 **Example:**
 


### PR DESCRIPTION
## What
Makes MDBList "official" list URLs (`mdblist.com/lists/official/{movies|shows}/{listname}`) fetch items instead of silently returning nothing.

Fixes #525

## Why
The URL regex took the first two path segments, so `official/shows/popular` resolved to user `official`, list `shows` — the slug was dropped and the API answered 404. Official lists live at `/lists/official/{slug}/items`, with the `movies|shows` segment of the web URL mapping to the API's `mediatype` filter.

The official **JustWatch Streaming Charts** page is a different beast: it's a live top-20 chart served by `/justwatch/streaming-charts/{movie|show}`, not a stored list. `/lists/official/justwatch-streaming-charts/items` is an aggregate across every country/period (146 movies) and does not match what the page shows. The website's filter form (`locale`, `rank`, `provider`, `genre`) uses the same parameter names as the chart API, so they are forwarded from the pasted URL.

## Changes
- `MdbListProvider.cs`
  - Second regex for `official/{movies|shows}/{slug}`; returns username `official`, the slug, and a `mediatype` filter appended to the items request.
  - `official/{movies|shows}/justwatch-streaming-charts` routed to `FetchJustWatchChartAsync`, which calls the chart endpoint and forwards whitelisted query params (`locale`, `country`, `rank`, `period`, `provider`, `genre`, `subgenre`); empty/unknown params dropped. No query = `en_US` daily, same as the website default.
  - Parse-failure warning now mentions the official URL format; fetch log shows the mediatype.
- `MdbListModels.cs` — `MdbListJustWatchChartResponse` (`results` array, reuses `MdbListItem`).
- `MdbListProviderTests.cs` (new) — URL parsing (11 cases) and chart query forwarding (6 cases).
- `docs/content/user-guide/external-lists.md` — Official list row; note that JustWatch filters come from the URL, and that some official lists on the website aren't exposed by the API.

## Verified
Against the dev container with a real API key:
- `official/movies/popular` → 50 items, matched library titles.
- `official/movies/justwatch-streaming-charts` → 20 items, matching the website's US daily top 20 exactly (previously 146 aggregate items).
- Website slugs `anticipated`, `most-watched`, `streaming-charts`, `trending` return 404 from the MDBList API itself; the existing warning log covers those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for MDBList official movie and show list URLs.
  - JustWatch Streaming Charts now preserve supported filters from copied URLs, including country, period, provider, and genre.
  - Media-type filtering is applied when loading eligible MDBList URLs.

- **Documentation**
  - Updated the external lists guide with supported official URLs, filter behavior, and API availability notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->