### PR TITLE
Live TV Channel media type for smart collections

### DIFF
--- a/Jellyfin.Plugin.SmartLists.Tests/Core/Constants/MediaTypesTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Core/Constants/MediaTypesTests.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using Jellyfin.Data.Enums;
+using MediaTypeConstants = Jellyfin.Plugin.SmartLists.Core.Constants.MediaTypes;
+
+namespace Jellyfin.Plugin.SmartLists.Tests.Core.Constants;
+
+public class MediaTypesTests
+{
+    [Fact]
+    public void LiveTvChannel_MapsToLiveTvChannelKind_InBothDirections()
+    {
+        // The query side uses BaseItemKind.LiveTvChannel; the runtime GetBaseItemKind() of a
+        // LiveTvChannel item is TvChannel, which is why OperandFactory/AutoRefreshService match
+        // the class directly instead.
+        Assert.Equal(BaseItemKind.LiveTvChannel, MediaTypeConstants.MediaTypeToBaseItemKind[MediaTypeConstants.LiveTvChannel]);
+        Assert.Equal(MediaTypeConstants.LiveTvChannel, MediaTypeConstants.BaseItemKindToMediaType[BaseItemKind.LiveTvChannel]);
+    }
+
+    [Fact]
+    public void Mappings_RoundTrip_AndAllHasNoDuplicates()
+    {
+        foreach (var (kind, mediaType) in MediaTypeConstants.BaseItemKindToMediaType)
+        {
+            Assert.Equal(kind, MediaTypeConstants.MediaTypeToBaseItemKind[mediaType]);
+        }
+
+        foreach (var (mediaType, kind) in MediaTypeConstants.MediaTypeToBaseItemKind)
+        {
+            Assert.Equal(mediaType, MediaTypeConstants.BaseItemKindToMediaType[kind]);
+        }
+
+        Assert.Equal(MediaTypeConstants.All.Length, MediaTypeConstants.All.Distinct().Count());
+    }
+}

--- a/Jellyfin.Plugin.SmartLists.Tests/Utilities/InputValidatorTests.cs
+++ b/Jellyfin.Plugin.SmartLists.Tests/Utilities/InputValidatorTests.cs
@@ -1014,6 +1014,7 @@ public class InputValidatorTests
     [InlineData(MediaTypeConstants.Series)]
     [InlineData(MediaTypeConstants.Season)]
     [InlineData(MediaTypeConstants.MusicAlbum)]
+    [InlineData(MediaTypeConstants.LiveTvChannel)]
     [InlineData(MediaTypeConstants.Collection)]
     [InlineData(MediaTypeConstants.Playlist)]
     public void ValidateSmartList_ContainerBumperMediaTypes_AreRejectedBecausePlaylistsCannotHoldThem(string mediaType)

--- a/Jellyfin.Plugin.SmartLists/Configuration/config-core.js
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config-core.js
@@ -168,6 +168,7 @@
         { Value: "Photo", Label: "Photo (Home Photo)" },
         { Value: "Book", Label: "Book" },
         { Value: "AudioBook", Label: "Audiobook" },
+        { Value: "LiveTvChannel", Label: "Live TV Channel", CollectionOnly: true }, // Jellyfin playlists silently drop channels (SupportsAddingToPlaylist is false)
         { Value: "Collection", Label: "Collection", CollectionOnly: true }, // Containers can only be added to Collections, not Playlists
         { Value: "Playlist", Label: "Playlist", CollectionOnly: true } // Containers can only be added to Collections, not Playlists
     ];

--- a/Jellyfin.Plugin.SmartLists/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/config.html
@@ -608,6 +608,7 @@
                                             <option value="Photo">Photo (Home Photo)</option>
                                             <option value="Book">Book</option>
                                             <option value="AudioBook">Audiobook</option>
+                                            <option value="LiveTvChannel">Live TV Channel</option>
                                         </select>
                                     </div>
 

--- a/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
+++ b/Jellyfin.Plugin.SmartLists/Configuration/user-playlists.html
@@ -549,6 +549,7 @@
                                             <option value="Photo">Photo (Home Photo)</option>
                                             <option value="Book">Book</option>
                                             <option value="AudioBook">Audiobook</option>
+                                            <option value="LiveTvChannel">Live TV Channel</option>
                                         </select>
                                     </div>
                                 </div>

--- a/Jellyfin.Plugin.SmartLists/Core/Constants/MediaTypes.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/Constants/MediaTypes.cs
@@ -42,6 +42,14 @@ namespace Jellyfin.Plugin.SmartLists.Core.Constants
         public const string Book = nameof(Book);
         public const string AudioBook = nameof(AudioBook);
 
+        // Live TV Types
+        // LiveTvChannel media type: Not supported in Playlists (Jellyfin's PlaylistManager drops any
+        // item whose SupportsAddingToPlaylist is false, and LiveTvChannel never overrides it) but
+        // supported in Collections. Note: LiveTvChannel.GetBaseItemKind() returns BaseItemKind.TvChannel
+        // at runtime, so the runtime type-name switches in OperandFactory/AutoRefreshService match the
+        // LiveTvChannel class directly instead of going through BaseItemKindToMediaType.
+        public const string LiveTvChannel = nameof(LiveTvChannel);
+
         // Container Types
         // Collection media type (BoxSet): Not supported in Playlists (Jellyfin playlists can only
         // contain media items; containers are silently dropped) but supported in Collections
@@ -74,6 +82,8 @@ namespace Jellyfin.Plugin.SmartLists.Core.Constants
             { BaseItemKind.Season, Season },
             // MusicAlbum: Supported in Collections, not in Playlists
             { BaseItemKind.MusicAlbum, MusicAlbum },
+            // LiveTvChannel: Supported in Collections, not in Playlists
+            { BaseItemKind.LiveTvChannel, LiveTvChannel },
             // Collection: Supported in Collections, not in Playlists
             { BaseItemKind.BoxSet, Collection },
             // Playlist: Supported in Collections, not in Playlists
@@ -99,6 +109,8 @@ namespace Jellyfin.Plugin.SmartLists.Core.Constants
             { Season, BaseItemKind.Season },
             // MusicAlbum: Supported in Collections, not in Playlists
             { MusicAlbum, BaseItemKind.MusicAlbum },
+            // LiveTvChannel: Supported in Collections, not in Playlists
+            { LiveTvChannel, BaseItemKind.LiveTvChannel },
             // Collection: Supported in Collections, not in Playlists
             { Collection, BaseItemKind.BoxSet },
             // Playlist: Supported in Collections, not in Playlists

--- a/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartLists/Core/QueryEngine/Factory.cs
@@ -3220,6 +3220,7 @@ namespace Jellyfin.Plugin.SmartLists.Core.QueryEngine
                 Video => MediaTypes.Video,
                 Photo => MediaTypes.Photo,
                 Book => MediaTypes.Book,
+                MediaBrowser.Controller.LiveTv.LiveTvChannel => MediaTypes.LiveTvChannel,
                 _ => null,
             };
 

--- a/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Collections/CollectionService.cs
@@ -1410,9 +1410,10 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
             var validTopParentIds = GetLibraryTopParentIds();
 
             // Container kinds (BoxSet/Playlist) live in Jellyfin's internal collections/playlists
-            // folders, outside the library TopParentIds scope - query them separately without it
-            var containerKinds = baseItemKinds.Where(static k => k is BaseItemKind.BoxSet or BaseItemKind.Playlist).ToArray();
-            var itemKinds = baseItemKinds.Where(static k => k is not (BaseItemKind.BoxSet or BaseItemKind.Playlist)).ToArray();
+            // folders and Live TV channels have no library parent at all - both sit outside the
+            // library TopParentIds scope, so query them separately without it
+            var unscopedKinds = baseItemKinds.Where(static k => k is BaseItemKind.BoxSet or BaseItemKind.Playlist or BaseItemKind.LiveTvChannel).ToArray();
+            var itemKinds = baseItemKinds.Where(static k => k is not (BaseItemKind.BoxSet or BaseItemKind.Playlist or BaseItemKind.LiveTvChannel)).ToArray();
 
             // Query all items the owner user has access to
             var includeVirtualItems = SmartListUtilities.UsesLibraryNameRule(dto);
@@ -1431,15 +1432,15 @@ namespace Jellyfin.Plugin.SmartLists.Services.Collections
             }
 
             IEnumerable<BaseItem> allItems = items;
-            if (containerKinds.Length > 0)
+            if (unscopedKinds.Length > 0)
             {
-                var containerQuery = new InternalItemsQuery(ownerUser)
+                var unscopedQuery = new InternalItemsQuery(ownerUser)
                 {
-                    IncludeItemTypes = containerKinds,
+                    IncludeItemTypes = unscopedKinds,
                     Recursive = true,
                 };
 
-                allItems = allItems.Concat(_libraryManager.GetItemsResult(containerQuery).Items);
+                allItems = allItems.Concat(_libraryManager.GetItemsResult(unscopedQuery).Items);
             }
 
             if (dto?.IncludeExtras != true)

--- a/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Playlists/PlaylistService.cs
@@ -1224,6 +1224,14 @@ namespace Jellyfin.Plugin.SmartLists.Services.Playlists
                 return (false, $"{Core.Constants.MediaTypes.MusicAlbum} media type is not supported for Playlists. Use {Core.Constants.MediaTypes.Audio} media type, or create a Collection instead.", string.Empty);
             }
 
+            if (mediaTypes?.Contains(Core.Constants.MediaTypes.LiveTvChannel) == true)
+            {
+                _logger.LogError(
+                    "Smart playlist '{PlaylistName}' uses '{MediaType}' media type. Jellyfin playlists cannot contain Live TV channels. Create a Collection for Live TV support. Skipping playlist refresh.",
+                    playlistName, Core.Constants.MediaTypes.LiveTvChannel);
+                return (false, $"{Core.Constants.MediaTypes.LiveTvChannel} media type is not supported for Playlists. Jellyfin playlists cannot contain Live TV channels - create a Collection instead.", string.Empty);
+            }
+
             return (true, string.Empty, string.Empty);
         }
 

--- a/Jellyfin.Plugin.SmartLists/Services/Shared/AutoRefreshService.cs
+++ b/Jellyfin.Plugin.SmartLists/Services/Shared/AutoRefreshService.cs
@@ -1377,6 +1377,7 @@ namespace Jellyfin.Plugin.SmartLists.Services.Shared
                 MediaBrowser.Controller.Entities.Video => MediaTypes.Video,
                 MediaBrowser.Controller.Entities.Photo => MediaTypes.Photo,
                 MediaBrowser.Controller.Entities.Book => MediaTypes.Book,
+                MediaBrowser.Controller.LiveTv.LiveTvChannel => MediaTypes.LiveTvChannel,
                 _ => null,
             };
 

--- a/Jellyfin.Plugin.SmartLists/Utilities/InputValidator.cs
+++ b/Jellyfin.Plugin.SmartLists/Utilities/InputValidator.cs
@@ -413,6 +413,7 @@ namespace Jellyfin.Plugin.SmartLists.Utilities
                     mt == Core.Constants.MediaTypes.Series
                     || mt == Core.Constants.MediaTypes.Season
                     || mt == Core.Constants.MediaTypes.MusicAlbum
+                    || mt == Core.Constants.MediaTypes.LiveTvChannel
                     || Core.Constants.MediaTypes.IsContainerType(mt));
                 if (unsupportedBumperType != null)
                 {

--- a/docs/content/examples/common-use-cases.md
+++ b/docs/content/examples/common-use-cases.md
@@ -363,6 +363,14 @@ Collections are great for organizing related content that you want to browse tog
 - Works the same way for a tag on a plain folder inside the library, or on a season or series for episodes
 - See [Parent metadata options](../user-guide/fields-and-operators.md#parent-metadata-options) for the full list of what counts as a parent
 
+### Live TV Channel Group
+- **List Type**: Collection
+- **Media Type**: Live TV Channel
+- **Name** contains "Sport" OR **Name** contains "ESPN"
+- Groups matching channels from your Live TV tuners into one collection, which Jellyfin's own Live TV view can't do
+- Channels carry little metadata, so **Name**, **Tags** and **Is Favorite** are the useful rules; tag channels in Jellyfin's metadata editor to group them by anything else
+- **Note**: Collections only (Jellyfin playlists cannot hold channels) and requires Jellyfin 12.0 or newer
+
 ## Operator Examples
 
 ### Using "Is In" for Multiple Values

--- a/docs/content/user-guide/bumpers.md
+++ b/docs/content/user-guide/bumpers.md
@@ -23,7 +23,7 @@ The **Bumpers (optional)** section appears below the sorting options in the play
 
 | Setting | Description |
 |---------|-------------|
-| **Bumper media type** | The media type of the bumper pool — it can differ from the playlist's main media types (e.g., Video items as bumpers between Episodes). Only playlist-supported types are available: Series, Season, and Album are collection-only and cannot be used as bumpers, since bumpers are woven into playlists. Set to **None (disabled)** to turn bumpers off. |
+| **Bumper media type** | The media type of the bumper pool — it can differ from the playlist's main media types (e.g., Video items as bumpers between Episodes). Only playlist-supported types are available: Series, Season, Album, and Live TV Channel are collection-only and cannot be used as bumpers, since bumpers are woven into playlists. Set to **None (disabled)** to turn bumpers off. |
 | **Bumper order** | How the bumper pool is cycled: **Random** (reshuffled on every refresh), **Name**, or **Release Date**. |
 | **Every N items** | How many main items play between bumpers. `1` inserts a bumper after every item, `2` after every second item, and so on. |
 | **Bumper rules** | A full rule editor, exactly like the main rules — including multiple rule groups via **Add Bumper Rule Group**. Only items matching these rules are used as bumpers. |

--- a/docs/content/user-guide/media-types.md
+++ b/docs/content/user-guide/media-types.md
@@ -20,6 +20,7 @@ When creating a smart list, you must select at least one **Media Type** to speci
 | **Photo** | Home Videos and Photos | Photo content |
 | **Books** | Books | E-book content |
 | **AudioBooks** | Books | Audiobook content |
+| **Live TV Channel** | Live TV | Channels from your Live TV tuners (collections only — Jellyfin playlists cannot hold channels). Channel metadata is thin: mostly **Name**, plus any tags or favorite status you set on the channel in Jellyfin. Requires Jellyfin 12.0 or newer. |
 | **Collection** | Collections | Jellyfin collections themselves (collections only, see [below](#container-media-types)) |
 | **Playlist** | Playlists | Jellyfin playlists themselves (collections only, see [below](#container-media-types)) |
 


### PR DESCRIPTION
Closes #290

## What
Adds **Live TV Channel** as a media type for smart collections. Channels from any Live TV tuner can now be grouped and filtered into collections by rules (Name, Tags, Is Favorite, etc.).

## Why
Jellyfin 12.0 removed the "Clean up collections and playlists" scheduled task (jellyfin/jellyfin#16062) that used to strip Live TV channels out of collections, which was the blocker noted in #290. Verified on 12.0 that channels in a BoxSet now survive a full metadata refresh, a library scan, a guide refresh and a server restart (links live in the `LinkedChildren` table; `collection.xml` stays empty for channels and that is fine).

Collections only: Jellyfin's `PlaylistManager` drops any item whose `SupportsAddingToPlaylist` is false, and `LiveTvChannel` inherits the `BaseItem` default of false, so playlists cannot hold channels regardless of what the plugin does.

## Changes
- **MediaTypes**: `LiveTvChannel` constant mapped to `BaseItemKind.LiveTvChannel` in both directions. `LiveTvChannel.GetBaseItemKind()` returns `TvChannel` at runtime, so `OperandFactory.GetItemTypeName` and `AutoRefreshService.GetMediaTypeForItem` match the class directly instead of relying on the kind fallback.
- **CollectionService.GetAllMedia**: channels have no library parent, so `LiveTvChannel` joins BoxSet/Playlist in the unscoped (no `TopParentIds`) query.
- **Playlists/bumpers**: rejected at refresh time like Series/Season/MusicAlbum, and in `InputValidator` for bumper pools.
- **UI**: media type offered with `CollectionOnly` (hidden on the playlist form, excluded from bumper types), list-filter option on both pages.
- **Docs**: media-types table row, bumpers note, Live TV example in common use cases.
- **Tests**: bumper rejection case, new `MediaTypesTests` (mapping round-trip, `All` has no duplicates).

## Verification
Dev container on Jellyfin 12.0 with an M3U tuner (`iptv-org` Sweden playlist, 142 channels):
- Smart collection, media type Live TV Channel, `Name contains "SVT"` → 142 channels filtered to 2, BoxSet created with 2 `TvChannel` children and a logo collage cover, no warnings.
- Same rule as a smart playlist → refresh fails with the unsupported-media-type error, same as Series.
- Tags set on a channel persist through a guide refresh, so `Tags` rules work for grouping.
- 1,698 unit tests pass.

## Not included
`Channel Number` / `Channel Type` (TV vs Radio) rule fields. Easy to add if someone with a real tuner asks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Live TV Channel media types in Smart Lists and Collections.
  * Live TV Channels can be selected and filtered in the Manage and User Playlists interfaces.
  * Collections targeting Live TV Channels can automatically refresh when channel data changes.
* **Bug Fixes**
  * Improved discovery and classification of Live TV Channels.
  * Prevented unsupported Live TV Channels from being used in playlists or bumpers, with guidance to use Collections instead.
* **Documentation**
  * Added Live TV Channel usage examples, limitations, and Jellyfin version requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->